### PR TITLE
support lazy copy while retrieving atom positions

### DIFF
--- a/src/core/ActionAtomistic.cpp
+++ b/src/core/ActionAtomistic.cpp
@@ -228,7 +228,11 @@ void ActionAtomistic::retrieveAtoms() {
   const std::vector<Vector> & p(atoms.positions);
   const std::vector<double> & c(atoms.charges);
   const std::vector<double> & m(atoms.masses);
-  for(unsigned j=0; j<indexes.size(); j++) positions[j]=p[indexes[j].index()];
+  if (plumed.isLazyCopy()) {
+    atoms.lazyCopyPos(positions, indexes);
+  } else {
+    for(unsigned j=0; j<indexes.size(); j++) positions[j]=p[indexes[j].index()];
+  }
   for(unsigned j=0; j<indexes.size(); j++) charges[j]=c[indexes[j].index()];
   for(unsigned j=0; j<indexes.size(); j++) masses[j]=m[indexes[j].index()];
 }

--- a/src/core/Atoms.h
+++ b/src/core/Atoms.h
@@ -154,6 +154,8 @@ public:
   void wait();
   void updateForces();
 
+  void lazyCopyPos(std::vector<Vector>&, const std::vector<AtomNumber>&);
+
   void setRealPrecision(int);
   int  getRealPrecision()const;
 

--- a/src/core/MDAtoms.cpp
+++ b/src/core/MDAtoms.cpp
@@ -123,6 +123,8 @@ public:
   void getPositions(const std::vector<int>&index,std::vector<Vector>&positions) const override;
   void getPositions(const std::set<AtomNumber>&index,const std::vector<unsigned>&i,std::vector<Vector>&positions) const override;
   void getPositions(unsigned j,unsigned k,std::vector<Vector>&positions) const override;
+  void getPositionsLazy(const std::vector<AtomNumber>&indexes,int natoms,std::vector<Vector>&action_positions,
+	std::vector<Vector>&positions,std::vector<Vector>&forces) const override;
   void getLocalPositions(std::vector<Vector>&p) const override;
   void getMasses(const std::vector<int>&index,std::vector<double>&) const override;
   void getCharges(const std::vector<int>&index,std::vector<double>&) const override;
@@ -212,6 +214,28 @@ void MDAtomsTyped<T>::getPositions(unsigned j,unsigned k,std::vector<Vector>&pos
   }
 }
 
+template <class T>
+void MDAtomsTyped<T>::getPositionsLazy(const std::vector<AtomNumber>&indexes,int natoms,
+                                   std::vector<Vector>&action_positions,
+                                   std::vector<Vector>&positions,
+                                   std::vector<Vector>&forces)const {
+  unsigned stride;
+  const T* ppx;
+  const T* ppy;
+  const T* ppz;
+  getPointers(p,px,py,pz,natoms,ppx,ppy,ppz,stride);
+  plumed_assert(ppx && ppy && ppz);
+  for(unsigned id=0; id<indexes.size(); id++) {
+    int i = indexes[id].index();
+    if (i < natoms) {
+      positions[i][0]=ppx[stride*i]*scalep;
+      positions[i][1]=ppy[stride*i]*scalep;
+      positions[i][2]=ppz[stride*i]*scalep;
+    }
+    action_positions[id]=positions[i];
+    forces[i].zero();
+  }
+}
 
 template <class T>
 void MDAtomsTyped<T>::getLocalPositions(std::vector<Vector>&positions)const {

--- a/src/core/MDAtoms.h
+++ b/src/core/MDAtoms.h
@@ -88,6 +88,9 @@ public:
   virtual void getPositions(const std::vector<int>&index,std::vector<Vector>&p)const=0;
 /// Retrieve all atom positions from index i to index j.
   virtual void getPositions(unsigned i,unsigned j,std::vector<Vector>&p)const=0;
+/// Retrieve all atom positions lazy
+  virtual void getPositionsLazy(const std::vector<AtomNumber>&indexes,int natoms,
+                                std::vector<Vector>&action_positions,std::vector<Vector>&positions,std::vector<Vector>&forces)const=0;
 /// Retrieve all atom positions from atom indices and local indices.
   virtual void getPositions(const std::set<AtomNumber>&index,const std::vector<unsigned>&i,std::vector<Vector>&p)const=0;
 /// Retrieve selected masses.

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -149,6 +149,7 @@ static Register myregister;
 
 PlumedMain::PlumedMain():
   initialized(false),
+  lazy_copy(false),
 // automatically write on log in destructor
   stopwatch_fwd(log),
   step(0),
@@ -729,6 +730,9 @@ void PlumedMain::readInputWords(const std::vector<std::string> & words) {
   else if(words[0]=="_SET_SUFFIX") {
     plumed_assert(words.size()==2);
     setSuffix(words[1]);
+  } else if(words[0]=="_LAZY_COPY") {
+    plumed_assert(words.size()==1);
+    lazy_copy=true;
   } else {
     std::vector<std::string> interpreted(words);
     Tools::interpretLabel(interpreted);

--- a/src/core/PlumedMain.h
+++ b/src/core/PlumedMain.h
@@ -118,6 +118,8 @@ private:
   std::unique_ptr<WithCmd> grex;
 /// Flag to avoid double initialization
   bool  initialized;
+/// Flag to set lazy copy
+  bool lazy_copy;
 /// Name of MD engine
   std::string MDEngine;
 
@@ -364,6 +366,10 @@ public:
   void exit(int c=0);
 /// Load a shared library
   void load(const std::string&);
+/// Check if lazy copy
+  bool isLazyCopy()const;
+/// Disable lazy copy
+  void disableLazyCopy();
 /// Get the suffix string
   const std::string & getSuffix()const;
 /// Set the suffix string
@@ -441,6 +447,15 @@ const std::string & PlumedMain::getSuffix()const {
 inline
 void PlumedMain::setSuffix(const std::string&s) {
   suffix=s;
+}
+
+inline
+bool PlumedMain::isLazyCopy() const {
+  return lazy_copy;
+}
+
+inline void PlumedMain::disableLazyCopy() {
+  lazy_copy=false;
 }
 
 inline


### PR DESCRIPTION
##### Description

While running Gromacs with Plumed, we noticed that `Sharing data` phrase is very time consuming which took `44.639684` cycles:
```
1934 PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
1935 PLUMED:                                                    1   107.355771   107.355771   107.355771   107.355771
1936 PLUMED: 1 Prepare dependencies                        100001     0.103680     0.000001     0.000001     0.000188
1937 PLUMED: 2 Sharing data                                100001    44.639684     0.000446     0.000376     0.019799
1938 PLUMED: 3 Waiting for data                            100001     0.022178     0.000000     0.000000     0.000186
1939 PLUMED: 4 Calculating (forward loop)                  100001    45.147029     0.000451     0.000426     0.011148
```
Most of the cycles are spending on copying atom positions. 
In our simulation, there are about 120,000 atoms but only ~3200 atoms are used in plumed. Actually, we do not need to copy all atoms' positions in `Sharing data`, but leave it to be done on action calculating which will only copy requested atoms.
In our tests, this way can save a lot which reduce to `0.047627` cycle:

```
1935 PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
1936 PLUMED:                                                    1    61.439300    61.439300    61.439300    61.439300
1937 PLUMED: 1 Prepare dependencies                        100001     0.105186     0.000001     0.000001     0.000199
1938 PLUMED: 2 Sharing data                                100001     0.047627     0.000000     0.000000     0.019528
1939 PLUMED: 3 Waiting for data                            100001     0.017113     0.000000     0.000000     0.000181
1940 PLUMED: 4 Calculating (forward loop)                  100001    46.277080     0.000463     0.000442     0.011822
```
Notice, the lazy copy can only be used in single walker simulation since in multi-simulation it needs to exchange atom positions among different domains before calculating.

##### Target release

I would like my code to appear in release v2.9

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
