### PR TITLE
--enable-rpath also use to PREFIX/lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -960,7 +960,7 @@ then
       test_LDSHARED="$LDSHARED -Wl,-R -Wl,/some/random/dir/"
       $test_LDSHARED $LDFLAGS conftest.o -o conftest.$SOEXT 1>/dev/null 2>/dev/null
       if readelf -d conftest.$SOEXT | grep RPATH | grep -q /some/random/dir ; then
-        LDSHARED="$LDSHARED -Wl,-R -Wl,\"$LIBRARY_PATH\""
+        LDSHARED="$LDSHARED -Wl,-R -Wl,\"${prefix}/lib:$LIBRARY_PATH\""
       else
         AC_MSG_WARN([-R option seems not working, disabling rpath])
       fi


### PR DESCRIPTION
##### Description

when `configure --enable-rpath --prefix=/non/standard/location`  build does not set RPATH to PREFIX/lib 
that brings the following error while installed
```
rpm_maker:plumed/plumed-2.7.2 > plumed -h 
plumed: error while loading shared libraries: libplumedKernel.so: cannot open shared object file: No such file or directory
```
the follwoing diff add PREFIX/lib to the rpath

##### Target release
plumed-2.7.2

regards 
Eric