### PR TITLE
Caseinsens

### DIFF
--- a/regtest/basic/rt5/plumed.dat
+++ b/regtest/basic/rt5/plumed.dat
@@ -1,5 +1,6 @@
-ang1: ANGLE ATOMS=2,6,3
-ang2: ANGLE ATOMS=2,6,7,3
+angle atoms=2,6,3 label=ang1
+ang2: AnglE ATOMS=2,6,7,3
+anglE ATOMS=2,6,7,3
 
 RESTRAINT ...
   ARG=ang2
@@ -9,7 +10,7 @@ RESTRAINT ...
 
 PRINT ...
   STRIDE=10
-  ARG=ang1,ang2
+  arg=ang1,ang2
   FILE=COLVAR FMT=%6.3f
 ... PRINT
 

--- a/src/core/ActionRegister.cpp
+++ b/src/core/ActionRegister.cpp
@@ -51,6 +51,8 @@ void ActionRegister::remove(creator_pointer f) {
 }
 
 void ActionRegister::add(string key,creator_pointer f,keywords_pointer k) {
+  // this force each action to be registered as an uppercase string
+  std::transform(key.begin(), key.end(), key.begin(), ::toupper); 
   if(m.count(key)) {
     m.erase(key);
     disabled.insert(key);

--- a/src/core/ActionRegister.cpp
+++ b/src/core/ActionRegister.cpp
@@ -52,7 +52,7 @@ void ActionRegister::remove(creator_pointer f) {
 
 void ActionRegister::add(string key,creator_pointer f,keywords_pointer k) {
   // this force each action to be registered as an uppercase string
-  if ( std::any_of( std::begin( key ), std::end( key ), []( char c ) { return ( islower( c ) ); } ) ) plumed_error() << "Action: " + key + " cannot be registered, use only UPPERCASE characters"; 
+  if ( std::any_of( std::begin( key ), std::end( key ), []( char c ) { return ( islower( c ) ); } ) ) plumed_error() << "Action: " + key + " cannot be registered, use only UPPERCASE characters";
   if(m.count(key)) {
     m.erase(key);
     disabled.insert(key);

--- a/src/core/ActionRegister.cpp
+++ b/src/core/ActionRegister.cpp
@@ -52,7 +52,7 @@ void ActionRegister::remove(creator_pointer f) {
 
 void ActionRegister::add(string key,creator_pointer f,keywords_pointer k) {
   // this force each action to be registered as an uppercase string
-  std::transform(key.begin(), key.end(), key.begin(), ::toupper); 
+  std::transform(key.begin(), key.end(), key.begin(), ::toupper);
   if(m.count(key)) {
     m.erase(key);
     disabled.insert(key);

--- a/src/core/ActionRegister.cpp
+++ b/src/core/ActionRegister.cpp
@@ -52,7 +52,7 @@ void ActionRegister::remove(creator_pointer f) {
 
 void ActionRegister::add(string key,creator_pointer f,keywords_pointer k) {
   // this force each action to be registered as an uppercase string
-  std::transform(key.begin(), key.end(), key.begin(), ::toupper);
+  if ( std::any_of( std::begin( key ), std::end( key ), []( char c ) { return ( islower( c ) ); } ) ) plumed_error() << "Action: " + key + " cannot be registered, use only UPPERCASE characters"; 
   if(m.count(key)) {
     m.erase(key);
     disabled.insert(key);

--- a/src/tools/Tools.cpp
+++ b/src/tools/Tools.cpp
@@ -225,12 +225,19 @@ void Tools::trimComments(string & s) {
   s=s.substr(0,n);
 }
 
+bool Tools::caseInSensStringCompare(const std::string & str1, const std::string &str2)
+{
+	return ((str1.size() == str2.size()) && std::equal(str1.begin(), str1.end(), str2.begin(), [](char c1, char c2){
+							return (c1 == c2 || std::toupper(c1) == std::toupper(c2));
+								}));
+}
+
 bool Tools::getKey(vector<string>& line,const string & key,string & s,int rep) {
   s.clear();
   for(auto p=line.begin(); p!=line.end(); ++p) {
     if((*p).length()==0) continue;
     string x=(*p).substr(0,key.length());
-    if(x==key) {
+    if(caseInSensStringCompare(x,key)) {
       if((*p).length()==key.length())return false;
       string tmp=(*p).substr(key.length(),(*p).length());
       line.erase(p);
@@ -293,7 +300,8 @@ void Tools::interpretLabel(vector<string>&s) {
   if(s0[l-1]==':') {
     s[0]=s[1];
     s[1]="LABEL="+s0.substr(0,l-1);
-  }
+  } 
+  std::transform(s[0].begin(), s[0].end(), s[0].begin(), ::toupper); 
 }
 
 vector<string> Tools::ls(const string&d) {

--- a/src/tools/Tools.cpp
+++ b/src/tools/Tools.cpp
@@ -227,9 +227,9 @@ void Tools::trimComments(string & s) {
 
 bool Tools::caseInSensStringCompare(const std::string & str1, const std::string &str2)
 {
-	return ((str1.size() == str2.size()) && std::equal(str1.begin(), str1.end(), str2.begin(), [](char c1, char c2){
-							return (c1 == c2 || std::toupper(c1) == std::toupper(c2));
-								}));
+  return ((str1.size() == str2.size()) && std::equal(str1.begin(), str1.end(), str2.begin(), [](char c1, char c2) {
+    return (c1 == c2 || std::toupper(c1) == std::toupper(c2));
+  }));
 }
 
 bool Tools::getKey(vector<string>& line,const string & key,string & s,int rep) {
@@ -300,8 +300,8 @@ void Tools::interpretLabel(vector<string>&s) {
   if(s0[l-1]==':') {
     s[0]=s[1];
     s[1]="LABEL="+s0.substr(0,l-1);
-  } 
-  std::transform(s[0].begin(), s[0].end(), s[0].begin(), ::toupper); 
+  }
+  std::transform(s[0].begin(), s[0].end(), s[0].begin(), ::toupper);
 }
 
 vector<string> Tools::ls(const string&d) {

--- a/src/tools/Tools.h
+++ b/src/tools/Tools.h
@@ -25,6 +25,7 @@
 #include "AtomNumber.h"
 #include <vector>
 #include <string>
+#include <cctype>
 #include <cstdio>
 #include <cmath>
 #include <limits>
@@ -71,6 +72,8 @@ public:
 /// This function already takes care of joining continued lines and splitting the
 /// resulting line into an array of words
   static bool getParsedLine(IFile&ifile,std::vector<std::string> & line);
+/// compare two string in a case insensitive manner
+  static bool caseInSensStringCompare(const std::string & str1, const std::string &str2);
 /// Convert a string to a double, reading it
   static bool convert(const std::string & str,double & t);
 /// Convert a string to a long double, reading it


### PR DESCRIPTION
##### Description

Make the parsing of the input case insensitive by
- forcing directives to be converted in uppercase
- using interpretLabel to convert in uppercase directives
- implement a case insensitive comparison for parsing tools

in this way I can overcome some problem with const Action in ActionRegister and avoid code duplication I think

##### Target release

v2.6

##### Type of contribution


- [x] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright


- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.


- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on Travis-CI.