### PR TITLE
Fix incorrect EXPANSION module in manual

### DIFF
--- a/src/opes/ECVcustom.cpp
+++ b/src/opes/ECVcustom.cpp
@@ -20,7 +20,7 @@ along with plumed.  If not, see <http://www.gnu.org/licenses/>.
 namespace PLMD {
 namespace opes {
 
-//+PLUMEDOC EXPANSION_CV ECV_CUSTOM
+//+PLUMEDOC OPES_EXPANSION_CV ECV_CUSTOM
 /*
 Use some given CVs as a set of expansion collective variables (ECVs).
 

--- a/src/opes/ECVlinear.cpp
+++ b/src/opes/ECVlinear.cpp
@@ -20,7 +20,7 @@ along with plumed.  If not, see <http://www.gnu.org/licenses/>.
 namespace PLMD {
 namespace opes {
 
-//+PLUMEDOC EXPANSION_CV ECV_LINEAR
+//+PLUMEDOC OPES_EXPANSION_CV ECV_LINEAR
 /*
 Linear expansion, according to a parameter lambda.
 

--- a/src/opes/ECVmultiThermal.cpp
+++ b/src/opes/ECVmultiThermal.cpp
@@ -22,7 +22,7 @@ along with plumed.  If not, see <http://www.gnu.org/licenses/>.
 namespace PLMD {
 namespace opes {
 
-//+PLUMEDOC EXPANSION_CV ECV_MULTITHERMAL
+//+PLUMEDOC OPES_EXPANSION_CV ECV_MULTITHERMAL
 /*
 Expand a simulation to sample multiple temperatures simultaneously.
 

--- a/src/opes/ECVmultiThermalBaric.cpp
+++ b/src/opes/ECVmultiThermalBaric.cpp
@@ -22,7 +22,7 @@ along with plumed.  If not, see <http://www.gnu.org/licenses/>.
 namespace PLMD {
 namespace opes {
 
-//+PLUMEDOC EXPANSION_CV ECV_MULTITHERMAL_MULTIBARIC
+//+PLUMEDOC OPES_EXPANSION_CV ECV_MULTITHERMAL_MULTIBARIC
 /*
 Expand a simulation to sample multiple temperatures and pressures.
 

--- a/src/opes/ECVumbrellasFile.cpp
+++ b/src/opes/ECVumbrellasFile.cpp
@@ -21,7 +21,7 @@ along with plumed.  If not, see <http://www.gnu.org/licenses/>.
 namespace PLMD {
 namespace opes {
 
-//+PLUMEDOC EXPANSION_CV ECV_UMBRELLAS_FILE
+//+PLUMEDOC OPES_EXPANSION_CV ECV_UMBRELLAS_FILE
 /*
 Target a multiumbrella ensemble, by combining systems each with a parabolic bias potential at a different location.
 

--- a/src/opes/ECVumbrellasLine.cpp
+++ b/src/opes/ECVumbrellasLine.cpp
@@ -20,7 +20,7 @@ along with plumed.  If not, see <http://www.gnu.org/licenses/>.
 namespace PLMD {
 namespace opes {
 
-//+PLUMEDOC EXPANSION_CV ECV_UMBRELLAS_LINE
+//+PLUMEDOC OPES_EXPANSION_CV ECV_UMBRELLAS_LINE
 /*
 Target a multiumbrella ensemble, by combining systems each with a parabolic bias potential at a different location.
 

--- a/user-doc/OPES.md
+++ b/user-doc/OPES.md
@@ -47,7 +47,7 @@ ECVs take as argument some underlying colvar and have as output components the s
 
 The following list contains the expansion CVs available in the OPES module.
 
-@EXPANSION_CV@
+@OPES_EXPANSION_CV@
 
 \page OPES_tutorial Tutorials
 


### PR DESCRIPTION
##### Description

This fixes an issue with the additional modules where at the moment there is a listing for `EXPANSION` that is incorrect (between VES and MAZE in the list on https://www.plumed.org/doc-master/user-doc/html/_add_mod.html). 

It seems that this is due to the usage of `EXPANSION_CV` in the OPES manual. I have changed this to `OPES_EXPANSION_CV` in the relevant places and this seems to fix the issue (as tested on my laptop). 

@invemichele should check that he agrees with these changes. 

##### Target release

I would like my code to appear in release v2.8 (master)

##### Type of contribution

- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [x] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright


- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.


- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 


- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

