### PR TITLE
Fix for bug in TD_GRID

### DIFF
--- a/CHANGES/v2.4.md
+++ b/CHANGES/v2.4.md
@@ -193,3 +193,8 @@ For developers:
   - `LDSHARED` is now correctly taken into account when launching `./configure`.
   - Fixed installation with `--disable-shared`.
   - Cppcheck upgraded to 1.84.
+
+## Version 2.4.3 (to be released)
+
+For users:
+  - Module VES: Fixed a bug in TD_GRID for 2D grids where the grid spacing is not the same for both dimensions.

--- a/src/ves/GridLinearInterpolation.cpp
+++ b/src/ves/GridLinearInterpolation.cpp
@@ -68,8 +68,8 @@ double GridLinearInterpolation::getGridValueWithLinearInterpolation_2D(Grid* gri
   i00[0] = i01[0] = unsigned( std::floor( (arg[0]-grid_min[0])/grid_delta[0] ) );
   i10[0] = i11[0] = unsigned( std::ceil(  (arg[0]-grid_min[0])/grid_delta[0] ) );
 
-  i00[1] = i10[1] = unsigned( std::floor( (arg[1]-grid_min[1])/grid_delta[0] ) );
-  i01[1] = i11[1] = unsigned( std::ceil(  (arg[1]-grid_min[1])/grid_delta[0] ) );
+  i00[1] = i10[1] = unsigned( std::floor( (arg[1]-grid_min[1])/grid_delta[1] ) );
+  i01[1] = i11[1] = unsigned( std::ceil(  (arg[1]-grid_min[1])/grid_delta[1] ) );
 
   // https://en.wikipedia.org/wiki/Bilinear_interpolation
   double x = arg[0];


### PR DESCRIPTION
##### Description

Fix for a bug in TD_GRID for 2D grids when the grid spacing is not the same for both dimensions.

##### Target release

I would like my code to appear in release v2.4

##### Type of contribution

- [ ] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [x] new module contribution or edit of a module authored by you

##### Copyright

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [x] the module I added or modified contains a `COPYRIGHT` file with the correct license information. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct.

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on Travis-CI.

