### PR TITLE
corrected tmax -> imax

### DIFF
--- a/user-doc/tutorials/aa-masterclass-22-2.txt
+++ b/user-doc/tutorials/aa-masterclass-22-2.txt
@@ -360,7 +360,7 @@ The functions for image saving can be used with regular expressions. This is
 useful for making movies. A movie of free energy evolution can be simply made
 by:
 \verbatim
-tfes<-fes(myhills12, tmax=50)
+tfes<-fes(myhills12, imax=50)
 png("snap%04d.png")
 plot(tfes, zlim=c(-200,0))
 for(i in 1:199) {


### PR DESCRIPTION
Small typo in the Masterclass-2022-02

##### Description

I corrected a typo tmax -> imax in one function

##### Target release

any

##### Type of contribution

- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

