### PR TITLE
refactor EDS documentation to fit into Camilloni submodule format, an…

### DIFF
--- a/src/eds/EDS.cpp
+++ b/src/eds/EDS.cpp
@@ -36,7 +36,7 @@ using namespace bias;
 namespace PLMD {
 namespace eds {
 
-//+PLUMEDOC BIAS EDS
+//+PLUMEDOC EDS_BIAS EDS_EDS
 /*
 Add a linear bias on a set of observables.
 
@@ -124,7 +124,6 @@ eds: EDS ARG=dist,dist2 CENTER=2.0,1.0 PERIOD=50000 TEMP=1.0 IN_RESTART=restart.
 //+ENDPLUMEDOC
 
 class EDS : public Bias {
-
 
 private:
   /*We will get this and store it once, since on-the-fly changing number of CVs will be fatal*/

--- a/user-doc/EDS.md
+++ b/user-doc/EDS.md
@@ -1,0 +1,30 @@
+\page EDS Experiment Directed Simulation
+
+<!-- 
+description: Methods for incorporating additional information about CVs into MD simulations by adaptively determined linear bias parameters
+authors: Glen Hocky, Andrew White
+reference: \cite white2014efficient \cite hocky2017cgds
+-->
+
+## Overview
+
+This Experiment Directed Simulation module contains methods for adaptively determining linear bias parameters such that each biased CV samples a new target mean value. This module implements the stochastic gradient descent algorithm in the original EDS paper \cite white2014efficient as well as additional minimization algorithms for Coarse-Grained Directed Simulation \cite hocky2017cgds.
+
+Notice that a similar method is available as \ref MAXENT, although with different features and using a different optimization algorithm.
+
+## Installation 
+This module is not installed by default. Add '\-\-enable-modules=eds' to your './configure' command when building PLUMED to enable these features.
+
+## Usage
+Currently, all features of the EDS module are included in a single EDS bias function: \ref EDS_EDS
+
+A tutorial using EDS specifically for biasing coordination number can be found on <a href="http://thewhitelab.org/Blog/tutorial/2017/05/10/lammps-coordination-number-tutorial/">Andrew White's webpage</a>.
+
+## Module Contents
+- \subpage EDSBias
+
+\page EDSBias Biases Documentation
+
+The following list contains descriptions of biases developed for the PLUMED-EDS module. They can be used in combination with other biases outside of the EDS module.
+
+@EDS_BIAS@

--- a/user-doc/bibliography.bib
+++ b/user-doc/bibliography.bib
@@ -2439,6 +2439,17 @@ volume = {10},
 year = {2014}
 }
 
+@article{hocky2017cgds,
+author = {Hocky, Glen M. and Dannenhoffer-Lafage, Thomas and Voth, Gregory A.},
+title = {Coarse-Grained Directed Simulation},
+journal = {Journal of Chemical Theory and Computation},
+volume = {13},
+number = {9},
+pages = {4593-4603},
+year = {2017},
+doi = {10.1021/acs.jctc.7b00690},
+}
+
 @article{cunha2017unraveling,
   title={Unraveling Mg2+--RNA binding with atomistic molecular dynamics},
   author={Cunha, Richard A and Bussi, Giovanni},


### PR DESCRIPTION
Refactor EDS documentation to fit into Camilloni (@carlocamilloni) submodule format, and added reference to new paper describing some features of the module.

##### Description

Updated EDS module documentation so that it now appears under Additional Modules in docs. Also edited bibliography file to include a new paper referred to in the revised docs. 

##### Type of contribution

- [x] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [x] new module contribution or edit of a module authored by you

##### Copyright

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.
