### PR TITLE
Small fix to allow loading v2.5b

### DIFF
--- a/patches/gromacs-2018.3.diff/src/programs/mdrun/runner.cpp
+++ b/patches/gromacs-2018.3.diff/src/programs/mdrun/runner.cpp
@@ -1338,7 +1338,16 @@ int Mdrunner::mdrunner()
           /* detect plumed API version */
           int pversion=0;
           plumed_cmd(plumedmain,"getApiVersion",&pversion);
-          if(pversion>5) plumed_cmd(plumedmain,"setNumOMPthreads",&hw_opt.nthreads_omp);
+          if(pversion>5) {
+            try{
+              plumed_cmd(plumedmain,"setNumOMPthreads",&hw_opt.nthreads_omp);
+            } catch(...) {
+              /*
+                plumed 2.5b declares a pversion=6 but does not support setNumOMPthreads.
+                Ignoring errors here would allow for loading the plumed 2.5b kernel.
+              */
+            }
+          }
         }
         /* END PLUMED */
 


### PR DESCRIPTION
Since 4e3774ffbacb5e5836e3f97eb598a82ed9f423be the gromacs 2018 patch uses cmd "setNumOMPthreads", that is however not available in plumed 2.5b. I would like to merge this small fix so that it will be possible to load v2.5b from a gromacs version patched with the later patch.

@carlocamilloni what do you think?