### PR TITLE
Grid: function to reset to default %14.9f output format

### DIFF
--- a/src/tools/Grid.h
+++ b/src/tools/Grid.h
@@ -215,6 +215,8 @@ public:
   void projectOnLowDimension(double &val, std::vector<int> &varHigh, WeightBase* ptr2obj );
 /// set output format
   void setOutputFmt(const std::string & ss) {fmt_=ss;}
+/// reset output format to the default %14.9f format
+  void resetToDefaultOutputFmt() {fmt_="%14.9f";}
 /// Integrate the function calculated on the grid
   double integrate( std::vector<unsigned>& npoints );
 ///


### PR DESCRIPTION

##### Description

Added a function to the Grid for resetting the output format to the default %14.9f format. This is something that I want to use in the VES module. 

##### Target release

I would like my code to appear in release v2.4

##### Type of contribution

- [x] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright


- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on Travis-CI.

