### PR TITLE
Small test so that calculation always crashes if you try to add force…

### DIFF
--- a/src/bias/Bias.cpp
+++ b/src/bias/Bias.cpp
@@ -41,6 +41,7 @@ Bias::Bias(const ActionOptions&ao):
     log<<cite("Ferrarotti, Bottaro, Perez-Villa, and Bussi, J. Chem. Theory Comput. 11, 139 (2015)")<<"\n";
   }
   for(unsigned i=0; i<getNumberOfArguments(); ++i) {
+    if( getPntrToArgument(i)->hasDerivatives() ) error("cannot bias value " + getPntrToArgument(i)->getName() + " as derivatives are not implemented");
     (getPntrToArgument(i)->getPntrToAction())->turnOnDerivatives();
   }
 

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -270,7 +270,7 @@ void Value::clearDerivatives() {
 
 inline
 void Value::addForce(double f) {
-  plumed_dbg_massert(hasDerivatives(),"forces can only be added to values with derivatives");
+  plumed_massert(hasDerivatives(),"forces can only be added to values with derivatives");
   hasForce=true;
   inputForce+=f;
 }

--- a/src/generic/DumpDerivatives.cpp
+++ b/src/generic/DumpDerivatives.cpp
@@ -101,10 +101,12 @@ DumpDerivatives::DumpDerivatives(const ActionOptions&ao):
   log.printf("  with format %s\n",fmt.c_str());
   unsigned nargs=getNumberOfArguments();
   if( nargs==0 ) error("no arguments specified");
+  if( !getPntrToArgument(0)->hasDerivatives() ) error("cannot bias value " + getPntrToArgument(0)->getName() + " as derivatives are not implemented");
   (getPntrToArgument(0)->getPntrToAction())->turnOnDerivatives();
   unsigned npar=getPntrToArgument(0)->getNumberOfDerivatives();
   if( npar==0 ) error("one or more arguments has no derivatives");
   for(unsigned i=1; i<nargs; i++) {
+    if( !getPntrToArgument(i)->hasDerivatives() ) error("cannot bias value " + getPntrToArgument(i)->getName() + " as derivatives are not implemented");
     (getPntrToArgument(i)->getPntrToAction())->turnOnDerivatives();
     if( npar!=getPntrToArgument(i)->getNumberOfDerivatives() ) error("the number of derivatives must be the same in all values being dumped");
   }

--- a/src/generic/DumpProjections.cpp
+++ b/src/generic/DumpProjections.cpp
@@ -97,6 +97,7 @@ DumpProjections::DumpProjections(const ActionOptions&ao):
   checkRead();
 
   for(unsigned i=0; i<getNumberOfArguments(); ++i) {
+    if( !getPntrToArgument(i)->hasDerivatives() ) error("cannot bias value " + getPntrToArgument(i)->getName() + " as derivatives are not implemented"); 
     (getPntrToArgument(i)->getPntrToAction())->turnOnDerivatives();
   }
 }


### PR DESCRIPTION
…s on a value that does not have derivatives


##### Description

This is a small change to the code to fix the fact that plumed will currently run even if you try to bias a quantity that does not have derivatives.  Obviously, you would like plumed to throw an error in these cases.

##### Target release

Possibly I should have backported this onto as many previous versions of plumed as I could.  I think it is a bug.

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright


- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct.

##### Tests

- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on Travis-CI.

It was not necessary to add any new regtests
