### PR TITLE
Fix LGTM warning in VesDeltaF.cpp

### DIFF
--- a/src/ves/VesDeltaF.cpp
+++ b/src/ves/VesDeltaF.cpp
@@ -565,7 +565,7 @@ void VesDeltaF::update_tg_and_rct()
   std::fill(tg_dV_dAlpha_.begin(),tg_dV_dAlpha_.end(),0);
   std::fill(tg_d2V_dAlpha2_.begin(),tg_d2V_dAlpha2_.end(),0);
   for(Grid::index_t t=rank_; t<grid_p_[0]->getSize(); t+=NumParallel_)
-  { //FIXME can we recycle some code?
+  { //TODO can we recycle some code?
     std::vector<double> prob(grid_p_.size());
     for(unsigned n=0; n<grid_p_.size(); n++)
       prob[n]=grid_p_[n]->getValue(t);


### PR DESCRIPTION
##### Description

Fixes a LGTM warning in VesDeltaF.cpp. Only a change in a comment. 

See https://lgtm.com/projects/g/plumed/plumed2/latest/files/src/ves/VesDeltaF.cpp?sort=name&dir=ASC&mode=heatmap#V553

##### Target release

I would like my code to appear in release v2.6

##### Type of contribution


- [ ] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [x] new module contribution or edit of a module authored by you

##### Copyright

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [x] the module I added or modified contains a `COPYRIGHT` file with the correct license information. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct.

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on Travis-CI.

