### PR TITLE
try to make sasa appear under module

### DIFF
--- a/regtest/sasa/Makefile
+++ b/regtest/sasa/Makefile
@@ -1,0 +1,2 @@
+include ../scripts/module.make
+

--- a/src/sasa/sasa_HASEL.cpp
+++ b/src/sasa/sasa_HASEL.cpp
@@ -43,9 +43,10 @@ namespace sasa {
 Calculates the solvent accessible surface area (SASA) of a protein molecule, or other properties related to it. The atoms for which the SASA is desired should be indicated with the keyword ATOMS, and a pdb file of the protein must be provided in input with the MOLINFO keyword. The algorithm described in \cite Hasel1988 is used for the calculation. The radius of the solvent is assumed to be 0.14 nm, which is the radius of water molecules. Using the keyword NL_STRIDE it is also possible to specify the frequency with which the neighbor list for the calculation of SASA is updated (the default is every 10 steps).
 
 Different properties can be calculated and selected using the TYPE keyword:
-the total SASA (TOTAL);
 
-the free energy of transfer for the protein according to the transfer model (TRANSFER. This keyword can be used, for instance, to compute the transfer of a protein to different temperatures, as detailed in \cite Arsiccio-SASA-2021).
+1) the total SASA (TOTAL);
+
+2) the free energy of transfer for the protein according to the transfer model (TRANSFER. This keyword can be used, for instance, to compute the transfer of a protein to different temperatures, as detailed in \cite Arsiccio-SASA-2021).
 
 
 When the TRANSFER keyword is used, a file with the free energy of transfer values for the sidechains and backbone atoms should be provided (using the keyword DELTAGFILE). Such file should have the following format:

--- a/src/sasa/sasa_LCPO.cpp
+++ b/src/sasa/sasa_LCPO.cpp
@@ -43,9 +43,10 @@ namespace sasa {
 Calculates the solvent accessible surface area (SASA) of a protein molecule, or other properties related to it. The atoms for which the SASA is desired should be indicated with the keyword ATOMS, and a pdb file of the protein must be provided in input with the MOLINFO keyword. The LCPO algorithm is used for the calculation (please, read and cite \cite Weiser1999). The radius of the solvent is assumed to be 0.14 nm, which is the radius of water molecules. Using the keyword NL_STRIDE it is also possible to specify the frequency with which the neighbor list for the calculation of the SASA is updated (the default is every 10 steps).
 
 Different properties can be calculated and selected using the TYPE keyword:
-the total SASA (TOTAL);
 
-the free energy of transfer for the protein according to the transfer model (TRANSFER. This keyword can be used to compute the transfer of a protein to different temperatures, as detailed in \cite Arsiccio-SASA-2021).
+1) the total SASA (TOTAL);
+
+2) the free energy of transfer for the protein according to the transfer model (TRANSFER. This keyword can be used to compute the transfer of a protein to different temperatures, as detailed in \cite Arsiccio-SASA-2021).
 
 
 When the TRANSFER keyword is used, a file with the free energy of transfer values for the sidechains and backbone atoms should be provided (using the keyword DELTAGFILE). Such file should have the following format:

--- a/user-doc/spelling_words.dict
+++ b/user-doc/spelling_words.dict
@@ -360,6 +360,7 @@ gyromagnetic
 GSL
 CRYST
 piv
+sasa
 namespaces
 OSX
 libplumedKernel
@@ -906,6 +907,7 @@ AFED
 LogPD
 LOGMFDMOD
 PIVMOD
+SASAMOD
 logmfd
 MFD
 adiabatically


### PR DESCRIPTION


##### Description

The SASA module kept appearing under root, rather than under the module section in the documentation. I tried again to address this issue.
 
##### Target release

I would like my code to appear in release  2.8

##### Type of contribution


- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [  x ] new module contribution or edit of a module authored by you

##### Copyright


- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [ x ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

- [ x ] I added a new regtest or modified an existing regtest to validate my changes.
- [x  ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).
