### PR TITLE
Fix for updating of bias potential in VES_LINEAR_EXPANSION

### DIFF
--- a/CHANGES/v2.5.md
+++ b/CHANGES/v2.5.md
@@ -198,4 +198,4 @@ For users:
   - Force using cython when compiling from source. Still using the pre-generated cpp file
     when installing from PyPI, to avoid cython dependency.
   - Using python 2 to create the cpp file uploaded on PyPI (this will change to python 3 in 2.6, see \issue{502}).
-
+- Module VES: Fixed a bug in updating of bias potential in VES_LINEAR_EXPANSION that is present for certain integrators that call the calculation of the bias multiple times (see [here](https://groups.google.com/d/msg/plumed-users/kPZu_tNZtgk/LrkS0EqrCQAJ)) and replica exchange.

--- a/CHANGES/v2.5.md
+++ b/CHANGES/v2.5.md
@@ -13,7 +13,7 @@ Changes from version 2.4 which are relevant for users:
     to set correctly the `LD_LIBRARY_PATH` variable for the linux executable to work correctly. The procedure has been tested well on OSX and Linux,
     but could give problems on other platform. Please report possible problems on the mailing list.
   - \ref driver now stops correctly when using \ref COMMITTOR. If you want to continue the analysis, use the `NOSTOP` flag in \ref COMMITTOR.
-  - \ref METAD the calculation of the reweighting factor is now activated by CALC_RCT instead of REWEIGHTING_NGRID and REWEIGHTING_NHILLS, the frequency of update can be set 
+  - \ref METAD the calculation of the reweighting factor is now activated by CALC_RCT instead of REWEIGHTING_NGRID and REWEIGHTING_NHILLS, the frequency of update can be set
     by RCT_USTRIDE, the default value is 1 and should be OK for most of the cases
   - Fixed sign in Cartesian components of \ref PUCKERING with 6 membered rings (thanks to Carol Simoes and Javi Iglesias).
 
@@ -64,7 +64,7 @@ Changes from version 2.4 which are relevant for users:
   - \ref SAXS includes the MARTINI bead structure factors for Proteins and Nucleic Acids
   - \ref SAXS includes a GPU implementation based on ArrayFire (need to be linked at compile time) that can be activated with GPU
   - \ref METAINFERENCE and all related methods has a new keyword REGRES_ZERO to scale data using a linear scale fit
-  - \ref CALIBER new bias to perform Maximum Caliber replica-averaged restrained simulations 
+  - \ref CALIBER new bias to perform Maximum Caliber replica-averaged restrained simulations
 
 - Changes in the eABF/DRR module (contributed by Haochuan Chen and Haohao Fu):
   - \ref DRR now supports the extended generalized ABF(egABF) method.
@@ -74,7 +74,7 @@ Changes from version 2.4 which are relevant for users:
   - Fixed conflicts of output files in multiple replicas.
 
 - Changes in the EDS module:
-  - \ref EDS implements Levenberg-Marquardt optimization in addition to previous gradient descent. 
+  - \ref EDS implements Levenberg-Marquardt optimization in addition to previous gradient descent.
   - \ref EDS no longer automatically increases prefactor for bias parameter updates. This results in more stable optimization for the cases tested.
   - \ref EDS now has a larger default RANGE parameter to go with these other changes.
 
@@ -110,7 +110,7 @@ Changes from version 2.4 which are relevant for developers:
   in the core parts of the code have been eliminated.
 - Exceptions cannot be disabled (`--disable-cxx-exceptions` option has been removed from `./configure`).
 - Every exception thrown in PLUMED now also writes its message on PLUMED log.
-- Runtime loader in `Plumed.c` now works also when linked without `-rdynamic` (that is, 
+- Runtime loader in `Plumed.c` now works also when linked without `-rdynamic` (that is,
   its names are not exported). Notice that all the combinations are expected to
   work, that is: `Plumed.c` from <=2.4 or >=2.5 combined with libplumedKernel
   from <=2.4 or >=2.5. In order to achieve this the following changes are implemented:
@@ -160,7 +160,7 @@ Changes from version 2.4 which are relevant for developers:
 For users:
 - in \ref SAXS the keyword ADDEXP is removed. Furthemore, SAXS intensities are automatically normalised for I(0)=1, in case experimental data are provided, the intensity is rescaled with the intensity of the lowest q provided. As a consequence SCALEINT is only needed for additional adjustments.
 - gromacs patch updated to gromacs 2018.5
-- Fixed a bug in gromacs patch that was resulting in incorrect number of threads (0) set when not explicitly using `-ntomp` on the 
+- Fixed a bug in gromacs patch that was resulting in incorrect number of threads (0) set when not explicitly using `-ntomp` on the
   command line or setting `OMP_NUM_THREADS` (see \issue{446}). To apply this fix you need to re-patch gromacs.
   Notice that setting the number of threads to zero might lead to inconsistent results when using secondary structure variables
   or other multicolvars.
@@ -179,9 +179,9 @@ For users:
 - Fixed performance of \ref CUSTOM when having zero derivatives with respect to some arguments.
 - New --parse-only option in \ref driver to check the validity of a plumed input file
 - New patch for GROMACS 2019.2
-- Module VES: Fixed performance of \ref BF_CUSTOM for basis functions with linear terms (e.g. having zero derivatives). 
+- Module VES: Fixed performance of \ref BF_CUSTOM for basis functions with linear terms (e.g. having zero derivatives).
 - Python wrappers:
-  - Python module is now always named `plumed` irrespectively of program prefix and suffix. Notice 
+  - Python module is now always named `plumed` irrespectively of program prefix and suffix. Notice
     that python module is installed inside the `lib/program_name` directory and thus it is not necessary to
     use `program_name` in order to install multiple modules side by side.
   - Python module can be compiled without compiling PLUMED first.
@@ -198,4 +198,4 @@ For users:
   - Force using cython when compiling from source. Still using the pre-generated cpp file
     when installing from PyPI, to avoid cython dependency.
   - Using python 2 to create the cpp file uploaded on PyPI (this will change to python 3 in 2.6, see \issue{502}).
-
+- Module VES: Fixed a bug in updating of bias potential in VES_LINEAR_EXPANSION that is present for certain integrators that call the calculation of the bias multiple times (see [here](https://groups.google.com/d/msg/plumed-users/kPZu_tNZtgk/LrkS0EqrCQAJ)) and replica exchange.

--- a/CHANGES/v2.5.md
+++ b/CHANGES/v2.5.md
@@ -13,7 +13,7 @@ Changes from version 2.4 which are relevant for users:
     to set correctly the `LD_LIBRARY_PATH` variable for the linux executable to work correctly. The procedure has been tested well on OSX and Linux,
     but could give problems on other platform. Please report possible problems on the mailing list.
   - \ref driver now stops correctly when using \ref COMMITTOR. If you want to continue the analysis, use the `NOSTOP` flag in \ref COMMITTOR.
-  - \ref METAD the calculation of the reweighting factor is now activated by CALC_RCT instead of REWEIGHTING_NGRID and REWEIGHTING_NHILLS, the frequency of update can be set
+  - \ref METAD the calculation of the reweighting factor is now activated by CALC_RCT instead of REWEIGHTING_NGRID and REWEIGHTING_NHILLS, the frequency of update can be set 
     by RCT_USTRIDE, the default value is 1 and should be OK for most of the cases
   - Fixed sign in Cartesian components of \ref PUCKERING with 6 membered rings (thanks to Carol Simoes and Javi Iglesias).
 
@@ -64,7 +64,7 @@ Changes from version 2.4 which are relevant for users:
   - \ref SAXS includes the MARTINI bead structure factors for Proteins and Nucleic Acids
   - \ref SAXS includes a GPU implementation based on ArrayFire (need to be linked at compile time) that can be activated with GPU
   - \ref METAINFERENCE and all related methods has a new keyword REGRES_ZERO to scale data using a linear scale fit
-  - \ref CALIBER new bias to perform Maximum Caliber replica-averaged restrained simulations
+  - \ref CALIBER new bias to perform Maximum Caliber replica-averaged restrained simulations 
 
 - Changes in the eABF/DRR module (contributed by Haochuan Chen and Haohao Fu):
   - \ref DRR now supports the extended generalized ABF(egABF) method.
@@ -74,7 +74,7 @@ Changes from version 2.4 which are relevant for users:
   - Fixed conflicts of output files in multiple replicas.
 
 - Changes in the EDS module:
-  - \ref EDS implements Levenberg-Marquardt optimization in addition to previous gradient descent.
+  - \ref EDS implements Levenberg-Marquardt optimization in addition to previous gradient descent. 
   - \ref EDS no longer automatically increases prefactor for bias parameter updates. This results in more stable optimization for the cases tested.
   - \ref EDS now has a larger default RANGE parameter to go with these other changes.
 
@@ -110,7 +110,7 @@ Changes from version 2.4 which are relevant for developers:
   in the core parts of the code have been eliminated.
 - Exceptions cannot be disabled (`--disable-cxx-exceptions` option has been removed from `./configure`).
 - Every exception thrown in PLUMED now also writes its message on PLUMED log.
-- Runtime loader in `Plumed.c` now works also when linked without `-rdynamic` (that is,
+- Runtime loader in `Plumed.c` now works also when linked without `-rdynamic` (that is, 
   its names are not exported). Notice that all the combinations are expected to
   work, that is: `Plumed.c` from <=2.4 or >=2.5 combined with libplumedKernel
   from <=2.4 or >=2.5. In order to achieve this the following changes are implemented:
@@ -160,7 +160,7 @@ Changes from version 2.4 which are relevant for developers:
 For users:
 - in \ref SAXS the keyword ADDEXP is removed. Furthemore, SAXS intensities are automatically normalised for I(0)=1, in case experimental data are provided, the intensity is rescaled with the intensity of the lowest q provided. As a consequence SCALEINT is only needed for additional adjustments.
 - gromacs patch updated to gromacs 2018.5
-- Fixed a bug in gromacs patch that was resulting in incorrect number of threads (0) set when not explicitly using `-ntomp` on the
+- Fixed a bug in gromacs patch that was resulting in incorrect number of threads (0) set when not explicitly using `-ntomp` on the 
   command line or setting `OMP_NUM_THREADS` (see \issue{446}). To apply this fix you need to re-patch gromacs.
   Notice that setting the number of threads to zero might lead to inconsistent results when using secondary structure variables
   or other multicolvars.
@@ -179,9 +179,9 @@ For users:
 - Fixed performance of \ref CUSTOM when having zero derivatives with respect to some arguments.
 - New --parse-only option in \ref driver to check the validity of a plumed input file
 - New patch for GROMACS 2019.2
-- Module VES: Fixed performance of \ref BF_CUSTOM for basis functions with linear terms (e.g. having zero derivatives).
+- Module VES: Fixed performance of \ref BF_CUSTOM for basis functions with linear terms (e.g. having zero derivatives). 
 - Python wrappers:
-  - Python module is now always named `plumed` irrespectively of program prefix and suffix. Notice
+  - Python module is now always named `plumed` irrespectively of program prefix and suffix. Notice 
     that python module is installed inside the `lib/program_name` directory and thus it is not necessary to
     use `program_name` in order to install multiple modules side by side.
   - Python module can be compiled without compiling PLUMED first.
@@ -198,4 +198,4 @@ For users:
   - Force using cython when compiling from source. Still using the pre-generated cpp file
     when installing from PyPI, to avoid cython dependency.
   - Using python 2 to create the cpp file uploaded on PyPI (this will change to python 3 in 2.6, see \issue{502}).
-- Module VES: Fixed a bug in updating of bias potential in VES_LINEAR_EXPANSION that is present for certain integrators that call the calculation of the bias multiple times (see [here](https://groups.google.com/d/msg/plumed-users/kPZu_tNZtgk/LrkS0EqrCQAJ)) and replica exchange.
+

--- a/src/ves/VesLinearExpansion.cpp
+++ b/src/ves/VesLinearExpansion.cpp
@@ -287,10 +287,14 @@ private:
   LinearBasisSetExpansion* bias_expansion_pntr_;
   size_t ncoeffs_;
   Value* valueForce2_;
+  bool all_values_inside;
+  std::vector<double> bf_values;
+  bool bf_values_set;
 public:
   explicit VesLinearExpansion(const ActionOptions&);
   ~VesLinearExpansion();
   void calculate();
+  void update();
   void updateTargetDistributions();
   void restartTargetDistributions();
   //
@@ -334,7 +338,10 @@ VesLinearExpansion::VesLinearExpansion(const ActionOptions&ao):
   nargs_(getNumberOfArguments()),
   basisf_pntrs_(0),
   bias_expansion_pntr_(NULL),
-  valueForce2_(NULL)
+  valueForce2_(NULL),
+  all_values_inside(true),
+  bf_values(0),
+  bf_values_set(false)
 {
   std::vector<std::string> basisf_labels;
   parseMultipleValues("BASIS_FUNCTIONS",basisf_labels,nargs_);
@@ -367,6 +374,7 @@ VesLinearExpansion::VesLinearExpansion(const ActionOptions&ao):
   bias_expansion_pntr_->linkVesBias(this);
   bias_expansion_pntr_->setGridBins(this->getGridBins());
   //
+  bf_values.assign(ncoeffs_,0.0);
 
 
 
@@ -410,17 +418,16 @@ void VesLinearExpansion::calculate() {
 
   std::vector<double> cv_values(nargs_);
   std::vector<double> forces(nargs_);
-  std::vector<double> coeffsderivs_values(ncoeffs_);
 
   for(unsigned int k=0; k<nargs_; k++) {
     cv_values[k]=getArgument(k);
   }
 
-  bool all_inside = true;
-  double bias = bias_expansion_pntr_->getBiasAndForces(cv_values,all_inside,forces,coeffsderivs_values);
+  all_values_inside = true;
+  double bias = bias_expansion_pntr_->getBiasAndForces(cv_values,all_values_inside,forces,bf_values);
   if(biasCutoffActive()) {
-    applyBiasCutoff(bias,forces,coeffsderivs_values);
-    coeffsderivs_values[0]=1.0;
+    applyBiasCutoff(bias,forces,bf_values);
+    bf_values[0]=1.0;
   }
   double totalForce2 = 0.0;
   for(unsigned int k=0; k<nargs_; k++) {
@@ -430,10 +437,22 @@ void VesLinearExpansion::calculate() {
 
   setBias(bias);
   valueForce2_->set(totalForce2);
-  if(all_inside) {
-    addToSampledAverages(coeffsderivs_values);
-  }
+
+  bf_values_set = true;
 }
+
+
+void VesLinearExpansion::update() {
+  plumed_assert(bf_values_set);
+  if(all_values_inside && bf_values_set) {
+    addToSampledAverages(bf_values);
+  }
+  bf_values_set = false;
+}
+
+
+
+
 
 
 void VesLinearExpansion::updateTargetDistributions() {

--- a/src/ves/VesLinearExpansion.cpp
+++ b/src/ves/VesLinearExpansion.cpp
@@ -447,6 +447,7 @@ void VesLinearExpansion::update() {
   if(all_values_inside && bf_values_set) {
     addToSampledAverages(bf_values);
   }
+  std::fill(bf_values.begin(), bf_values.end(), 0.0);
   bf_values_set = false;
 }
 

--- a/src/ves/VesLinearExpansion.cpp
+++ b/src/ves/VesLinearExpansion.cpp
@@ -443,7 +443,9 @@ void VesLinearExpansion::calculate() {
 
 
 void VesLinearExpansion::update() {
-  plumed_assert(bf_values_set);
+  if(!bf_values_set) {
+    warning("VesLinearExpansion::update() is being called without calling VesLinearExpansion::calculate() first to calculate the basis function values. This can lead to incorrect behavior.");
+  }
   if(all_values_inside && bf_values_set) {
     addToSampledAverages(bf_values);
   }


### PR DESCRIPTION
##### Description

This fixes an issue with updating of bias potential in VES_LINEAR_EXPANSION that is present for certain integrators that call the calculation of the bias multiple times and replica exchange. 

See discussion on PLUMED group: 
https://groups.google.com/d/msg/plumed-users/kPZu_tNZtgk/LrkS0EqrCQAJ

##### Target release

I would like my code to appear in release v2.5

##### Type of contribution


- [x] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [x] new module contribution or edit of a module authored by you

##### Copyright



- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.


- [x] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on Travis-CI.


