### PR TITLE
Exceptions

### DIFF
--- a/configure
+++ b/configure
@@ -710,7 +710,6 @@ enable_debug_glibcxx
 enable_shared
 enable_dependency_tracking
 enable_rpath
-enable_cxx_exceptions
 enable_ld_r
 enable_ar_cr
 enable_mpi
@@ -1379,7 +1378,6 @@ Optional Features:
   --enable-dependency-tracking
                           enable dependency tracking, default: yes
   --enable-rpath          enable store rpath, default: no
-  --enable-cxx-exceptions enable c++ exceptions, default: yes
   --enable-ld-r           enable group object files, default: yes
   --enable-ar-cr          enable use ar to build libplumedWrapper.a, default:
                           yes
@@ -2665,24 +2663,6 @@ else
   case "no" in
              (yes) rpath=true ;;
              (no)  rpath=false ;;
-  esac
-
-fi
-
-
-
-cxx_exceptions=
-# Check whether --enable-cxx-exceptions was given.
-if test "${enable_cxx_exceptions+set}" = set; then :
-  enableval=$enable_cxx_exceptions; case "${enableval}" in
-             (yes) cxx_exceptions=true ;;
-             (no)  cxx_exceptions=false ;;
-             (*)   as_fn_error $? "wrong argument to --enable-cxx-exceptions" "$LINENO" 5 ;;
-  esac
-else
-  case "yes" in
-             (yes) cxx_exceptions=true ;;
-             (no)  cxx_exceptions=false ;;
   esac
 
 fi
@@ -8295,13 +8275,6 @@ if test "$debug_glibcxx" == true ; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: Check boundaries, adding -D_GLIBCXX_DEBUG" >&5
 $as_echo "$as_me: Check boundaries, adding -D_GLIBCXX_DEBUG" >&6;}
   $as_echo "#define _GLIBCXX_DEBUG 1" >>confdefs.h
-
-fi
-
-if test "$cxx_exceptions" == true ; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: Enabling c++ exceptions -D__PLUMED_HAS_EXCEPTIONS" >&5
-$as_echo "$as_me: Enabling c++ exceptions -D__PLUMED_HAS_EXCEPTIONS" >&6;}
-  $as_echo "#define __PLUMED_HAS_EXCEPTIONS 1" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -237,7 +237,6 @@ PLUMED_CONFIG_ENABLE([debug-glibcxx],[enable boundary check],[no])
 PLUMED_CONFIG_ENABLE([shared],[shared libs],[yes])
 PLUMED_CONFIG_ENABLE([dependency-tracking],[dependency tracking],[yes])
 PLUMED_CONFIG_ENABLE([rpath],[store rpath],[no])
-PLUMED_CONFIG_ENABLE([cxx-exceptions],[c++ exceptions],[yes])
 PLUMED_CONFIG_ENABLE([ld-r],[group object files],[yes])
 PLUMED_CONFIG_ENABLE([ar-cr],[use ar to build libplumedWrapper.a],[yes])
 PLUMED_CONFIG_ENABLE([mpi],[search for mpi],[yes])
@@ -685,11 +684,6 @@ fi
 if test "$debug_glibcxx" == true ; then
   AC_MSG_NOTICE([Check boundaries, adding -D_GLIBCXX_DEBUG])
   AC_DEFINE([_GLIBCXX_DEBUG])
-fi
-
-if test "$cxx_exceptions" == true ; then
-  AC_MSG_NOTICE([Enabling c++ exceptions -D__PLUMED_HAS_EXCEPTIONS])
-  AC_DEFINE([__PLUMED_HAS_EXCEPTIONS])
 fi
 
 # this is necessary in many MPI implementations

--- a/regtest/basic/rt-make-exceptions/config
+++ b/regtest/basic/rt-make-exceptions/config
@@ -1,2 +1,2 @@
 type=make
-plumed_needs="dlopen exceptions"
+plumed_needs="dlopen"

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -102,6 +102,8 @@ PlumedMain::~PlumedMain() {
 
 void PlumedMain::cmd(const std::string & word,void*val) {
 
+  try {
+
   stopwatch.start();
 
   std::vector<std::string> words=Tools::getWords(word);
@@ -463,6 +465,16 @@ void PlumedMain::cmd(const std::string & word,void*val) {
     }
   }
   stopwatch.pause();
+
+  } catch (Exception &e) {
+    if(log.isOpen()) {
+      log<<"\n\n################################################################################\n\n";
+      log<<e.what();
+      log<<"\n\n################################################################################\n\n";
+      log.flush();
+    }
+    throw;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/Exception.cpp
+++ b/src/tools/Exception.cpp
@@ -61,22 +61,18 @@ std::string Exception::format(const std::string&msg,const std::string&file,unsig
 }
 
 
-Exception::Exception():
-  stackString(trace()),
-  msg(format("","",0,""))
+Exception::Exception()
 {
   abortIfExceptionsAreDisabled();
 }
 
 Exception::Exception(const std::string&msg):
-  stackString(trace()),
   msg(format(msg,"",0,""))
 {
   abortIfExceptionsAreDisabled();
 }
 
 Exception::Exception(const std::string&msg,const std::string&file,unsigned line,const std::string&function):
-  stackString(trace()),
   msg(format(msg,file,line,function))
 {
   abortIfExceptionsAreDisabled();

--- a/src/tools/Exception.cpp
+++ b/src/tools/Exception.cpp
@@ -49,7 +49,7 @@ std::string Exception::trace() {
 std::string Exception::format(const std::string&msg,const std::string&file,unsigned line,const std::string&function) {
   std::string message;
   if(getenv("PLUMED_STACK_TRACE"))message+=trace();
-  message+="\n+++ Internal PLUMED error";
+  message+="\n+++ PLUMED error";
   if(file.length()>0) {
     char cline[1000];
     sprintf(cline,"%u",line);

--- a/src/tools/Exception.cpp
+++ b/src/tools/Exception.cpp
@@ -63,28 +63,16 @@ std::string Exception::format(const std::string&msg,const std::string&file,unsig
 
 Exception::Exception()
 {
-  abortIfExceptionsAreDisabled();
 }
 
 Exception::Exception(const std::string&msg):
   msg(format(msg,"",0,""))
 {
-  abortIfExceptionsAreDisabled();
 }
 
 Exception::Exception(const std::string&msg,const std::string&file,unsigned line,const std::string&function):
   msg(format(msg,file,line,function))
 {
-  abortIfExceptionsAreDisabled();
-}
-
-void Exception::abortIfExceptionsAreDisabled() {
-#if ! defined(__PLUMED_HAS_EXCEPTIONS)
-  fprintf(stderr,"%s","Exceptions are disabled, aborting now\n");
-  fprintf(stderr,"%s",what());
-  fprintf(stderr,"\n");
-  std::abort();
-#endif
 }
 
 }

--- a/src/tools/Exception.h
+++ b/src/tools/Exception.h
@@ -96,9 +96,9 @@ is slower (GB)
 class Exception : public std::exception
 {
 /// Stack trace at exception
-  std::string stackString;
+  std::string stackString = trace();
 /// Reported message
-  std::string msg;
+  std::string msg = format("","",0,"");
 /// Create stack trace
   static std::string trace();
 /// Common tool, invoked by all the constructor to build the message string

--- a/src/tools/Exception.h
+++ b/src/tools/Exception.h
@@ -66,11 +66,8 @@ check is only performed when NDEBUG macro is not defined. They should
 be used when the check is expensive and should be skipped in production
 code.
 
-By default, execution is terminated imediately and a message is printed on stderr.
 
-If PLUMED is compiled with -D__PLUMED_EXCEPTIONS execution will continue
-and the exception will be passed to c++, so that it will be possible
-to intercepted it at a higher level, even outside plumed.
+Exceptions can be caught within plumed or outside it.
 E.g., in an external c++ code using PLUMED as a library, one can type
 \verbatim
   try{
@@ -103,8 +100,6 @@ class Exception : public std::exception
   static std::string trace();
 /// Common tool, invoked by all the constructor to build the message string
   static std::string format(const std::string&,const std::string&,unsigned,const std::string&);
-/// Method which aborts in case exceptions are disabled
-  void abortIfExceptionsAreDisabled();
 public:
 /// Without message
   Exception();


### PR DESCRIPTION
@plumed/all can you have a look at this?

This request implements the following stuff:
- remove flag `--disable-cxx-exceptions` so that exceptions are always enabled
- add a try/catch block in PlumedMain so that errors are reported to plumed log

The important commit is this one: 307c4ef458fe0245a3192f1c6f85c4d40cb5fcef

The rationale is that any error arising within a `cmd` should be reported both on stderr and on the plumed.log. I noticed that in many parts of the code we just duplicate the code, preparing a message that is written both in `plumed_merror(msg)` and in `log<<msg`. This change would allow to remove the duplicate code. More importantly, it would make all errors raised with `plumed_merror` (also those from internal plumed tools that do not have access to log) reported on the log file.

What do you think?
