### PR TITLE
Correct lambda meta-dynamics units

### DIFF
--- a/patches/gromacs-2020.4.diff/src/gromacs/mdlib/expanded.cpp
+++ b/patches/gromacs-2020.4.diff/src/gromacs/mdlib/expanded.cpp
@@ -1336,6 +1336,7 @@ int ExpandedEnsembleDynamics(FILE*                 log,
             plumed_cmd(plumedmain, "prepareCalc", nullptr);
             plumed_cmd(plumedmain, "performCalcNoUpdate", nullptr);
             plumed_cmd(plumedmain, "getBias", &bias);
+            bias /= expand->mc_temp * BOLTZ;
             if (i == 0)
             {
                 zeroBias = bias;


### PR DESCRIPTION
Related to #603, this fixes a unit mismatch between PLUMED and GROMACS. Would need to be fixed in #603 as well if that was merged, but I assume the patches to GROMACS 2020.4 deprecate #603 (which patches 2020.2).