### PR TITLE
Added integration weights for Grid class 

### DIFF
--- a/src/bias/MetaD.cpp
+++ b/src/bias/MetaD.cpp
@@ -1942,10 +1942,11 @@ void MetaD::computeReweightingFactor()
 
   const unsigned rank=comm.Get_rank();
   const unsigned stride=comm.Get_size();
+  const std::vector<double> integration_weights = BiasGrid_->getIntegrationWeights();
   for (Grid::index_t t=rank; t<BiasGrid_->getSize(); t+=stride) {
     const double val=BiasGrid_->getValue(t);
-    Z_0+=std::exp(minusBetaF*val-big_number);
-    Z_V+=std::exp(minusBetaFplusV*val-big_number);
+    Z_0+=integration_weights[t]*std::exp(minusBetaF*val-big_number);
+    Z_V+=integration_weights[t]*std::exp(minusBetaFplusV*val-big_number);
   }
   if (stride>1) {
     comm.Sum(Z_0);

--- a/src/bias/MetaD.cpp
+++ b/src/bias/MetaD.cpp
@@ -135,16 +135,16 @@ for replica exchange methods to be computed correctly.
 Multiple walkers  \cite multiplewalkers can also be used. See below the examples.
 
 
-The \\f$c(t)\\f$ reweighting factor can also be calculated on the fly using the equations
+The \f$c(t)\f$ reweighting factor can also be calculated on the fly using the equations
 presented in \cite Tiwary_jp504920s.
-The expression used to calculate \\f$c(t)\\f$ follows directly from Eq. 3 in \cite Tiwary_jp504920s,
-where \\f$F(\vec{s})=-\gamma/(\gamma-1) V(\vec{s})\\f$.
+The expression used to calculate \f$c(t)\f$ follows directly from Eq. 3 in \cite Tiwary_jp504920s,
+where \f$F(\vec{s})=-\gamma/(\gamma-1) V(\vec{s})\f$.
 This gives smoother results than equivalent Eqs. 13 and Eqs. 14 in that paper.
-The \\f$c(t)\\f$ is given by the rct component while the bias
-normalized by \\f$c(t)\\f$ is given by the rbias component (rbias=bias-rct) which can be used
+The \f$c(t)\f$ is given by the rct component while the bias
+normalized by \f$c(t)\f$ is given by the rbias component (rbias=bias-rct) which can be used
 to obtain a reweighted histogram.
-The calculation of \\f$c(t)\\f$ is enabled by using the keyword CALC_RCT.
-By default \\f$c(t)\\f$ is updated every time the bias changes, but if this slows down the simulation
+The calculation of \f$c(t)\f$ is enabled by using the keyword CALC_RCT.
+By default \f$c(t)\f$ is updated every time the bias changes, but if this slows down the simulation
 the keyword RCT_USTRIDE can be set to a value higher than 1.
 This option requires that a grid is used.
 
@@ -233,7 +233,7 @@ one update and the other. Since version 2.2.5, hills files are automatically
 flushed every WALKERS_RSTRIDE steps.
 
 \par
-The \\f$c(t)\\f$ reweighting factor can be calculated on the fly using the equations
+The \f$c(t)\f$ reweighting factor can be calculated on the fly using the equations
 presented in \cite Tiwary_jp504920s as described above.
 This is enabled by using the keyword CALC_RCT,
 and can be done only if the bias is defined on a grid.
@@ -248,9 +248,9 @@ METAD ...
 \endplumedfile
 Here we have asked that the calculation is performed every 10 hills deposition by using
 RCT_USTRIDE keyword. If this keyword is not given, the calculation will
-by default be performed every time the bias changes. The \\f$c(t)\\f$ reweighting factor will be given
+by default be performed every time the bias changes. The \f$c(t)\f$ reweighting factor will be given
 in the rct component while the instantaneous value of the bias potential
-normalized using the \\f$c(t)\\f$ reweighting factor is given in the rbias component
+normalized using the \f$c(t)\f$ reweighting factor is given in the rbias component
 [rbias=bias-rct] which can be used to obtain a reweighted histogram or
 free energy surface using the \ref HISTOGRAM analysis.
 

--- a/src/bias/MetaD.cpp
+++ b/src/bias/MetaD.cpp
@@ -1942,11 +1942,10 @@ void MetaD::computeReweightingFactor()
 
   const unsigned rank=comm.Get_rank();
   const unsigned stride=comm.Get_size();
-  const std::vector<double> integration_weights = BiasGrid_->getIntegrationWeights();
   for (Grid::index_t t=rank; t<BiasGrid_->getSize(); t+=stride) {
     const double val=BiasGrid_->getValue(t);
-    Z_0+=integration_weights[t]*std::exp(minusBetaF*val-big_number);
-    Z_V+=integration_weights[t]*std::exp(minusBetaFplusV*val-big_number);
+    Z_0+=std::exp(minusBetaF*val-big_number);
+    Z_V+=std::exp(minusBetaFplusV*val-big_number);
   }
   if (stride>1) {
     comm.Sum(Z_0);

--- a/src/isdb/SAXS.cpp
+++ b/src/isdb/SAXS.cpp
@@ -356,7 +356,7 @@ SAXS::SAXS(const ActionOptions&ao):
   log<<"  Bibliography ";
   if(martini) {
     log<<plumed.cite("Niebling, Björling, Westenhoff, J Appl Crystallogr 47, 1190–1198 (2014).");
-    log<<plumed.cite("Paissoni, Jussupow, Camilloni, bioRxiv 444901.");
+    log<<plumed.cite("Paissoni, Jussupow, Camilloni, bioRxiv 498147.");
   }
   if(atomistic) {
     log<<plumed.cite("Fraser, MacRae, Suzuki, J. Appl. Crystallogr., 11, 693–694 (1978).");

--- a/src/tools/Grid.h
+++ b/src/tools/Grid.h
@@ -84,6 +84,7 @@ private:
   double contour_location;
   std::vector<double> grid_;
   std::vector< std::vector<double> > der_;
+  std::vector<double> getOneDimensionalTrapezoidalWeights(const unsigned int, const double, const bool) const;
 protected:
   std::string funcname;
   std::vector<std::string> argnames;
@@ -232,6 +233,8 @@ public:
 /// Find the maximum over paths of the minimum value of the gridded function along the paths
 /// for all paths of neighboring grid lattice points from a source point to a sink point.
   virtual double findMaximalPathMinimum(const std::vector<double> &source, const std::vector<double> &sink);
+/// Returns a vector with the weights for doing integration over the grid.
+  std::vector<double> getIntegrationWeights(const std::string& weights_type="trapezoidal", const std::string& fname_weights_grid="") const;
 };
 
 

--- a/src/ves/BasisFunctions.cpp
+++ b/src/ves/BasisFunctions.cpp
@@ -24,7 +24,6 @@
 #include "TargetDistribution.h"
 #include "VesBias.h"
 #include "VesTools.h"
-#include "GridIntegrationWeights.h"
 
 #include "tools/Grid.h"
 #include "tools/Tools.h"
@@ -260,7 +259,7 @@ std::vector<double> BasisFunctions::numericalTargetDistributionIntegralsFromGrid
   plumed_massert(grid_pntr->getDimension()==1,"the target distribution grid should be one dimensional");
   //
   std::vector<double> targetdist_integrals(nbasis_,0.0);
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(grid_pntr);
+  std::vector<double> integration_weights = grid_pntr->getIntegrationWeights();
 
   for(Grid::index_t k=0; k < grid_pntr->getSize(); k++) {
     double arg = grid_pntr->getPoint(k)[0];

--- a/src/ves/GridIntegrationWeights.cpp
+++ b/src/ves/GridIntegrationWeights.cpp
@@ -30,48 +30,6 @@
 namespace PLMD {
 namespace ves {
 
-std::vector<double> GridIntegrationWeights::getIntegrationWeights(const Grid* grid_pntr, const std::string& fname_weights_grid, const std::string& weights_type) {
-  std::vector<double> dx = grid_pntr->getDx();
-  std::vector<bool> isPeriodic = grid_pntr->getIsPeriodic();
-  std::vector<unsigned int> nbins = grid_pntr->getNbin();
-  std::vector<std::vector<double> > weights_perdim;
-  for(unsigned int k=0; k<grid_pntr->getDimension(); k++) {
-    std::vector<double> weights_tmp;
-    if(weights_type=="trapezoidal") {
-      weights_tmp = getOneDimensionalTrapezoidalWeights(nbins[k],dx[k],isPeriodic[k]);
-    }
-    else {
-      plumed_merror("getIntegrationWeights: unknown weight type, the available type is trapezoidal");
-    }
-    weights_perdim.push_back(weights_tmp);
-  }
-
-  std::vector<double> weights_vector(grid_pntr->getSize(),0.0);
-  for(Grid::index_t l=0; l<grid_pntr->getSize(); l++) {
-    std::vector<unsigned int> ind = grid_pntr->getIndices(l);
-    double value = 1.0;
-    for(unsigned int k=0; k<grid_pntr->getDimension(); k++) {
-      value *= weights_perdim[k][ind[k]];
-    }
-    weights_vector[l] = value;
-  }
-
-  if(fname_weights_grid.size()>0) {
-    Grid weights_grid = Grid(*grid_pntr);
-    for(Grid::index_t l=0; l<weights_grid.getSize(); l++) {
-      weights_grid.setValue(l,weights_vector[l]);
-    }
-    OFile ofile;
-    ofile.enforceBackup();
-    ofile.open(fname_weights_grid);
-    weights_grid.writeToFile(ofile);
-    ofile.close();
-  }
-  //
-  return weights_vector;
-}
-
-
 void GridIntegrationWeights::getOneDimensionalIntegrationPointsAndWeights(std::vector<double>& points, std::vector<double>& weights, const unsigned int nbins, const double min, const double max, const std::string& weights_type) {
   double dx = (max-min)/(static_cast<double>(nbins)-1.0);
   points.resize(nbins);

--- a/src/ves/GridIntegrationWeights.h
+++ b/src/ves/GridIntegrationWeights.h
@@ -38,7 +38,6 @@ class GridIntegrationWeights {
 private:
   static std::vector<double> getOneDimensionalTrapezoidalWeights(const unsigned int, const double, const bool periodic=false);
 public:
-  static std::vector<double> getIntegrationWeights(const Grid*, const std::string& fname_weights_grid="", const std::string& weights_type="trapezoidal");
   static void getOneDimensionalIntegrationPointsAndWeights(std::vector<double>&, std::vector<double>&, const unsigned int, const double, const double, const std::string& weights_type="trapezoidal");
 };
 

--- a/src/ves/LinearBasisSetExpansion.cpp
+++ b/src/ves/LinearBasisSetExpansion.cpp
@@ -24,7 +24,6 @@
 #include "VesBias.h"
 #include "CoeffsVector.h"
 #include "VesTools.h"
-#include "GridIntegrationWeights.h"
 #include "BasisFunctions.h"
 #include "TargetDistribution.h"
 
@@ -571,7 +570,7 @@ void LinearBasisSetExpansion::restartTargetDistribution() {
 void LinearBasisSetExpansion::calculateTargetDistAveragesFromGrid(const Grid* targetdist_grid_pntr) {
   plumed_assert(targetdist_grid_pntr!=NULL);
   std::vector<double> targetdist_averages(ncoeffs_,0.0);
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(targetdist_grid_pntr);
+  std::vector<double> integration_weights = targetdist_grid_pntr->getIntegrationWeights();
   Grid::index_t stride=mycomm_.Get_size();
   Grid::index_t rank=mycomm_.Get_rank();
   for(Grid::index_t l=rank; l<targetdist_grid_pntr->getSize(); l+=stride) {
@@ -615,7 +614,7 @@ double LinearBasisSetExpansion::calculateReweightFactor() const {
   plumed_massert(targetdist_grid_pntr_!=NULL,"calculateReweightFactor only be used if the target distribution grid is defined");
   plumed_massert(bias_grid_pntr_!=NULL,"calculateReweightFactor only be used if the bias grid is defined");
   double sum = 0.0;
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(targetdist_grid_pntr_);
+  std::vector<double> integration_weights = targetdist_grid_pntr_->getIntegrationWeights();
   //
   for(Grid::index_t l=0; l<targetdist_grid_pntr_->getSize(); l++) {
     sum += integration_weights[l] * targetdist_grid_pntr_->getValue(l) * exp(+beta_*bias_grid_pntr_->getValue(l));

--- a/src/ves/MD_LinearExpansionPES.cpp
+++ b/src/ves/MD_LinearExpansionPES.cpp
@@ -23,7 +23,6 @@
 #include "BasisFunctions.h"
 #include "LinearBasisSetExpansion.h"
 #include "CoeffsVector.h"
-#include "GridIntegrationWeights.h"
 
 #include "cltools/CLTool.h"
 #include "cltools/CLToolRegister.h"
@@ -418,7 +417,7 @@ int MD_LinearExpansionPES::main( FILE* in, FILE* out, PLMD::Communicator& pc) {
   ofile_potential.close();
 
   Grid histo_grid(*potential_expansion_pntr->getPntrToBiasGrid());
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(&histo_grid);
+  std::vector<double> integration_weights = histo_grid.getIntegrationWeights();
   double norm=0.0;
   for(Grid::index_t i=0; i<histo_grid.getSize(); i++) {
     double value = integration_weights[i]*exp(-histo_grid.getValue(i)/temp);

--- a/src/ves/OutputTargetDistribution.cpp
+++ b/src/ves/OutputTargetDistribution.cpp
@@ -22,7 +22,6 @@
 
 #include "TargetDistribution.h"
 
-#include "GridIntegrationWeights.h"
 #include "VesTools.h"
 
 #include "core/ActionRegister.h"

--- a/src/ves/TD_Custom.cpp
+++ b/src/ves/TD_Custom.cpp
@@ -21,7 +21,6 @@
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 #include "TargetDistribution.h"
-#include "GridIntegrationWeights.h"
 
 #include "core/ActionRegister.h"
 #include "tools/Grid.h"
@@ -236,7 +235,7 @@ void TD_Custom::updateGrid() {
     } catch(PLMD::lepton::Exception& exc) {}
   }
   //
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(getTargetDistGridPntr());
+  std::vector<double> integration_weights = getTargetDistGridPntr()->getIntegrationWeights();
   double norm = 0.0;
   //
   for(Grid::index_t l=0; l<targetDistGrid().getSize(); l++) {

--- a/src/ves/TD_Grid.cpp
+++ b/src/ves/TD_Grid.cpp
@@ -21,7 +21,6 @@
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 #include "TargetDistribution.h"
-#include "GridIntegrationWeights.h"
 #include "VesTools.h"
 #include "GridLinearInterpolation.h"
 

--- a/src/ves/TD_ProductCombination.cpp
+++ b/src/ves/TD_ProductCombination.cpp
@@ -29,7 +29,6 @@
 #include "core/PlumedMain.h"
 #include "tools/Grid.h"
 
-#include "GridIntegrationWeights.h"
 
 
 namespace PLMD {
@@ -197,7 +196,7 @@ void TD_ProductCombination::updateGrid() {
   for(unsigned int i=0; i<ndist_; i++) {
     distribution_pntrs_[i]->updateTargetDist();
   }
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(getTargetDistGridPntr());
+  std::vector<double> integration_weights = getTargetDistGridPntr()->getIntegrationWeights();
   double norm = 0.0;
   for(Grid::index_t l=0; l<targetDistGrid().getSize(); l++) {
     double value = 1.0;

--- a/src/ves/TD_WellTempered.cpp
+++ b/src/ves/TD_WellTempered.cpp
@@ -21,7 +21,6 @@
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 
 #include "TargetDistribution.h"
-#include "GridIntegrationWeights.h"
 
 #include "core/ActionRegister.h"
 #include "tools/Grid.h"
@@ -146,7 +145,7 @@ double TD_WellTempered::getValue(const std::vector<double>& argument) const {
 void TD_WellTempered::updateGrid() {
   double beta_prime = getBeta()/bias_factor_;
   plumed_massert(getFesGridPntr()!=NULL,"the FES grid has to be linked to use TD_WellTempered!");
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(getTargetDistGridPntr());
+  std::vector<double> integration_weights = getTargetDistGridPntr()->getIntegrationWeights();
   double norm = 0.0;
   for(Grid::index_t l=0; l<targetDistGrid().getSize(); l++) {
     double value = beta_prime * getFesGridPntr()->getValue(l);

--- a/src/ves/TargetDistribution.cpp
+++ b/src/ves/TargetDistribution.cpp
@@ -24,7 +24,6 @@
 #include "TargetDistModifer.h"
 
 #include "VesBias.h"
-#include "GridIntegrationWeights.h"
 #include "VesTools.h"
 
 #include "core/Value.h"
@@ -206,7 +205,7 @@ void TargetDistribution::calculateStaticDistributionGrid() {
 
 
 double TargetDistribution::integrateGrid(const Grid* grid_pntr) {
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(grid_pntr);
+  std::vector<double> integration_weights = grid_pntr->getIntegrationWeights();
   double sum = 0.0;
   for(Grid::index_t l=0; l<grid_pntr->getSize(); l++) {
     sum += integration_weights[l]*grid_pntr->getValue(l);
@@ -302,7 +301,7 @@ void TargetDistribution::updateBiasCutoffForTargetDistGrid() {
   // plumed_massert(log_targetdist_grid_pntr_!=NULL,"the grids have not been setup using setupGrids");
   plumed_massert(getBiasWithoutCutoffGridPntr()!=NULL,"the bias without cutoff grid has to be linked");
   //
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(targetdist_grid_pntr_);
+  std::vector<double> integration_weights = targetdist_grid_pntr_->getIntegrationWeights();
   double norm = 0.0;
   for(Grid::index_t l=0; l<targetdist_grid_pntr_->getSize(); l++)
   {
@@ -327,7 +326,7 @@ void TargetDistribution::applyTargetDistModiferToGrid(TargetDistModifer* modifer
   // plumed_massert(targetdist_grid_pntr_!=NULL,"the grids have not been setup using setupGrids");
   // plumed_massert(log_targetdist_grid_pntr_!=NULL,"the grids have not been setup using setupGrids");
   //
-  std::vector<double> integration_weights = GridIntegrationWeights::getIntegrationWeights(targetdist_grid_pntr_);
+  std::vector<double> integration_weights = targetdist_grid_pntr_->getIntegrationWeights();
   double norm = 0.0;
   for(Grid::index_t l=0; l<targetdist_grid_pntr_->getSize(); l++)
   {


### PR DESCRIPTION
##### Description

Added a function to the Grid class to get the integration weights for the grids. For multi-dimensional integration, the weights are a product of one-dimensional weights. Currently only Trapezoidal weights are supported. 

This is function that I have been using for doing integrations in the VES code. I have changed all calls in the VES code to now call the function in the Grid class. 

I also added the integration weights to the calculations of the c(t) in MetaD.cpp (#401 by @invemichele). The results of the regtest (rt67) are the same since for periodic CVs all the weights are the same. 

##### Target release

I would like my code to appear in release v2.5

##### Type of contribution

- [x] changes to code or doc authored by PLUMED developers
- [x] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct.

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on Travis-CI.

