### PR TITLE
V2.6 some cppcheck fixes

### DIFF
--- a/src/drr/drrtool.cpp
+++ b/src/drr/drrtool.cpp
@@ -204,7 +204,7 @@ void drrtool::mergewindows(const vector<string> &filename) {
   // Generate new file name for merged grad and count
   vector<string> tmp_name = filename;
   std::transform(std::begin(tmp_name), std::end(tmp_name), std::begin(tmp_name), [&](string s) {return s.substr(0, s.find(suffix));});
-  string mergename = std::accumulate(std::begin(tmp_name), std::end(tmp_name), string(""), [](string a, string b) {return a + b + "+";});
+  string mergename = std::accumulate(std::begin(tmp_name), std::end(tmp_name), string(""), [](const string & a, const string & b) {return a + b + "+";});
   mergename = mergename.substr(0, mergename.size() - 1);
   cmerged.writeAll(mergename);
   cmerged.writeZCount(mergename);

--- a/src/multicolvar/InPlaneDistances.cpp
+++ b/src/multicolvar/InPlaneDistances.cpp
@@ -107,7 +107,9 @@ InPlaneDistances::InPlaneDistances(const ActionOptions&ao):
       use_link=true; rcut=lt->getCutoff();
     } else {
       vesselbase::Between* bt=dynamic_cast<vesselbase::Between*>( getPntrToVessel(0) );
-      if( bt ) use_link=true; rcut=bt->getCutoff();
+      if( bt ) {
+        use_link=true; rcut=bt->getCutoff();
+      }
     }
     if( use_link ) {
       for(unsigned i=1; i<getNumberOfVessels(); ++i) {

--- a/src/ves/MD_LinearExpansionPES.cpp
+++ b/src/ves/MD_LinearExpansionPES.cpp
@@ -669,7 +669,7 @@ int MD_LinearExpansionPES::main( FILE* in, FILE* out, PLMD::Communicator& pc) {
   if(plumed) {delete plumed;}
   if(plumed_bf) {delete plumed_bf;}
   if(potential_expansion_pntr) {delete potential_expansion_pntr;}
-  if(coeffs_pntr) {delete coeffs_pntr;}
+  delete coeffs_pntr; //NOTE: this is always non null
   for(unsigned int i=0; i<args.size(); i++) {delete args[i];}
   args.clear();
   //printf("Rank: %d, Size: %d \n", pc.Get_rank(), pc.Get_size() );

--- a/src/wrapper/Plumed.h
+++ b/src/wrapper/Plumed.h
@@ -2667,6 +2667,11 @@ plumed plumed_f2c(const char*c) {
   assert(sizeof(p.p)<=16);
 
   assert(c);
+
+  /*
+     needed to avoid cppcheck warning on uninitialized p
+  */
+  p.p=NULL;
   cc=(unsigned char*)&p.p;
   for(i=0; i<sizeof(p.p); i++) {
     assert(c[2*i]>=48 && c[2*i]<48+64);


### PR DESCRIPTION
##### Description

I fixed some warnings that I obtained using cppcheck 2.1. I open a pull request so as to perform the full test set.

@gtribello one of the commits (4c25861faef0f2c8febfaa2037db34dda0547126) is a bit critical, since it might be a real bug. Can you double check? In case this is a bug, we can easily backport this change.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.6__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers
- [x] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on Travis-CI. **will wait for the full test set**

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
