### PR TITLE
Fix 446

### DIFF
--- a/patches/gromacs-2018.5.diff/src/programs/mdrun/runner.cpp
+++ b/patches/gromacs-2018.5.diff/src/programs/mdrun/runner.cpp
@@ -1342,7 +1342,10 @@ int Mdrunner::mdrunner()
           /* detect plumed API version */
           int pversion=0;
           plumed_cmd(plumedmain,"getApiVersion",&pversion);
-          if(pversion>5) plumed_cmd(plumedmain,"setNumOMPthreads",&hw_opt.nthreads_omp);
+          if(pversion>5) {
+             int nth = gmx_omp_nthreads_get(emntDefault);
+             if(pversion>5) plumed_cmd(plumedmain,"setNumOMPthreads",&nth);
+          }
         }
         /* END PLUMED */
 

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -457,7 +457,7 @@ void PlumedMain::cmd(const std::string & word,void*val) {
       /* ADDED WITH API==6 */
       case cmd_setNumOMPthreads:
         CHECK_NOTNULL(val,word);
-        OpenMP::setNumThreads(*static_cast<unsigned*>(val)>0?*static_cast<unsigned*>(val):1);
+        OpenMP::setNumThreads(*static_cast<int*>(val)>0?*static_cast<int*>(val):1);
         break;
       /* ADDED WITH API==6 */
       /* only used for testing */

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -457,7 +457,7 @@ void PlumedMain::cmd(const std::string & word,void*val) {
       /* ADDED WITH API==6 */
       case cmd_setNumOMPthreads:
         CHECK_NOTNULL(val,word);
-        OpenMP::setNumThreads(*static_cast<unsigned*>(val));
+        OpenMP::setNumThreads(*static_cast<unsigned*>(val)>0?*static_cast<unsigned*>(val):1);
         break;
       /* ADDED WITH API==6 */
       /* only used for testing */


### PR DESCRIPTION
##### Description

<!-- describe here your pull request -->

This change makes it so that when `cmd("setNumOMPthreads",&x);` is invoked with `x<=0`, the number of threads is set to 1. This should fix #446, at least in the fact that we will not have erroneous results.

Notice however that the optimal fix would be to find out the correct number of threads chosen by GROMACS. However, I am not sure that at the time we initialize PLUMED this number has been already chosen by GROMACS, not I don't know how to find its value. Currently, we call `plumed_cmd(plumedmain,"setNumOMPthreads",&hw_opt.nthreads_omp);`. Maybe @carlocamilloni knows how to better solve this? Otherwise, this fix might be sufficient.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release v2.5