### PR TITLE
Try to make sasa appear under module

### DIFF
--- a/src/sasa/sasa_HASEL.cpp
+++ b/src/sasa/sasa_HASEL.cpp
@@ -38,7 +38,7 @@ using namespace std;
 namespace PLMD {
 namespace sasa {
 
-//+PLUMEDOC COLVAR SASA_HASEL
+//+PLUMEDOC SASAMOD_COLVAR SASA_HASEL
 /*
 Calculates the solvent accessible surface area (SASA) of a protein molecule, or other properties related to it. The atoms for which the SASA is desired should be indicated with the keyword ATOMS, and a pdb file of the protein must be provided in input with the MOLINFO keyword. The algorithm described in \cite Hasel1988 is used for the calculation. The radius of the solvent is assumed to be 0.14 nm, which is the radius of water molecules. Using the keyword NL_STRIDE it is also possible to specify the frequency with which the neighbor list for the calculation of SASA is updated (the default is every 10 steps).
 

--- a/src/sasa/sasa_LCPO.cpp
+++ b/src/sasa/sasa_LCPO.cpp
@@ -38,7 +38,7 @@ using namespace std;
 namespace PLMD {
 namespace sasa {
 
-//+PLUMEDOC COLVAR SASA_LCPO
+//+PLUMEDOC SASAMOD_COLVAR SASA_LCPO
 /*
 Calculates the solvent accessible surface area (SASA) of a protein molecule, or other properties related to it. The atoms for which the SASA is desired should be indicated with the keyword ATOMS, and a pdb file of the protein must be provided in input with the MOLINFO keyword. The LCPO algorithm is used for the calculation (please, read and cite \cite Weiser1999). The radius of the solvent is assumed to be 0.14 nm, which is the radius of water molecules. Using the keyword NL_STRIDE it is also possible to specify the frequency with which the neighbor list for the calculation of the SASA is updated (the default is every 10 steps).
 


### PR DESCRIPTION


##### Description

I have tried to fix the problem with manual generation for the SASA module as suggested.  Thanks a lot for your suggestions, and please forgive me for these issues with the documentation of this module.

##### Target release

I would like my code to appear in release 2.8

##### Type of contribution


- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ x ] new module contribution or edit of a module authored by you

##### Copyright


- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.
- [ x ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests


- [ x ] I added a new regtest or modified an existing regtest to validate my changes.
- [x ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).
