### PR TITLE
Update travis build to use Ubuntu 16 xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,14 @@ install:
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ; fi
 # install some package - these are fast, we install them anyway
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libfftw3-dev gsl-bin libgsl0-dev  libboost-serialization-dev ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libfftw3-dev gsl-bin libgsl0-dev ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      if [[ "$CONFIG_FLAGS" == *debug* ]] ; then 
+        .travis/install.boost ;
+      else
+        sudo apt-get install -y libboost-serialization-dev ;
+      fi
+    fi
   - if test "$PLUMED_CXX" ; then ./.travis/install.xdrfile ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       ./.travis/install.ccache v3.5 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,22 @@ matrix:
 # If some of them is not enabled, the whole suite will fail.
   - name: Run all tests and build doc. All features enabled (system blas and lapack + asmjit)
     os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     env: PLUMED_CC=mpicc PLUMED_CXX=mpic++ MAKEDOC=yes PLUMED_ALL_TESTS=yes LAPACK=yes ASMJIT=yes
   - name: Run all tests and scan coverage
     os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     env: PLUMED_CC=mpicc PLUMED_CXX=mpic++ MAKECOVERAGE=yes PLUMED_ALL_TESTS=yes
   - name: Debug flags, no MPI
     os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     env: PLUMED_CC=gcc   PLUMED_CXX=g++    CONFIG_FLAGS="--enable-debug --enable-debug-glibcxx"
   - name: Debug flags, MPI
     os: linux
-    dist: trusty
+    dist: xenial
     sudo: required
     env: PLUMED_CC=mpicc PLUMED_CXX=mpic++ CONFIG_FLAGS="--enable-debug --enable-debug-glibcxx"
   - name: Cppcheck and codecheck
@@ -35,7 +35,7 @@ matrix:
   - name: External blas with internal lapack, including asmjit
     os: linux
     if: branch =~ ^test- OR type IN(pull_request)
-    dist: trusty
+    dist: xenial
     sudo: required
     env: PLUMED_CC=mpicc PLUMED_CXX=mpic++  PLUMED_CXXFLAGS=-O3 LAPACK=yes CONFIG_FLAGS="--disable-external-lapack" ASMJIT=yes
   - name: Docker image (ubuntu 17, with gcc6)
@@ -152,6 +152,7 @@ install:
 # we do it only when needed
   - if test "$PLUMED_CXX" == "mpic++" -a "$TRAVIS_OS_NAME" == "linux" ; then sudo apt-get install -y libopenmpi-dev openmpi-bin ; fi
   - if test "$PLUMED_CXX" == "mpic++" -a "$TRAVIS_OS_NAME" == "osx" ;   then brew install openmpi ; fi
+  - export OMPI_MCA_btl="^openib"
   - if test "$MAKEDOC" == yes ; then sudo apt-get install -y graphviz            ; fi
 # install doxygen-latex
   - if test "$MAKEDOC" == yes ; then sudo apt-get install -y doxygen-latex ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,8 @@ install:
       brew update > /dev/null ;
       brew install ccache ;
       export PLUMED_MPIRUN="mpirun --oversubscribe" ;
+    else
+      export PLUMED_MPIRUN="mpirun.openmpi" ;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ; fi
 # install some package - these are fast, we install them anyway

--- a/.travis/install.boost
+++ b/.travis/install.boost
@@ -1,0 +1,29 @@
+#! /bin/bash
+  
+set -e
+set -x
+
+cd "$(mktemp -dt plumed.XXXXXX)"
+
+# this should probably match system boost
+version=1.58.0
+
+version_=${version//./_}
+
+echo $version $version_
+
+wget https://sourceforge.net/projects/boost/files/boost/$version/boost_${version_}.tar.gz/download > /dev/null 2> /dev/null
+tar xzf download
+
+cd boost_${version_}
+
+./bootstrap.sh --with-libraries=serialization --prefix="$HOME/opt"
+
+# debug build:
+./b2 debug cxxflags=-D_GLIBCXX_DEBUG install -j 4 > /dev/null 2> /dev/null
+
+# release build would be this one:
+#./b2 release install -j 4 
+# not needed since we can use system boost
+
+

--- a/src/maketools/plumedcheck
+++ b/src/maketools/plumedcheck
@@ -264,7 +264,10 @@ BEGINFILE{
 # DOC: When you modify the latter, the former should be regenerated using `autoconf` and
 # DOC: committed to git. This error indicates that the `./configure.ac` and `./configure` files
 # DOC: in the repository are not consistent.
-    if(s!=0) error("autoconf","autoconf not satisfied")
+# DOC: Notice that Ubuntu 16 ships with an autoconf version that is not standard
+# DOC: (2.69 + some patch). This makes this test report a false positive.
+# DOC: This is thus changed to a style warning.
+    if(s!=0) style("autoconf","autoconf not satisfied")
     system("rm " tempfile)
   }
 


### PR DESCRIPTION
##### Description

Update travis build to use Ubuntu 16 xenial

##### Target release

I would like my code to appear in release __v2.6__

##### Notes

I made some fix already, namely:
- changed a check on autoconf since ubuntu 16 has a custom autoconf
- install by hand boost libraries when compiling in debug mode, since linking a code with debug flags with non-debug boost gives problems.

There is however one thing that I cannot fix. Regtest `mapping/rt-adapt` fails. I am not sure if this is a real bug or just some numerical instability, but it would be great if @gtribello can have a look at it.

Thanks!

Giovanni
