### PR TITLE
Fix for compiling python interface on Mac OS 10.14

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -29,6 +29,13 @@ import os
 import os.path
 import sys
 from shutil import copyfile
+import platform
+from distutils.sysconfig import get_config_var
+from distutils.version import LooseVersion
+
+
+def is_platform_mac():
+    return sys.platform == 'darwin'
 
 if os.getenv("plumed_macports") is not None:
     copyfile("../VERSION","VERSION")
@@ -45,12 +52,25 @@ if plumedversion is None:
 print( "Module name " + plumedname )
 print( "Version number " + plumedversion )
 
-extra_compile_args=['-D__PLUMED_HAS_DLOPEN','-D__PLUMED_WRAPPER_LINK_RUNTIME=1','-D__PLUMED_WRAPPER_CXX=1','-D__PLUMED_WRAPPER_IMPLEMENTATION=1','-D__PLUMED_WRAPPER_EXTERN=0','-D__PLUMED_WRAPPER_CXX_DEFAULT_INVALID=1'] 
+extra_compile_args=['-D__PLUMED_HAS_DLOPEN','-D__PLUMED_WRAPPER_LINK_RUNTIME=1','-D__PLUMED_WRAPPER_CXX=1','-D__PLUMED_WRAPPER_IMPLEMENTATION=1','-D__PLUMED_WRAPPER_EXTERN=0','-D__PLUMED_WRAPPER_CXX_DEFAULT_INVALID=1']
 
 defaultkernel=os.getenv("plumed_default_kernel")
 if defaultkernel is not None:
     extra_compile_args.append("-D__PLUMED_DEFAULT_KERNEL=" + os.path.abspath(defaultkernel))
     print( "Hardcoded PLUMED_KERNEL " + os.path.abspath(defaultkernel))
+
+# Fixes problem with compiling the PYTHON interface in Mac OS 10.14 and higher.
+# Sets the deployment target to 10.9 when compiling on version 10.9 and above,
+# overriding distutils behaviour to target the Mac OS version python was built for.
+# This can be overridden by setting MACOSX_DEPLOYMENT_TARGET before compiling the
+# python interface.
+# This fix is taken from https://github.com/pandas-dev/pandas/pull/24274/files
+if is_platform_mac():
+    if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
+        current_system = LooseVersion(platform.mac_ver()[0])
+        python_target = LooseVersion(get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+        if python_target < '10.9' and current_system >= '10.9':
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
 
 def readme():
     with open('README.rst') as f:


### PR DESCRIPTION
##### Description

Fix for compiling python interface on Mac OS 10.14, issue https://github.com/plumed/plumed2/issues/443. 

Sets the deployment targetfor python  to 10.9 when compiling on version 10.9 and above.

The fix is based on https://github.com/pandas-dev/pandas/pull/24274/files

I have tested the changes on MacOS 10.14 and 10.12 and everything seems fine. I have also done the extended regtests (https://travis-ci.org/valsson/plumed2/builds/496552207) and everything appears fine, apart from the allowed failures (one of the Mac OS tests hangs). 

##### Target release

I would like my code to appear in release 2.5

##### Type of contribution

- [x] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright


- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on Travis-CI.

