### PR TITLE
Added an option in OFile to enforce backup of files even if restarting

### DIFF
--- a/src/tools/OFile.cpp
+++ b/src/tools/OFile.cpp
@@ -72,7 +72,8 @@ OFile::OFile():
   linked(NULL),
   fieldChanged(false),
   backstring("bck"),
-  enforceRestart_(false)
+  enforceRestart_(false),
+  enforceBackup_(false)
 {
   fmtField();
   buflen=1;
@@ -373,6 +374,7 @@ FileBase& OFile::flush(){
 
 bool OFile::checkRestart()const{
   if(enforceRestart_) return true;
+  else if(enforceBackup_) return false;
   else if(action) return action->getRestart();
   else if(plumed) return plumed->getRestart();
   else return false;
@@ -380,9 +382,15 @@ bool OFile::checkRestart()const{
 
 OFile& OFile::enforceRestart(){
   enforceRestart_=true;
+  enforceBackup_=false;
   return *this;
 }
 
+OFile& OFile::enforceBackup(){
+  enforceBackup_=true;
+  enforceRestart_=false;
+  return *this;
 }
 
 
+}

--- a/src/tools/OFile.h
+++ b/src/tools/OFile.h
@@ -183,6 +183,8 @@ public virtual FileBase{
   bool checkRestart()const;
 /// True if restart behavior should be forced
   bool enforceRestart_;
+/// True if backup behavior (i.e. non restart) should be forced
+  bool enforceBackup_;
 public:
 /// Constructor
   OFile();
@@ -251,9 +253,11 @@ this method can be used to clean the field list.
   OFile&rewind();
 /// Flush a file
   virtual FileBase&flush();
-/// Enforce restart, also if the attached plume object is not restarting.
+/// Enforce restart, also if the attached plumed object is not restarting.
 /// Useful for tests
   OFile&enforceRestart();
+/// Enforce backup, even if the attached plumed object is restarting.
+  OFile&enforceBackup();
 };
 
 /// Write using << syntax


### PR DESCRIPTION
Allows for per-file adjustment of output files such that from the same action you can backup some files and append others. 

Didn't add a new regtest as this feature of OFile is not used in any current action. 

Make sure these boxes are checked before submitting your pull request:

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed succesfully on Travis.
- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers.

