### PR TITLE
Let GROMACS runtime logs show PLUMED patch active

### DIFF
--- a/patches/gromacs-2021.config
+++ b/patches/gromacs-2021.config
@@ -29,5 +29,8 @@ EOF
 
 plumed_before_patch(){
   plumed_patch_info
+  
+  mv cmake/gmxVersionInfo.cmake cmake/gmxVersionInfo.cmake.preplumed
+  awk -v version="$PLUMED_VERSION" '/^set\(GMX_VERSION_STRING_OF_FORK/{gsub(/""/, version)}; {print}' cmake/gmxVersionInfo.cmake.preplumed > cmake/gmxVersionInfo.cmake
 }
 


### PR DESCRIPTION

##### Description

Knowing which PLUMED version has patched GROMACS is potentially valuable information for GROMACS and PLUMED users and developers troubleshooting their runs.

Closes #737

##### Target release

I would like my code to appear in release 2.7 and master

##### Type of contribution

- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).
