### PR TITLE
small fix for single precision timestep

### DIFF
--- a/src/core/Atoms.cpp
+++ b/src/core/Atoms.cpp
@@ -442,6 +442,11 @@ void Atoms::updateUnits() {
 
 void Atoms::setTimeStep(void*p) {
   MD2double(p,timestep);
+// The following is to avoid extra digits in case the MD code uses floats
+// e.g.: float f=0.002 when converted to double becomes 0.002000000094995
+// To avoid this, we keep only up to 6 significant digits after first one
+  double magnitude=std::pow(10,std::floor(std::log10(timestep)));
+  timestep=std::floor(timestep/magnitude*1e6)/1e6*magnitude;
 }
 
 double Atoms::getTimeStep()const {


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

A possible fix for the small annoyance of non rounded time step if MD engine uses single precision (see https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/plumed-users/qv-rqQvdODE/aSfcMM_dCAAJ ).
I implemented this for myself long time back, now I saw the discussion on plumed-users, so I decided to make this PR. Feel free to ignore it if you think is not useful.

This is the rationale: the MD time step is set by the user in some input file in decimal notation, and it is extremely unlikely that the user needs more than 6 significant digits. The MD code then stores it in single or double precision. Plumed might want to stay close to the original decimal time step, instead of simply casting it to double, especially since it is only used when outputting the time, and does not play a role in calculations.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.7 (maybe also in older versions?)

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on Travis-CI.

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
