### PR TITLE
Fix for S2CM manual generation

### DIFF
--- a/src/s2cm/COPYRIGHT
+++ b/src/s2cm/COPYRIGHT
@@ -1,4 +1,4 @@
-   Copyright (c) 2021 Omar Valsson
+   Copyright (c) 2017-2021 Omar Valsson
 
    This file is part of S2 contact model module 
 

--- a/src/s2cm/S2ContactModel.cpp
+++ b/src/s2cm/S2ContactModel.cpp
@@ -1,7 +1,7 @@
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-   Copyright (c) 2021 Omar Valsson
+   Copyright (c) 2017-2021 Omar Valsson
 
-   This file is part of S2 contact model module
+   This file is part of S2 contact model module 
 
    The S2 contact model module is free software: you can redistribute it and/or modify
    it under the terms of the GNU Lesser General Public License as published by

--- a/src/s2cm/S2ContactModel.cpp
+++ b/src/s2cm/S2ContactModel.cpp
@@ -1,7 +1,7 @@
 /* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
    Copyright (c) 2017-2021 Omar Valsson
 
-   This file is part of S2 contact model module 
+   This file is part of S2 contact model module
 
    The S2 contact model module is free software: you can redistribute it and/or modify
    it under the terms of the GNU Lesser General Public License as published by

--- a/src/s2cm/S2ContactModel.cpp
+++ b/src/s2cm/S2ContactModel.cpp
@@ -33,7 +33,7 @@ namespace s2cm {
 
 //
 
-//+PLUMEDOC S2CM_COLVAR S2CM
+//+PLUMEDOC S2CMMOD_COLVAR S2CM
 /*
 S2 contact model CV used in \cite Palazzesi_s2_2017, based on NH order parameter from \cite Zhang_s2_2002 and methyl order parameter from \cite Ming_s2_2004. Input parameters can be found in the relevant papers.
 

--- a/user-doc/S2CMMOD.md
+++ b/user-doc/S2CMMOD.md
@@ -21,4 +21,4 @@ Currently, all features of the S2 contact model module are included in a single 
 
 \page S2CMMODColvar CVs Documentation
 
-@S2CM_COLVAR@
+@S2CMMOD_COLVAR@


### PR DESCRIPTION
##### Description

Fixes some issues with incorrect manual generation for the S2CM module. 

##### Target release

I would like my code to appear in release v2.8

##### Type of contribution

- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [x] new module contribution or edit of a module authored by you

##### Copyright


- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.


- [x] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests


- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

