### PR TITLE
Added cross refs in EDS and MAXENT

### DIFF
--- a/src/bias/MaxEnt.cpp
+++ b/src/bias/MaxEnt.cpp
@@ -78,6 +78,8 @@ The value of \f$ \xi(\lambda,t)\f$ is written in output as a component named: ar
 Setting \f$ \sigma =0\f$ is equivalent to enforce a pure Maximum Entropy restraint without any noise modelling.
 This method can be also used to enforce inequality restraint as shown in following examples.
 
+Notice that a similar method is available as \ref EDS, although with different features and using a different optimization algorithm.
+
 \par Examples
 
 The following input tells plumed to restrain the distance between atoms 7 and 15

--- a/src/eds/EDS.cpp
+++ b/src/eds/EDS.cpp
@@ -65,6 +65,8 @@ to zero with the default value of \f$s_i\f$ as this will cause a
 divide-by-zero error. Instead, set \f$s_i=1\f$ or modify the CV so the
 desired target value is no longer zero.
 
+Notice that a similar method is available as \ref MAXENT, although with different features and using a different optimization algorithm.
+
 \par Examples
 
 The following input for a harmonic oscillator of two beads will


### PR DESCRIPTION
As discussed with @hockyg, it makes sense to cross link these two implementations of similar methods.

@hockyg or @whitead: can you confirm you are ok with this change of the EDS documentation?

I also cc @a-cesari who originally wrote the MAXENT keyword.

Thanks!