### PR TITLE
Fixed an initialization of class member in EDS

### DIFF
--- a/src/eds/EDS.cpp
+++ b/src/eds/EDS.cpp
@@ -327,6 +327,7 @@ EDS::EDS(const ActionOptions&ao):
   kbt_(0.0),
   multi_prop_(-1.0),
   lm_mixing_par_(0.1),
+  virial_scaling_(0.),
   pseudo_virial_sum_(0.0),
   value_force2_(NULL)
 {
@@ -457,7 +458,7 @@ EDS::EDS(const ActionOptions&ao):
   }
 
   if (b_mean && !b_freeze_) {
-    error("EDS keyworkd MEAN can only be used along with keyword FREEZE");
+    error("EDS keyword MEAN can only be used along with keyword FREEZE");
   }
 
   if(in_restart_name_ != "") {


### PR DESCRIPTION
##### Description

Thank you to @gtribello for spotting an initialization bug. I never noticed it on my machines because it appears that the double was always initialized to 0, but now this has been made explicit :) @hockyg 

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release v2.6

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [x] new module contribution or edit of a module authored by you
