### PR TITLE
Improved plumed loader

### DIFF
--- a/CHANGES/v2.5.md
+++ b/CHANGES/v2.5.md
@@ -60,3 +60,14 @@ Changes from version 2.4 which are relevant for developers:
 - When launching `plumed`, flags `--no-mpi` and `--mpi` can appear multiple times. The last appearence is the effective one.
 - Internal blas and lapack libraries updated to gromacs 2018.
 - Choosing `./configure --prefix=$PWD` does not lead anymore to deletion of all header files.
+- Runtime loader in `Plumed.c` now works also when linked without `-rdynamic` (that is, 
+  its names are not exported). Notice that all the combinations are expected to
+  work, that is: `Plumed.c` from <=2.4 or >=2.5 combined with libplumedKernel
+  from <=2.4 or >=2.5. In order to achieve this the following changes are implemented:
+  - libplumedKernel does not depend anymore on `Plumed.c`. This allows loading it even
+    in cases where names in the loader are not visible. The relevant function needed
+    to be compatible with `Plumed.c` <=2.4 are found using `dlsym`.
+  - `Plumed.c` does not need anymore libplumedKernel to register itself, but rather
+    searches the relevant functions using `dlsym`. In addition, if it is not able to
+    load `libplumedKernel` since the latter is <=2.4 and needs `Plumed.c` to be visible,
+    it just uses as a fallback `libplumed`, which should load properly.

--- a/configure
+++ b/configure
@@ -725,6 +725,7 @@ enable_zlib
 enable_readdir_r
 enable_cregex
 enable_dlopen
+enable_rtld_default
 enable_execinfo
 enable_gsl
 enable_xdrfile
@@ -1403,6 +1404,7 @@ Optional Features:
                           yes
   --enable-cregex         enable search for C regular expression, default: yes
   --enable-dlopen         enable search for dlopen, default: yes
+  --enable-rtld_default   enable search for RTLD_DEFAULT macro, default: yes
   --enable-execinfo       enable search for execinfo, default: yes
   --enable-gsl            enable search for gsl, default: yes
   --enable-xdrfile        enable search for xdrfile, default: yes
@@ -2891,6 +2893,24 @@ else
   case "yes" in
              (yes) dlopen=true ;;
              (no)  dlopen=false ;;
+  esac
+
+fi
+
+
+
+rtld_default=
+# Check whether --enable-rtld_default was given.
+if test "${enable_rtld_default+set}" = set; then :
+  enableval=$enable_rtld_default; case "${enableval}" in
+             (yes) rtld_default=true ;;
+             (no)  rtld_default=false ;;
+             (*)   as_fn_error $? "wrong argument to --enable-rtld_default" "$LINENO" 5 ;;
+  esac
+else
+  case "yes" in
+             (yes) rtld_default=true ;;
+             (no)  rtld_default=false ;;
   esac
 
 fi
@@ -7183,6 +7203,67 @@ $as_echo "$as_me: WARNING: cannot enable __PLUMED_HAS_DLOPEN" >&2;}
     fi
 
 fi
+
+if test $rtld_default == true ; then
+
+    found=ko
+    __PLUMED_HAS_RTLD_DEFAULT=no
+    if test "${libsearch}" == true ; then
+      testlibs=""
+    else
+      testlibs=""
+    fi
+    for testlib in "" $testlibs
+    do
+      save_LIBS="$LIBS"
+      if test -n "$testlib" ; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking RTLD_DEFAULT with -l$testlib" >&5
+$as_echo_n "checking RTLD_DEFAULT with -l$testlib... " >&6; }
+        LIBS="-l$testlib $LIBS"
+      else
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking RTLD_DEFAULT without extra libs" >&5
+$as_echo_n "checking RTLD_DEFAULT without extra libs... " >&6; }
+      fi
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <dlfcn.h>
+int
+main ()
+{
+  void* f=dlsym(RTLD_DEFAULT,"path");
+  return 0;
+}
+
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  found=ok
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+      if test $found == ok ; then
+        break
+      fi
+      LIBS="$save_LIBS"
+    done
+    if test $found == ok ; then
+      $as_echo "#define __PLUMED_HAS_RTLD_DEFAULT 1" >>confdefs.h
+
+      __PLUMED_HAS_RTLD_DEFAULT=yes
+    else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cannot enable __PLUMED_HAS_RTLD_DEFAULT" >&5
+$as_echo "$as_me: WARNING: cannot enable __PLUMED_HAS_RTLD_DEFAULT" >&2;}
+      LIBS="$save_LIBS"
+    fi
+
+fi
+
 if test $execinfo == true ; then
 
     found=ko

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,7 @@ PLUMED_CONFIG_ENABLE([zlib],[search for zlib],[yes])
 PLUMED_CONFIG_ENABLE([readdir-r],[search for readdir_r (threadsafe)],[yes])
 PLUMED_CONFIG_ENABLE([cregex],[search for C regular expression],[yes])
 PLUMED_CONFIG_ENABLE([dlopen],[search for dlopen],[yes])
+PLUMED_CONFIG_ENABLE([rtld_default],[search for RTLD_DEFAULT macro],[yes])
 PLUMED_CONFIG_ENABLE([execinfo],[search for execinfo],[yes])
 PLUMED_CONFIG_ENABLE([gsl],[search for gsl],[yes])
 PLUMED_CONFIG_ENABLE([xdrfile],[search for xdrfile],[yes])
@@ -597,6 +598,19 @@ fi
 if test $dlopen == true ; then
   PLUMED_CHECK_PACKAGE([dlfcn.h],[dlopen],[__PLUMED_HAS_DLOPEN])
 fi
+
+if test $rtld_default == true ; then
+  PLUMED_CHECK_CXX_PACKAGE([RTLD_DEFAULT],[
+#include <dlfcn.h>
+int
+main ()
+{
+  void* f=dlsym(RTLD_DEFAULT,"path");
+  return 0;
+}
+  ], [__PLUMED_HAS_RTLD_DEFAULT])
+fi
+
 if test $execinfo == true ; then
   PLUMED_CHECK_PACKAGE([execinfo.h],[backtrace],[__PLUMED_HAS_EXECINFO])
 fi

--- a/developer-doc/InstallationLayout.md
+++ b/developer-doc/InstallationLayout.md
@@ -51,7 +51,7 @@ scripts) and the method that can be used to retrieve them from C++ code.
 When using plumed from its build directory (without installing it) these paths will be set to the
 value reported below:
 - `PLUMED_ROOT=/build/directory`
-- `PLUMED_INCLUDEDIR=$PLUMED_ROOT/include` (this works thanks to a symlink of `/build/directory/src` to `/build/directory/include/plumed`)
+- `PLUMED_INCLUDEDIR=$PLUMED_ROOT/src/include` (this works thanks to a symlink of `/build/directory/src` to `/build/directory/src/include/plumed`)
 - `PLUMED_HTMLDIR=$PLUMED_ROOT`
 - `PLUMED_PROGRAM_NAME=plumed`
 

--- a/src/cltools/Driver.cpp
+++ b/src/cltools/Driver.cpp
@@ -22,7 +22,7 @@
 #include "CLTool.h"
 #include "CLToolRegister.h"
 #include "tools/Tools.h"
-#include "wrapper/Plumed.h"
+#include "core/PlumedMain.h"
 #include "tools/Communicator.h"
 #include "tools/Random.h"
 #include "tools/Pbc.h"
@@ -201,7 +201,7 @@ public:
   static void registerKeywords( Keywords& keys );
   explicit Driver(const CLToolOptions& co );
   int main(FILE* in,FILE*out,Communicator& pc);
-  void evaluateNumericalDerivatives( const long int& step, Plumed& p, const std::vector<real>& coordinates,
+  void evaluateNumericalDerivatives( const long int& step, PlumedMain& p, const std::vector<real>& coordinates,
                                      const std::vector<real>& masses, const std::vector<real>& charges,
                                      std::vector<real>& cell, const double& base, std::vector<real>& numder );
   string description()const;
@@ -493,7 +493,7 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
     if( !Communicator::initialized() ) error("needs mpi for debug-pd");
   }
 
-  Plumed p;
+  PlumedMain p;
   int rr=sizeof(real);
   p.cmd("setRealPrecision",&rr);
   int checknatoms=-1;
@@ -981,7 +981,7 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
 }
 
 template<typename real>
-void Driver<real>::evaluateNumericalDerivatives( const long int& step, Plumed& p, const std::vector<real>& coordinates,
+void Driver<real>::evaluateNumericalDerivatives( const long int& step, PlumedMain& p, const std::vector<real>& coordinates,
     const std::vector<real>& masses, const std::vector<real>& charges,
     std::vector<real>& cell, const double& base, std::vector<real>& numder ) {
 

--- a/src/cltools/Makefile
+++ b/src/cltools/Makefile
@@ -1,4 +1,4 @@
-USE=core wrapper config tools molfile
+USE=core config tools molfile
 
 # generic makefile
 include ../maketools/make.module

--- a/src/cltools/SimpleMD.cpp
+++ b/src/cltools/SimpleMD.cpp
@@ -21,7 +21,7 @@
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 #include "CLTool.h"
 #include "CLToolRegister.h"
-#include "wrapper/Plumed.h"
+#include "core/PlumedMain.h"
 #include "tools/Vector.h"
 #include "tools/Random.h"
 #include <string>
@@ -444,10 +444,10 @@ private:
 
     Random random;                 // random numbers stream
 
-    std::unique_ptr<Plumed> plumed;
+    std::unique_ptr<PlumedMain> plumed;
 
 // Commenting the next line it is possible to switch-off plumed
-    plumed.reset(new PLMD::Plumed);
+    plumed.reset(new PLMD::PlumedMain);
 
     if(plumed) {
       int s=sizeof(double);

--- a/src/cltools/pesmd.cpp
+++ b/src/cltools/pesmd.cpp
@@ -21,7 +21,7 @@
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 #include "CLTool.h"
 #include "CLToolRegister.h"
-#include "wrapper/Plumed.h"
+#include "core/PlumedMain.h"
 #include "tools/Vector.h"
 #include "tools/Random.h"
 #include "tools/Communicator.h"
@@ -184,7 +184,7 @@ public:
     else if( lperiod ) error("invalid dimension for periodic potential must be 1, 2 or 3");
 
     // Create plumed object and initialize
-    std::unique_ptr<PLMD::Plumed> plumed(new PLMD::Plumed);
+    std::unique_ptr<PLMD::PlumedMain> plumed(new PLMD::PlumedMain);
     int s=sizeof(double);
     plumed->cmd("setRealPrecision",&s);
     if(Communicator::initialized()) plumed->cmd("setMPIComm",&pc.Get_comm());

--- a/src/core/PlumedMainInitializer.cpp
+++ b/src/core/PlumedMainInitializer.cpp
@@ -22,6 +22,9 @@
 #include "PlumedMain.h"
 #include "tools/Exception.h"
 #include <cstdlib>
+#if defined __PLUMED_HAS_DLOPEN
+#include <dlfcn.h>
+#endif
 
 using namespace std;
 
@@ -39,6 +42,14 @@ typedef struct {
   void(*cmd)(void*,const char*,const void*);
   void(*finalize)(void*);
 } plumed_plumedmain_function_holder;
+
+/**
+  Container for symbol table. Presently only contains a version number and a plumed_plumedmain_function_holder object.
+*/
+typedef struct {
+  int version;
+  plumed_plumedmain_function_holder functions;
+} plumed_symbol_table_type;
 
 /* These functions should be accessible from C, since they might be statically
    used from Plumed.c (for static binding) */
@@ -59,20 +70,68 @@ extern "C" void plumed_plumedmain_finalize(void*plumed) {
   delete static_cast<PLMD::PlumedMain*>(plumed);
 }
 
-/* This refers to a function implemented in Plumed.c */
-extern "C" plumed_plumedmain_function_holder* plumed_kernel_register(const plumed_plumedmain_function_holder*);
+/// This is a static structure that is searched by the plumed loader, so it should be here.
+extern "C" plumed_symbol_table_type plumed_symbol_table;
+
+
+/// Notice that this object is only searched with dlsym after a dlopen on libplumedKernel
+/// has completed. Thus, it should not suffer for any static initialization problem.
+/// It is initialized using the plumed_symbol_table_init
+plumed_symbol_table_type plumed_symbol_table;
+
+extern "C" void plumed_symbol_table_init() {
+  plumed_symbol_table.version=1;
+  plumed_symbol_table.functions.create=plumed_plumedmain_create;
+  plumed_symbol_table.functions.cmd=plumed_plumedmain_cmd;
+  plumed_symbol_table.functions.finalize=plumed_plumedmain_finalize;
+}
 
 namespace PLMD {
 
 /// Static object which registers Plumed.
 /// This is a static object which, during its construction at startup,
 /// registers the pointers to plumed_plumedmain_create, plumed_plumedmain_cmd and plumed_plumedmain_finalize
-/// to the plumed_kernel_register function
+/// to the plumed_kernel_register function.
+/// Registration is only required with plumed loader <=2.4, but we do it anyway in order to maintain
+/// backward compatibility. Notice that as of plumed 2.5 the plumed_kernel_register is found
+/// using dlsym, in order to allow the libplumedKernel library to be loadable also when
+/// the plumed_kernel_register symbol is not available.
 static class PlumedMainInitializer {
 public:
   PlumedMainInitializer() {
-    plumed_plumedmain_function_holder fh= {plumed_plumedmain_create,plumed_plumedmain_cmd,plumed_plumedmain_finalize};
-    plumed_kernel_register(&fh);
+#if defined(__PLUMED_HAS_DLOPEN)
+    bool debug=std::getenv("PLUMED_LOAD_DEBUG");
+    if(std::getenv("PLUMED_LOAD_SKIP_REGISTRATION")) {
+      if(debug) fprintf(stderr,"+++ Skipping registration +++\n");
+      return;
+    }
+    typedef plumed_plumedmain_function_holder* (*plumed_kernel_register_type)(const plumed_plumedmain_function_holder*);
+    plumed_kernel_register_type plumed_kernel_register=nullptr;
+    void* handle=nullptr;
+#if defined(__PLUMED_HAS_RTLD_DEFAULT)
+    if(debug) fprintf(stderr,"+++ Registering functions. Looking in RTLD_DEFAULT +++\n");
+    plumed_kernel_register=(plumed_kernel_register_type) dlsym(RTLD_DEFAULT,"plumed_kernel_register");
+#else
+    handle=dlopen(NULL,RTLD_LOCAL);
+    if(debug) fprintf(stderr,"+++ Registering functions. dlopen handle at %p +++\n",handle);
+    plumed_kernel_register=(plumed_kernel_register_type) dlsym(handle,"plumed_kernel_register");
+#endif
+    if(debug) {
+      if(plumed_kernel_register) {
+        fprintf(stderr,"+++ plumed_kernel_register found at %p +++\n",(void*)plumed_kernel_register);
+      }
+      else fprintf(stderr,"+++ plumed_kernel_register not found +++\n");
+    }
+// make sure static plumed_function_pointers is initialized here
+    plumed_symbol_table_init();
+    if(plumed_kernel_register && debug) fprintf(stderr,"+++ Registering functions at %p (%p,%p,%p) +++\n",
+          (void*)&plumed_symbol_table.functions,(void*)plumed_symbol_table.functions.create,(void*)plumed_symbol_table.functions.cmd,(void*)plumed_symbol_table.functions.finalize);
+    if(plumed_kernel_register) (*plumed_kernel_register)(&plumed_symbol_table.functions);
+// Notice that handle could be null in the following cases:
+// - if we use RTLD_DEFAULT
+// - on Linux if we don't use RTLD_DEFAULT, since dlopen(NULL,RTLD_LOCAL) returns a null pointer.
+    if(handle) dlclose(handle);
+#endif
   }
 } RegisterMe;
 

--- a/src/maketools/plumedcheck
+++ b/src/maketools/plumedcheck
@@ -215,6 +215,14 @@ BEGINFILE{
           for(mod in used_modules[module]) used_modules_here=used_modules_here " " mod
         }
         information("used_modules",module " uses:" used_modules_here)
+# DOC: :used_wrapper_module:
+# DOC: Wrapper module should not be used in other modules (via `USE=wrapper` in `Makefile`).
+# DOC: The reason is that this makes `libplumedKernel` dependent on the PLUMED wrappers.
+# DOC: An exception is the `main` module, which needs to use the `wrapper` module.
+# DOC: Notice that within the PLUMED library there is no need to use the external `cmd` interface
+# DOC: since one can directly declare a `PlumedMain` object.
+        if(!(module in outer_modules) && isarray(used_modules[module]) && ("wrapper" in used_modules[module]))
+           error("used_wrapper_module","wrapped module should not be used except in main")
       }
     }
   }

--- a/src/ves/Makefile
+++ b/src/ves/Makefile
@@ -1,4 +1,4 @@
-USE=bias cltools colvar config core tools wrapper lepton
+USE=bias cltools colvar config core tools lepton
 
 #generic makefile
 include ../maketools/make.module

--- a/src/wrapper/Plumed.c
+++ b/src/wrapper/Plumed.c
@@ -25,6 +25,7 @@
 #include <dlfcn.h>
 #endif
 #include <stdio.h>
+#include <string.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -36,13 +37,36 @@ extern "C" {
 #endif
 
 /**
+  Function pointer to plumed_create
+*/
+
+typedef void*(*plumed_create_pointer)(void);
+/**
+  Function pointer to plumed_cmd
+*/
+typedef void(*plumed_cmd_pointer)(void*,const char*,const void*);
+
+/**
+  Function pointer to plumed_finalize
+*/
+typedef void(*plumed_finalize_pointer)(void*);
+
+/**
    Holder for plumedmain function pointers.
 */
 typedef struct {
-  void*(*create)(void);
-  void(*cmd)(void*,const char*,const void*);
-  void(*finalize)(void*);
+  plumed_create_pointer create;
+  plumed_cmd_pointer cmd;
+  plumed_finalize_pointer finalize;
 } plumed_plumedmain_function_holder;
+
+/**
+   Holder for plumed symbol table.
+*/
+typedef struct {
+  int version;
+  plumed_plumedmain_function_holder functions;
+} plumed_symbol_table_type;
 
 /**
   Register for plumedmain function pointers
@@ -99,31 +123,47 @@ void plumed_dummy_finalize(void*p) {
 #endif
 
 plumed_plumedmain_function_holder* plumed_kernel_register(const plumed_plumedmain_function_holder* f) {
+  /*
+    Argument f is present for historical reasons but ignored in PLUMED>=2.5.
+  */
+  if(f) {
+    if(getenv("PLUMED_LOAD_DEBUG")) {
+      fprintf(stderr,"+++ Ignoring registration at %p (%p,%p,%p) +++\n",(void*)f,(void*)f->create,(void*)f->cmd,(void*)f->finalize);
+    }
+  }
 #ifdef __PLUMED_STATIC_KERNEL
   /*
     When __PLUMED_STATIC_KERNEL is defined, the function holder is initialized
     to statically bound plumed_plumedmain_create, plumed_plumedmain_cmd, plumed_plumedmain_finalize and
-    cannot be changed. This saves from mis-set values for PLUMED_KERNEL
+    cannot be changed. This saves from mis-set values for PLUMED_KERNEL.
   */
   static plumed_plumedmain_function_holder g= {plumed_plumedmain_create,plumed_plumedmain_cmd,plumed_plumedmain_finalize};
-  (void) f; /* avoid warning on unused parameter */
-  return &g;
 #else
   /*
-    On the other hand, for runtime binding, we allow to reset the function holder on the
-    first call to plumed_kernel_register.
-    Notice that in principle plumed_kernel_register is entered *twice*: one for the first
-    plumed usage, and then from the PlumedMainInitializer object of the shared library.
-    This is why we set "first=0" only *after* loading the shared library.
+    On the other hand, for runtime binding, we use dlsym to find the relevant functions.
+    Notice that as of PLUMED 2.5 self registration of the kernel is ignored, so argument f
+    is not used anymore.
     Also notice that we should put some guard here for safe multithread calculations.
   */
   static plumed_plumedmain_function_holder g= {plumed_dummy_create,plumed_dummy_cmd,plumed_dummy_finalize};
   static int first=1;
 #ifdef __PLUMED_HAS_DLOPEN
-  char* path;
+  const char* path;
+  char* pathcopy;
   void* p;
+  char* pc;
+  plumed_symbol_table_type* plumed_symbol_table_ptr;
+  plumed_plumedmain_function_holder functions;
+  char* debug;
+  size_t strlenpath;
+  int dlopenmode;
+  /*
+    f==NULL is required here otherwise we would enter this block a second time
+    when plumed_kernel_register is called by the just loaded shared library.
+  */
   if(first && f==NULL) {
     path=getenv("PLUMED_KERNEL");
+    debug=getenv("PLUMED_LOAD_DEBUG");
 #ifdef __PLUMED_DEFAULT_KERNEL
     /*
       This variable allows a default path for the kernel to be hardcoded.
@@ -140,21 +180,98 @@ plumed_plumedmain_function_holder* plumed_kernel_register(const plumed_plumedmai
     if(path && (*path)) {
       fprintf(stderr,"+++ Loading the PLUMED kernel runtime +++\n");
       fprintf(stderr,"+++ PLUMED_KERNEL=\"%s\" +++\n",path);
-      p=dlopen(path,RTLD_NOW|RTLD_GLOBAL);
-      if(p) {
-        fprintf(stderr,"+++ PLUMED kernel successfully loaded +++\n");
-        installed=1;
+      if(getenv("PLUMED_LOAD_NAMESPACE") && !strcmp(getenv("PLUMED_LOAD_NAMESPACE"),"LOCAL")) {
+        dlopenmode=RTLD_NOW|RTLD_LOCAL;
+        if(debug) fprintf(stderr,"+++ Loading with mode RTLD_NOW|RTLD_LOCAL +++\n");
       } else {
-        fprintf(stderr,"+++ PLUMED kernel not found ! +++\n");
-        fprintf(stderr,"+++ error message from dlopen(): %s\n",dlerror());
+        dlopenmode=RTLD_NOW|RTLD_GLOBAL;
+        if(debug) fprintf(stderr,"+++ Loading with mode RTLD_NOW|RTLD_GLOBAL +++\n");
+      }
+      p=dlopen(path,dlopenmode);
+      if(!p) {
+        /*
+          Something went wrong. We try to remove "Kernel" string from the PLUMED_KERNEL variable
+          and load directly the shared library. Notice that this particular path is only expected
+          to be necessary when using PLUMED<=2.4 and the symbols in the main executable are
+          not visible. All the other cases (either PLUMED>=2.5 or symbols in the main executable visible)
+          should work correctly without entering here.
+        */
+        fprintf(stderr,"+++ An error occurred. Message from dlopen(): %s +++\n",dlerror());
+        strlenpath=strlen(path);
+        pathcopy=(char*) malloc(strlenpath+1);
+        strncpy(pathcopy,path,strlenpath+1);
+        pc=pathcopy+strlenpath-6;
+        while(pc>=pathcopy && memcmp(pc,"Kernel",6)) pc--;
+        if(pc>=pathcopy) {
+          memmove(pc, pc+6, strlen(pc)-5);
+          fprintf(stderr,"+++ Trying %s +++\n",pathcopy);
+          p=dlopen(pathcopy,dlopenmode);
+          if(!p) fprintf(stderr,"+++ An error occurred. Message from dlopen(): %s +++\n",dlerror());
+        }
+        free(pathcopy);
+      }
+      if(p) {
+        functions.create=NULL;
+        functions.cmd=NULL;
+        functions.finalize=NULL;
+      /*
+        If the library was loaded, use dlsym to initialize pointers.
+        Notice that as of PLUMED 2.5 we ignore self registrations.
+        Pointers are searched in the form of a single pointer to a structure, which
+        is the standard way in PLUMED 2.5, as well as using alternative names used in
+        PLUMED 2.0 to 2.4 (e.g. plumedmain_create) and in some intermediate versions between
+        PLUMED 2.4 and 2.5 (e.g. plumed_plumedmain_create). The last chance is probably
+        unnecessary and might be removed at some point.
+      */
+        plumed_symbol_table_ptr=(plumed_symbol_table_type*) dlsym(p,"plumed_symbol_table");
+        if(plumed_symbol_table_ptr) functions=plumed_symbol_table_ptr->functions;
+        if(debug && plumed_symbol_table_ptr) {
+          fprintf(stderr,"+++ plumed_symbol_table version %i found at %p +++\n",plumed_symbol_table_ptr->version,(void*)plumed_symbol_table_ptr);
+          fprintf(stderr,"+++ plumed_function_pointers found at %p (%p,%p,%p) +++\n",(void*)&plumed_symbol_table_ptr->functions,(void*)functions.create,(void*)functions.cmd,(void*)functions.finalize);
+        }
+
+        if(!functions.create) {
+          functions.create=(plumed_create_pointer) dlsym(p,"plumedmain_create");
+          if(debug && functions.create) fprintf(stderr,"+++ %s found at %p +++\n","plumedmain_create",(void*)functions.create);
+        }
+        if(!functions.create) {
+          functions.create=(plumed_create_pointer) dlsym(p,"plumed_plumedmain_create");
+          if(debug && functions.create) fprintf(stderr,"+++ %s found at %p +++\n","plumed_plumedmain_create",(void*)functions.create);
+        }
+
+        if(!functions.cmd) {
+          functions.cmd=(plumed_cmd_pointer) dlsym(p,"plumedmain_cmd");
+          if(debug && functions.cmd) fprintf(stderr,"+++ %s found at %p +++\n","plumedmain_cmd",(void*)functions.cmd);
+        }
+        if(!functions.cmd) {
+          functions.cmd=(plumed_cmd_pointer) dlsym(p,"plumed_plumedmain_cmd");
+          if(debug && functions.cmd) fprintf(stderr,"+++ %s found at %p +++\n","plumed_plumedmain_cmd",(void*)functions.cmd);
+        }
+
+        if(!functions.finalize) {
+          functions.finalize=(plumed_finalize_pointer) dlsym(p,"plumedmain_finalize");
+          if(debug && functions.finalize) fprintf(stderr,"+++ %s found at %p +++\n","plumedmain_finalize",(void*)functions.finalize);
+        }
+        if(!functions.finalize) {
+          functions.finalize=(plumed_finalize_pointer) dlsym(p,"plumed_plumedmain_finalize");
+          if(debug && functions.finalize) fprintf(stderr,"+++ %s found at %p +++\n","plumed_plumedmain_finalize",(void*)functions.finalize);
+        }
+
+        if(functions.create && functions.cmd && functions.finalize) {
+          g=functions;
+          installed=1;
+        } else {
+          if(!functions.create) fprintf(stderr,"+++ pointer to (plumed_)plumedmain_create not found +++\n");
+          if(!functions.cmd) fprintf(stderr,"+++ pointer to (plumed_)plumedmain_cmd not found +++\n");
+          if(!functions.finalize) fprintf(stderr,"+++ pointer to (plumed_)plumedmain_finalize not found +++\n");
+        }
       }
     }
+    first=0;
   }
 #endif
-  first=0;
-  if(f) g=*f;
-  return &g;
 #endif
+  return &g;
 }
 
 /* C wrappers: */


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

Dear all,

I open a pull request for this in case someone has comments. I plan to merge it next week.

I made significant changes to the way PLUMED is loaded when using `--runtime` option resulting in the following improvements:

1. It is now not anymore necessary to link the MD code calling PLUMED with the `-rdynamic` (or `-Wl,--export-dynamic`) option. I think this is useful in term of portability of the `Plumed.c` file, especially when it is directly included in other MD codes (as in Amber or Espresso++).
2. It should be possible to load PLUMED also if the `Plumed.c` file has been in turn loaded with `dlopen` flag `RTLD_LOCAL` or `RTLD_LAZY`

The latter is related to a problem that was reported in linking PLUMED within Espresso++ by a collaborator of @valsson.

The main changes are the following ones:

- The loader (`wrapper/Plumed.c`) now uses `dlsym` in order to find symbols in the `libplumedKernel` library, instead of relying on automatic registration. This allows loading the library also when the symbols in `wrapper/Plumed.c` are not visible.
- The `libplumedKernel` library still uses self-registration in order to be compatible with MD codes patched with `--runtime` before this fix (that is, including an old `Plumed.c` file). However, it does so by using `dlsym` as well. Thus, `libplumedKernel` will be loadable also if symbols of `wrapper/Plumed.c` are not available.
- To allow loading old versions of the `libplumedKernel` library which are not selfcontained and thus cannot be opened if `wrapper/Plumed.c` symbols are not visible, in case of a failure loading `libplumedKernel` we remove the `Kernel` portion of the file name and try to directly load `libplumed`. This seems to work correctly.

Some env var can be used to control the behavior:

- `PLUMED_LOAD_DEBUG` can be used to debug all the loading procedure. Just do `export PLUMED_LOAD_DEBUG=1` before launching the MD code.
- `PLUMED_LOAD_NAMESPACE` controls in which namespace PLUMED is loaded. One can use `export PLUMED_LOAD_NAMESPACE=LOCAL` to load it in a local namespace (`RTLD_LOCAL`) and avoid clashes if multiple PLUMED versions are loaded. This however makes the `LOAD` action not functional (since the loaded dylib cannot see the PLUMED library anymore). The default is `PLUMED_LOAD_NAMESPACE=GLOBAL` and is identical to the previous loader.

All combinations are expected to work (previously patched MD codes with the new library, newly patched MD codes with the old library, etc). In case anyone finds problem (also after I will have merged this) let me know.

Giovanni



