### PR TITLE
Removed an inconsistency detected by cppcheck

### DIFF
--- a/src/gridtools/FindContour.cpp
+++ b/src/gridtools/FindContour.cpp
@@ -99,10 +99,6 @@ private:
   OFile of;
   double lenunit;
   std::string fmt_xyz;
-/// The data is stored in a grid
-// NOTE: this suppression should be double checked:
-// cppcheck-suppress duplInheritedMember
-  vesselbase::StoreDataVessel* mydata;
 public:
   static void registerKeywords( Keywords& keys );
   explicit FindContour(const ActionOptions&ao);


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

@gtribello can you double check this? Cppcheck 2.4.1 tells me this:
```
[gridtools/FindContour.cpp:103] (warning) :duplInheritedMember: The class 'FindContour' defines member variable with name 'mydata' also defined in its parent class 'ActionWithVessel'.
```

I suppressed the error in order to use cppcheck 2.4.1 on master branch, but I suspect that cppcheck is correct. If this variable was added by mistake I would merge this branch.


<!-- describe here your pull request -->

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.8__, but if it's a bug fix it should be backported

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
