### PR TITLE
Fix OPES_METAD html doc

### DIFF
--- a/src/opes/OPESmetad.cpp
+++ b/src/opes/OPESmetad.cpp
@@ -121,8 +121,8 @@ Our target distribution is a Gaussian centered there, thus the target free energ
 
 \plumedfile
 phi: TORSION ATOMS=5,7,9,15
-Ftg_func: CUSTOM ARG=phi PERIODIC=NO FUNC=(x/0.4)^2
-Ftg: BIASVALUE ARG=Ftg_func
+FtgValue: CUSTOM ARG=phi PERIODIC=NO FUNC=(x/0.4)^2
+Ftg: BIASVALUE ARG=FtgValue
 opes: OPES_METAD ...
   ARG=phi,Ftg.bias
   EXTRA_BIAS_ARG
@@ -415,7 +415,7 @@ OPESmetad<mode>::OPESmetad(const ActionOptions& ao)
     {
       plumed_massert(Tools::convertNoexcept(sigma_str[i],sigma0_[i]),error_in_input1+"SIGMA"+error_in_input2);
       if(mode::explore)
-        sigma0_[i]*=std::sqrt(biasfactor_); //the sigma of the target is broader F_t(s)=1/gamma*F(s)
+        sigma0_[i]*=std::sqrt(biasfactor_); //the sigma of the target is broader Ftg(s)=1/gamma*F(s)
     }
   }
   parseVector("SIGMA_MIN",sigma_min_);


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

<!-- describe here your pull request -->
The doc page for OPES_METAD is displaying only up to this line `Ftg: BIASVALUE ARG=Ftg_func`, see https://www.plumed.org/doc-master/user-doc/html/_o_p_e_s__m_e_t_a_d.html
When clicking on `Ftg:` one can see that the rest of the page is wrongly included among the components of `BIASVALUE`.

I fixed the problem simply by renaming `Ftg_func` to something without an underscore, but this might happen also somewhere else in the doc, and probably the function "click to see the output components" should be made more robust.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __2.8__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [x] ~new module contribution or~ edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
