### PR TITLE
Fix bug in Environment Similarity - check for pdb files before read 

### DIFF
--- a/src/crystallization/EnvironmentSimilarity.cpp
+++ b/src/crystallization/EnvironmentSimilarity.cpp
@@ -415,7 +415,9 @@ void EnvironmentSimilarity::parseReferenceEnvironments( std::vector<std::vector<
     if (!reffile.empty()) {
       // Case with one reference environment
       environments.resize(1);
-      PDB pdb; pdb.read(reffile,plumed.getAtoms().usingNaturalUnits(),0.1/plumed.getAtoms().getUnits().getLength());
+      PDB pdb;
+      if( !pdb.read(reffile,plumed.getAtoms().usingNaturalUnits(),0.1/plumed.getAtoms().getUnits().getLength()) )
+        error("missing input file " + reffile );
       unsigned natoms=pdb.getPositions().size(); environments[0].resize( natoms );
       for(unsigned i=0; i<natoms; ++i) environments[0][i]=pdb.getPositions()[i];
       max_dist=maxDistance(environments[0]);
@@ -425,7 +427,9 @@ void EnvironmentSimilarity::parseReferenceEnvironments( std::vector<std::vector<
       max_dist=0;
       for(unsigned int i=1;; i++) {
         if(!parseNumbered("REFERENCE_",i,reffile) ) {break;}
-        PDB pdb; pdb.read(reffile,plumed.getAtoms().usingNaturalUnits(),0.1/plumed.getAtoms().getUnits().getLength());
+        PDB pdb;
+        if( !pdb.read(reffile,plumed.getAtoms().usingNaturalUnits(),0.1/plumed.getAtoms().getUnits().getLength()) )
+          error("missing input file " + reffile );
         unsigned natoms=pdb.getPositions().size();   std::vector<Vector> environment; environment.resize( natoms );
         for(unsigned i=0; i<natoms; ++i) environment[i]=pdb.getPositions()[i];
         environments.push_back(environment);


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

Existence of PDB files for reference environments was not checked before reading them. Thus, absence of reference environments would not raise an error but rather give a wrong result. This PR checks for PDB files before reading them and raises an error if they are not found.

In the master branch this bug is fixed by #832 .

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release v2.8

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [x] changes to a module not authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
