### PR TITLE
Missing include

### DIFF
--- a/src/bias/MetaD.cpp
+++ b/src/bias/MetaD.cpp
@@ -34,6 +34,7 @@
 #include "tools/File.h"
 #include <iostream>
 #include <limits>
+#include <time.h>
 
 #define DP2CUTOFF 6.25
 


### PR DESCRIPTION
Trivial addition for `time()`.