### PR TITLE
Update doc of ENERGY CV

### DIFF
--- a/src/colvar/Energy.cpp
+++ b/src/colvar/Energy.cpp
@@ -32,7 +32,7 @@ namespace colvar {
 
 //+PLUMEDOC COLVAR ENERGY
 /*
-Calculate the total energy of the simulation box.
+Calculate the total potential energy of the simulation box.
 
 Total energy can be biased with umbrella sampling \cite bart-karp98jpcb or with well tempered metadynamics \cite Bonomi:2009p17935.
 


### PR DESCRIPTION
The documentation of the ENERGY CV states that it calculates the total energy. For most people total energy means potential+kinetic energy. I think this should be clarified and that there is an implicit convention, followed at least by LAMMPS and Gromacs, that the energy CV is the **total potential energy** (without tail corrections as discussed in issue #567). I also believe that most if not all papers that use some energy as CV use the potential energy. Furthermore, the two citations in the ENERGY CV are papers that use the potential energy.

For the reasons stated above this PR proposes to change **total energy**  to **total potential energy** in the documentation of the ENERGY CV.

Please disregard this PR if the plan is to use the total energy in the future.

This issue was pointed out to me by Tom Gartner @tgartner .

<!--
  Feel free to delete not relevant sections below
-->

##### Description

<!-- describe here your pull request -->

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in any release

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x ] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [x ] No regtests required
- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on Travis-CI.

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
