### PR TITLE
header fix for issue #459

### DIFF
--- a/src/maze/Core.cpp
+++ b/src/maze/Core.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Core.h
+++ b/src/maze/Core.h
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,9 +16,11 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#ifndef __PLUMED_maze_Core_h
+#define __PLUMED_maze_Core_h
 
 /**
  * @file Core.h
@@ -27,9 +29,6 @@ along with maze. If not, see <https://www.gnu.org/licenses/>.
  *
  * @brief Header with needed includes from std and PLMD.
  */
-
-#ifndef __PLUMED_maze_Core_h
-#define __PLUMED_maze_Core_h
 
 namespace PLMD {
 namespace maze {

--- a/src/maze/Loss.cpp
+++ b/src/maze/Loss.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Loss.h
+++ b/src/maze/Loss.h
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,18 +16,17 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#ifndef __PLUMED_maze_Loss_h
+#define __PLUMED_maze_Loss_h
 
 /**
  * @file Loss.h
  *
  * @author J. Rydzewski (jr@fizyka.umk.pl)
  */
-
-#ifndef __PLUMED_maze_Loss_h
-#define __PLUMED_maze_Loss_h
 
 #include "colvar/Colvar.h"
 #include "core/ActionRegister.h"

--- a/src/maze/Member.cpp
+++ b/src/maze/Member.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Member.h
+++ b/src/maze/Member.h
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,18 +16,17 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#ifndef __PLUMED_maze_Member_h
+#define __PLUMED_maze_Member_h
 
 /**
  * @file Member.h
  *
  * @author J. Rydzewski (jr@fizyka.umk.pl)
  */
-
-#ifndef __PLUMED_maze_Member_h
-#define __PLUMED_maze_Member_h
 
 #include "Core.h"
 

--- a/src/maze/Memetic.cpp
+++ b/src/maze/Memetic.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Memetic.h
+++ b/src/maze/Memetic.h
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,18 +16,17 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#ifndef __PLUMED_maze_Memetic_h
+#define __PLUMED_maze_Memetic_h
 
 /**
  * @file Memetic.h
  *
  * @author J. Rydzewski (jr@fizyka.umk.pl)
  */
-
-#ifndef __PLUMED_maze_Memetic_h
-#define __PLUMED_maze_Memetic_h
 
 #include "core/ActionRegister.h"
 

--- a/src/maze/Optimizer.cpp
+++ b/src/maze/Optimizer.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Optimizer.h
+++ b/src/maze/Optimizer.h
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,18 +16,17 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#ifndef __PLUMED_maze_Optimizer_h
+#define __PLUMED_maze_Optimizer_h
 
 /**
  * @file Optimizer.h
  *
  * @author J. Rydzewski (jr@fizyka.umk.pl)
  */
-
-#ifndef __PLUMED_maze_Optimizer_h
-#define __PLUMED_maze_Optimizer_h
 
 #include "colvar/Colvar.h"
 #include "tools/Communicator.h"

--- a/src/maze/Optimizer_Bias.cpp
+++ b/src/maze/Optimizer_Bias.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Random_Acceleration_MD.cpp
+++ b/src/maze/Random_Acceleration_MD.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Random_MT.cpp
+++ b/src/maze/Random_MT.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Random_MT.h
+++ b/src/maze/Random_MT.h
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,18 +16,17 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#ifndef __PLUMED_maze_Random_MT_h
+#define __PLUMED_maze_Random_MT_h
 
 /**
  * @file Random_MT.h
  *
  * @author J. Rydzewski (jr@fizyka.umk.pl)
  */
-
-#ifndef __PLUMED_maze_Random_MT_h
-#define __PLUMED_maze_Random_MT_h
 
 #include "Core.h"
 

--- a/src/maze/Random_Walk.cpp
+++ b/src/maze/Random_Walk.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Simulated_Annealing.cpp
+++ b/src/maze/Simulated_Annealing.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Steered_MD.cpp
+++ b/src/maze/Steered_MD.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Tools.cpp
+++ b/src/maze/Tools.cpp
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,7 +16,7 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 

--- a/src/maze/Tools.h
+++ b/src/maze/Tools.h
@@ -6,8 +6,8 @@ See http://www.maze-code.github.io for more information.
 This file is part of maze.
 
 maze is free software: you can redistribute it and/or modify it under the
-terms of the GNU Lesser General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
+terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) 
 any later version.
 
 maze is distributed in the hope that it will be useful, but WITHOUT ANY
@@ -16,18 +16,17 @@ FOR A PARTICULAR PURPOSE.
 
 See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
+You should have received a copy of the GNU Lesser General Public License 
 along with maze. If not, see <https://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#ifndef __PLUMED_maze_Tools_h
+#define __PLUMED_maze_Tools_h
 
 /**
  * @file Tools.h
  *
  * @author J. Rydzewski
  */
-
-#ifndef __PLUMED_maze_Tools_h
-#define __PLUMED_maze_Tools_h
 
 #include "core/ActionSet.h"
 #include "tools/Vector.h"


### PR DESCRIPTION
##### Description

I fixed issues with the headers from the maze module (#459). Now `cd src && ./header.sh maze` does not introduce any change to the maze module.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.6__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [X] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] the module I added or modified contains a `COPYRIGHT` file with the correct license information. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct.

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on Travis-CI.

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://plumed.github.io/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
