### PR TITLE
Fixing a simple LGTM warning about multiplication overflow

### DIFF
--- a/src/bias/ReweightWham.cpp
+++ b/src/bias/ReweightWham.cpp
@@ -134,7 +134,7 @@ double ReweightWham::getWeight( const unsigned& iweight ) const {
 }
 
 void ReweightWham::calculateWeights( const unsigned& nframes ) {
-  if( stored_biases.size()!=nreplicas*nframes ) error("wrong number of weights stored");
+  if( stored_biases.size()!=(unsigned long) nreplicas*nframes ) error("wrong number of weights stored");
   // Get the minimum value of the bias
   double minv = *min_element(std::begin(stored_biases), std::end(stored_biases));
   // Resize final weights array

--- a/src/core/MDAtoms.cpp
+++ b/src/core/MDAtoms.cpp
@@ -122,7 +122,7 @@ void MDAtomsTyped<T>::setUnits(const Units& units,const Units& MDUnits) {
 
 template <class T>
 void MDAtomsTyped<T>::getBox(Tensor&box)const {
-  if(this->box) for(int i=0; i<3; i++)for(int j=0; j<3; j++) box(i,j)=this->box[3*i+j]*scaleb;
+  if(this->box) for(int i=0; i<3; i++)for(int j=0; j<3; j++) box(i,j)=(double) this->box[3*i+j] * (double) scaleb;
   else box.zero();
 }
 
@@ -130,9 +130,9 @@ template <class T>
 void MDAtomsTyped<T>::getPositions(const vector<int>&index,vector<Vector>&positions)const {
 // cannot be parallelized with omp because access to positions is not ordered
   for(unsigned i=0; i<index.size(); ++i) {
-    positions[index[i]][0]=px[stride*i]*scalep;
-    positions[index[i]][1]=py[stride*i]*scalep;
-    positions[index[i]][2]=pz[stride*i]*scalep;
+    positions[index[i]][0]=(double) px[stride*i] * (double) scalep;
+    positions[index[i]][1]=(double) py[stride*i] * (double) scalep;
+    positions[index[i]][2]=(double) pz[stride*i] * (double) scalep;
   }
 }
 
@@ -141,9 +141,9 @@ void MDAtomsTyped<T>::getPositions(const std::set<AtomNumber>&index,const vector
 // cannot be parallelized with omp because access to positions is not ordered
   unsigned k=0;
   for(const auto & p : index) {
-    positions[p.index()][0]=px[stride*i[k]]*scalep;
-    positions[p.index()][1]=py[stride*i[k]]*scalep;
-    positions[p.index()][2]=pz[stride*i[k]]*scalep;
+    positions[p.index()][0]=(double) px[stride*i[k]] * (double) scalep;
+    positions[p.index()][1]=(double) py[stride*i[k]] * (double) scalep;
+    positions[p.index()][2]=(double) pz[stride*i[k]] * (double) scalep;
     k++;
   }
 }
@@ -152,9 +152,9 @@ template <class T>
 void MDAtomsTyped<T>::getPositions(unsigned j,unsigned k,vector<Vector>&positions)const {
   #pragma omp parallel for num_threads(OpenMP::getGoodNumThreads(&positions[j],(k-j)))
   for(unsigned i=j; i<k; ++i) {
-    positions[i][0]=px[stride*i]*scalep;
-    positions[i][1]=py[stride*i]*scalep;
-    positions[i][2]=pz[stride*i]*scalep;
+    positions[i][0]=(double) px[stride*i] * (double) scalep;
+    positions[i][1]=(double) py[stride*i] * (double) scalep;
+    positions[i][2]=(double) pz[stride*i] * (double) scalep;
   }
 }
 
@@ -163,22 +163,22 @@ template <class T>
 void MDAtomsTyped<T>::getLocalPositions(vector<Vector>&positions)const {
   #pragma omp parallel for num_threads(OpenMP::getGoodNumThreads(positions))
   for(unsigned i=0; i<positions.size(); ++i) {
-    positions[i][0]=px[stride*i]*scalep;
-    positions[i][1]=py[stride*i]*scalep;
-    positions[i][2]=pz[stride*i]*scalep;
+    positions[i][0]=(double) px[stride*i] * (double) scalep;
+    positions[i][1]=(double) py[stride*i] * (double) scalep;
+    positions[i][2]=(double) pz[stride*i] * (double) scalep;
   }
 }
 
 
 template <class T>
 void MDAtomsTyped<T>::getMasses(const vector<int>&index,vector<double>&masses)const {
-  if(m) for(unsigned i=0; i<index.size(); ++i) masses[index[i]]=scalem*m[i];
+  if(m) for(unsigned i=0; i<index.size(); ++i) masses[index[i]]=(double) scalem  * (double) m[i];
   else  for(unsigned i=0; i<index.size(); ++i) masses[index[i]]=0.0;
 }
 
 template <class T>
 void MDAtomsTyped<T>::getCharges(const vector<int>&index,vector<double>&charges)const {
-  if(c) for(unsigned i=0; i<index.size(); ++i) charges[index[i]]=scalec*c[i];
+  if(c) for(unsigned i=0; i<index.size(); ++i) charges[index[i]]=(double) scalec * (double) c[i];
   else  for(unsigned i=0; i<index.size(); ++i) charges[index[i]]=0.0;
 }
 

--- a/src/isdb/CS2Backbone.cpp
+++ b/src/isdb/CS2Backbone.cpp
@@ -983,7 +983,7 @@ void CS2Backbone::calculate()
   }
 
   unsigned nt=OpenMP::getNumThreads();
-  if(nt*stride*2>chemicalshifts.size()) nt=1;
+  if((long) nt * (long) stride * 2 > chemicalshifts.size()) nt=1;
 
   // a single loop over all chemical shifts
   #pragma omp parallel num_threads(nt)

--- a/src/isdb/SAXS.cpp
+++ b/src/isdb/SAXS.cpp
@@ -2041,10 +2041,10 @@ double SAXS::calculateASF(const vector<AtomNumber> &atoms, vector<vector<long do
         FF_tmp[k][i] = param_c[i];
         // SUM [a_i * EXP( - b_i * (q/4pi)^2 )] Waasmaier and Kirfel (1995)
         for(unsigned j=0; j<4; j++) {
-          FF_tmp[k][i] += param_a[i][j]*exp(-param_b[i][j]*s*s);
+          FF_tmp[k][i] += (long double) param_a[i][j] * exp(-param_b[i][j]*s*s);
         }
         // subtract solvation: rho * v_i * EXP( (- v_i^(2/3) / (4pi)) * q^2  ) // since  D in Fraser 1978 is 2*s
-        FF_tmp[k][i] -= rho*param_v[i]*exp(-volr*q*q);
+        FF_tmp[k][i] -= (long double) rho*param_v[i]*exp(-volr*q*q);
       }
     }
     // cycle over the atoms to assign the atom type and calculate I0

--- a/src/ves/MD_LinearExpansionPES.cpp
+++ b/src/ves/MD_LinearExpansionPES.cpp
@@ -307,7 +307,7 @@ int MD_LinearExpansionPES::main( FILE* in, FILE* out, PLMD::Communicator& pc) {
       }
     }
   }
-  else if(initPosTmp.size()==dim*replicas) {
+  else if(initPosTmp.size()==(unsigned long) dim*replicas) {
     for(unsigned int i=0; i<replicas; i++) {
       for(unsigned int k=0; k<dim; k++) {
         initPos[i][k]=initPosTmp[i*dim+k];


### PR DESCRIPTION
##### Description

Found a couple of low-hanging fruits in LGTM output, mainly multiplications overflows. This PR attempts to fix them. 

https://lgtm.com/projects/g/plumed/plumed2/?mode=list

##### Type of contribution

- [x] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on Travis-CI.

