### PR TITLE
Small Correction in switching function documentation to 2.8

### DIFF
--- a/src/tools/SwitchingFunction.cpp
+++ b/src/tools/SwitchingFunction.cpp
@@ -111,9 +111,9 @@ s(r) = 1 - \tanh\left( \frac{ r - d_0 }{ r_0 } \right)
 </tr> <tr>
 <td> COSINUS </td> <td>
 \f$s(r) =\left\{\begin{array}{ll}
-   1                                                           & \text{if } r \leq d_0 \\
-   0.5 \left( \cos ( \frac{ r - d_0 }{ r_0 } \pi ) + 1 \right) & \text{if } d_0 < r\leq d_0 + r_0 \\
-   0                                                           & \text{if } r < d_0 + r_0
+   1                                                           & \mathrm{if } r \leq d_0 \\
+   0.5 \left( \cos ( \frac{ r - d_0 }{ r_0 } \pi ) + 1 \right) & \mathrm{if } d_0 < r\leq d_0 + r_0 \\
+   0                                                           & \mathrm{if } r < d_0 + r_0
   \end{array}\right.
 \f$
 </td> <td>

--- a/src/tools/SwitchingFunction.cpp
+++ b/src/tools/SwitchingFunction.cpp
@@ -110,11 +110,11 @@ s(r) = 1 - \tanh\left( \frac{ r - d_0 }{ r_0 } \right)
 </td> <td> </td>
 </tr> <tr>
 <td> COSINUS </td> <td>
-\f$
-s(r) &= 1  & if r<=d0
-s(r) &= 0.5 \left( \cos ( \frac{ r - d_0 }{ r_0 } * PI ) + 1 \right) & if d0<r<=d0+r0
-s(r) &= 0  & if r> d0+r0
-\f$
+\f{eqnarray*}{
+  s(r) &= 1  & if r<=d0 \\
+  s(r) &= 0.5 \left( \cos ( \frac{ r - d_0 }{ r_0 } * PI ) + 1 \right) & if d0<r<=d0+r0 \\
+  s(r) &= 0  & if r> d0+r0
+\f}
 </td> <td>
 {COSINUS R_0=\f$r_0\f$ D_0=\f$d_0\f$}
 </td> <td> </td>

--- a/src/tools/SwitchingFunction.cpp
+++ b/src/tools/SwitchingFunction.cpp
@@ -36,7 +36,7 @@ Functions that measure whether values are less than a certain quantity.
 
 Switching functions \f$s(r)\f$ take a minimum of one input parameter \f$r_0\f$.
 For \f$r \le d_0 \quad s(r)=1.0\f$ while for \f$r > d_0\f$ the function decays smoothly to 0.
-The various switching functions available in plumed differ in terms of how this decay is performed.
+The various switching functions available in PLUMED differ in terms of how this decay is performed.
 
 Where there is an accepted convention in the literature (e.g. \ref COORDINATION) on the form of the
 switching function we use the convention as the default.  However, the flexibility to use different
@@ -47,7 +47,7 @@ takes an input with the following form:
 KEYWORD={TYPE <list of parameters>}
 \endverbatim
 
-The following table contains a list of the various switching functions that are available in plumed 2
+The following table contains a list of the various switching functions that are available in PLUMED 2
 together with an example input.
 
 <table align=center frame=void width=95%% cellpadding=5%%>
@@ -110,11 +110,12 @@ s(r) = 1 - \tanh\left( \frac{ r - d_0 }{ r_0 } \right)
 </td> <td> </td>
 </tr> <tr>
 <td> COSINUS </td> <td>
-\f{eqnarray*}{
-  s(r) &= 1  & if r<=d0 \\
-  s(r) &= 0.5 \left( \cos ( \frac{ r - d_0 }{ r_0 } * PI ) + 1 \right) & if d0<r<=d0+r0 \\
-  s(r) &= 0  & if r> d0+r0
-\f}
+\f$s(r) =\left\{\begin{array}{ll}
+   1                                                           & \text{if } r \leq d_0 \\
+   0.5 \left( \cos ( \frac{ r - d_0 }{ r_0 } \pi ) + 1 \right) & \text{if } d_0 < r\leq d_0 + r_0 \\
+   0                                                           & \text{if } r < d_0 + r_0
+  \end{array}\right.
+\f$
 </td> <td>
 {COSINUS R_0=\f$r_0\f$ D_0=\f$d_0\f$}
 </td> <td> </td>

--- a/src/tools/SwitchingFunction.h
+++ b/src/tools/SwitchingFunction.h
@@ -32,7 +32,7 @@ class Log;
 class Keywords;
 
 /// \ingroup TOOLBOX
-/// Small class to compure switching functions.
+/// Small class to compute switching functions.
 /// Switching functions are created using set() and
 /// then can be used with function calculate() or calculateSqr().
 /// Since this is typically computed on a distance vector,

--- a/src/ves/TD_Multicanonical.cpp
+++ b/src/ves/TD_Multicanonical.cpp
@@ -59,7 +59,12 @@ The advantage with respect to Wang-Landau is that instead of sampling the potent
 The algorithm works as follows.
 The target distribution for the potential energy is chosen to be:
 
-MISSING EQUATION TO BE FIXED
+\f[
+p(E)= \left\{\begin{array}{ll}
+         \frac{1}{E_2-E_1} & \mathrm{if} \quad E_1<E<E_2 \\
+         0 & \mathrm{otherwise}
+      \end{array}\right.
+\f]
 
 where the energy limits \f$E_1\f$ and \f$E_2\f$ are yet to be determined.
 Clearly the interval \f$E_1–E_2\f$ chosen is related to the interval of temperatures \f$T_1-T_2\f$.

--- a/src/ves/TD_Uniform.cpp
+++ b/src/ves/TD_Uniform.cpp
@@ -36,7 +36,14 @@ Using this keyword you can define a uniform target distribution which is a
 product of one-dimensional distributions \f$p_{k}(s_{k})\f$ that are uniform
 over a given interval \f$[a_{k},b_{k}]\f$
 
-MISSING EQUATION TO BE FIXED
+\f[
+p_{k}(s_{k}) =
+\left \{\begin{array}{ll}
+\frac{1}{(b_{k}-a_{k})} & \mathrm{if} \ a_{k} \leq s_{k} \leq b_{k} \\
+&\\
+0 & \mathrm{otherwise}
+\end{array}\right .
+\f]
 
 The overall distribution is then given as
 \f[

--- a/src/ves/TD_Uniform.cpp
+++ b/src/ves/TD_Uniform.cpp
@@ -49,12 +49,12 @@ The overall distribution is then given as
 \f[
 p(\mathbf{s}) =
 \prod^{d}_{k} p_{k}(s_{k}) =
-\begin{cases}
+\left\{\begin{array}{ll}
 \prod^{d}_{k} \frac{1}{(b_{k}-a_{k})}
 & \mathrm{if} \ a_{k} \leq s_{k} \leq b_{k} \ \mathrm{for\ all}\ k \\
 \\
 0 & \mathrm{otherwise}
-\end{cases}
+\end{array}\right.
 \f]
 The distribution is thus uniform inside a rectangular for two arguments
 and a cube for a three arguments.

--- a/user-doc/tutorials/others/ves-lugano2017-02-ves1.txt
+++ b/user-doc/tutorials/others/ves-lugano2017-02-ves1.txt
@@ -273,7 +273,14 @@ of introducing a barrier as done in the example above, in this case we will
 use a uniform target distribution in the interval [0.23:0.6] nm and decaying to
 zero in the interval [0.6:0.8] nm. The expression is:
 
-MISSING EQUATION TO BE FIXED
+\f[
+p(s)=
+        \left\{\begin{array}{ll}
+                \frac{1}{C} \: &  \mathrm{if} \: s<s_0 \\
+                \frac{1}{C} e^{-\frac{(s-s_0)^2}{2\sigma^2}} \: &
+\mathrm{if} \: s>s_0\\
+        \end{array}\right .
+\f]
 
 where \f$ s_0=0.6\f$ nm and \f$ \sigma=0.05\f$.
 To define this \f$ p(s) \f$ in Plumed the input is:

--- a/user-doc/tutorials/others/ves-lugano2017-03-ves2.txt
+++ b/user-doc/tutorials/others/ves-lugano2017-03-ves2.txt
@@ -76,7 +76,14 @@ p(s)=\frac{p_{\mathrm{WT}}(s) \, p_{\mathrm{barrier}}(s)}
 \f]
 where \f$ p_{\mathrm{WT}}(s) \f$ is the well-tempered target distribution and:
 
-MISSING EQUATION TO BE FIXED
+\f[
+p_{\mathrm{barrier}}(s)=
+        \left\{\begin{array}{ll}
+                \frac{1}{C} \: &  \mathrm{if} \: s<s_0 \\
+                \frac{1}{C} e^{-\frac{(s-s_0)^2}{2\sigma^2}} \: &
+\mathrm{if} \: s>s_0\\
+        \end{array}\right.
+\f]
 
 with \f$ C \f$ a normalization factor.
 The files needed for this exercise are in the directory Example1.


### PR DESCRIPTION
##### Description

This a exactly like PR #927, but rebased on the v2.8 branch
As stated there, this PE should also resolve #643 : now TexLive2021 compiles the manual

The formula for the COSINUS switching function was not visualized correctly in the documentation, I also correct a small typo in the developer documentation

##### Target release

I would like my code to appear in release v2.8

##### Type of contribution

- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
