### PR TITLE
Update VES.md to fix links to tutorial

### DIFF
--- a/user-doc/VES.md
+++ b/user-doc/VES.md
@@ -109,7 +109,7 @@ Variationally Enhanced Sampling:
 
 \par Tuesday February 14
 
-\ref lugano-1 "Tutorial 1": Introduction to PLUMED and analyzing molecular simulations
+\ref marvel-1 "Tutorial 1": Introduction to PLUMED and analyzing molecular simulations
 
 \par Wednesday February 15
 
@@ -122,7 +122,7 @@ Variationally Enhanced Sampling:
 \ref ves-lugano2017-ves2 "Tutorial 4": Further on variationally enhanced sampling
 
 Tutorial 5: Advanced collective variables
-- \ref lugano-2 "Path CVs"
+- \ref marvel-2 "Path CVs"
 - \ref belfast-10 "Multicolvar"
 - \ref belfast-3 "Dimensionality reduction"
 


### PR DESCRIPTION
##### Description

Fix links to tutorial in VES manual due to changes in 5770d9120c4baa908a8d362b1695ba13b9879cce. 

According to what I see in the commit this should be done only in the master (not v2.5)

##### Target release

I would like my code to appear in release v2.6

##### Type of contribution

- [ ] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [x] new module contribution or edit of a module authored by you

##### Copyright

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.


- [x] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests


- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on Travis-CI.

