### PR TITLE
Made some non-necessary modules default-on rather than always on

### DIFF
--- a/src/gridtools/module.type
+++ b/src/gridtools/module.type
@@ -1,1 +1,1 @@
-always
+default-on

--- a/src/reference/module.type
+++ b/src/reference/module.type
@@ -1,1 +1,1 @@
-always
+default-on

--- a/src/vesselbase/module.type
+++ b/src/vesselbase/module.type
@@ -1,1 +1,1 @@
-always
+default-on


### PR DESCRIPTION
##### Description

I used the following script to analyze module dependences:
```
# run from plumed2/src
for type in always default-on default-off ; do
echo Type $type
for mod in $(grep "$type" */module.type  | sed "s|/.*||") ; do
used_in=$(git grep 'include *"'$mod'/' | sed "s|/.*||" | sort | uniq)
echo $mod: $used_in
done | grep -v ":$"
echo "###"
done
```

The result is the following:
```
Type always
asmjit: lepton
blas: lapack
core: adjmat analysis bias cltools colvar crystallization dimred drr eds fisst function funnel generic gridtools isdb logmfd manyrestraints mapping maze membranefusion multicolvar opes pamm piv pytorch reference s2cm sasa secondarystructure setup tools vatom ves vesselbase
gridtools: analysis dimred multicolvar
lapack: tools
lepton: core function tools ves
reference: analysis colvar dimred function mapping secondarystructure
tools: adjmat analysis bias cltools colvar core crystallization dimred drr eds fisst function funnel generic gridtools isdb mapping maze multicolvar opes pamm piv reference s2cm setup tools vatom ves vesselbase
vesselbase: adjmat analysis crystallization gridtools manyrestraints mapping multicolvar secondarystructure
###
Type default-on
analysis: dimred vesselbase
bias: analysis drr eds fisst funnel isdb logmfd maze opes ves vesselbase
cltools: drr mapping ves
colvar: funnel isdb maze membranefusion piv s2cm
function: annfunc isdb pytorch
molfile: cltools
multicolvar: adjmat analysis crystallization pamm
xdrfile: cltools generic
###
Type default-off
adjmat: pamm
###
```

In short:
- tools and core are used basically everywhere, so they should be always on
- asmjit blas lapack and lepton are, directly or indirectly, used in tools and core, so they should be always on as well
- gridtools, reference, and vesselbase can be made default-on. For comparison, also `bias` is now default-on, and is used in many other modules

I would then proceed with merging this in master.

See also https://github.com/spack/spack/pull/29743#issuecomment-1169326528


##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __master__
