### PR TITLE
Fixed behavior of braces

### DIFF
--- a/src/tools/Tools.cpp
+++ b/src/tools/Tools.cpp
@@ -158,7 +158,7 @@ vector<string> Tools::getWords(const string & line,const char* separators,int * 
     if(parenthesisLevel==0) for(unsigned j=0; j<sep.length(); j++) if(line[i]==sep[j]) found=true;
 // If at parenthesis level zero (outer)
     if(!(parenthesisLevel==0 && (found||onParenthesis))) word.push_back(line[i]);
-    if(onParenthesis) word.push_back(' ');
+    //if(onParenthesis) word.push_back(' ');
     if(line[i]==openpar) parenthesisLevel++;
     if(found && word.length()>0) {
       if(!parlevel) plumed_massert(parenthesisLevel==0,"Unmatching parenthesis in '" + line + "'");


### PR DESCRIPTION
##### Description

I would like to make a tiny fix to the way curly braces are interpreted. Currently what happens is the following:
1. Every time we try to split a string in tokens, we ignore separators that are enclosed between braces. This allows using spaces in atom lists.
2. Each outer brace is then replaced with a single space.

What I propose is to change the second step with "Each outer brace is then removed".

The original idea was to have something similar to bash quotes (to escape separators within the quotes) but easier to parse (open and close braces have different symbols). However, I think I did a small mistake. Bash quotes are removed indeed before calling a command, and not replaced with spaces.

Consider the following:
````
METAD FILE={/path/with space/HILLS}
````
With the current parser PLUMED will look for " /path/with space/HILLS " (notice the extra spaces). After the fix it would correctly look for "/path/with space/HILLS".

Similarly, if you use
````
RMSD TYPE={OPTIMAL}
````
With the current parser you will get an error (" OPTIMAL " is not recognized). After the fix it would work.

Strictly speaking, **this is changing the parser in a backward incompatible manner**. In particular, if anyone is doing:
````
a: GROUP ATOMS={1}{2}{3}{4}
````
With the current parser the group has four atoms. Indeed, when splitting the line in tokens the third token is "ATOMS= 1  2  3  4 ", and the spaces act as separators when parsing the atoms vector. After the fix, the third token would be "ATOMS=1234" and the group would only contain a single atom. Notice that using individual braces to separate lists in this manner is not suggested anywhere in the manual nor used in any regtest. In all the examples, we use either commas or spaces as separators. I guess nobody does this in real input files.

Given this, I would propose to **merge this change in version 2.4**. If anyone has doubts and thinks that this change risks to induce people in error, I am happy to **wait for 2.6** instead.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release v2.4
