### PR TITLE
Change to fixzeros.sh script in regtests

### DIFF
--- a/regtest/scripts/fixzeroes.sh
+++ b/regtest/scripts/fixzeroes.sh
@@ -2,6 +2,7 @@
 
 file=$1
 
-sed "s/-0.000/ 0.000/g" $file > $file.$$.tmp
+sed "s/-\(0\.0*0 \)/ \1/g; 
+     s/-\(0\.0*0$\)/ \1/g" $file > $file.$$.tmp
 mv $file.$$.tmp $file
 


### PR DESCRIPTION
##### Description

Change to fixzeros.sh script in regtests to make it more general. For example, now values of the form `-0.00` are correctly handled. This change is needed to make the PR #759 pass the CI tests.

This passes all CI tests, see https://github.com/ves-code/plumed2-ves/actions/runs/1482785956 

##### Target release

I would like my code to appear in release v2.8

##### Type of contribution

- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests


- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

