### PR TITLE
New warnings for METAD  adn WALKERS_MPI

### DIFF
--- a/src/bias/MetaD.cpp
+++ b/src/bias/MetaD.cpp
@@ -877,7 +877,13 @@ MetaD::MetaD(const ActionOptions& ao):
 
   // MPI version
   parseFlag("WALKERS_MPI",walkers_mpi_);
-
+  
+  ///TODO: set up a test that simulates an external program that trigger this error when MPI is not initialized
+  //If this Action is not compiled with MPI the user is informed and we exit gracefully
+  if(walkers_mpi_)
+    plumed_assert(Communicator::initialized()) << "Invalid walkers configuration: WALKERS_MPI"
+  " flag requires MPI compilation and the correct initialization of the communicator.";
+  
   // Flying Gaussian
   parseFlag("FLYING_GAUSSIAN", flying_);
 

--- a/src/bias/MetaD.cpp
+++ b/src/bias/MetaD.cpp
@@ -878,11 +878,11 @@ MetaD::MetaD(const ActionOptions& ao):
   // MPI version
   parseFlag("WALKERS_MPI",walkers_mpi_);
   
-  ///TODO: set up a test that simulates an external program that trigger this error when MPI is not initialized
   //If this Action is not compiled with MPI the user is informed and we exit gracefully
-  if(walkers_mpi_)
-    plumed_assert(Communicator::initialized()) << "Invalid walkers configuration: WALKERS_MPI"
-  " flag requires MPI compilation and the correct initialization of the communicator.";
+  if(walkers_mpi_){
+    plumed_assert(Communicator::PlumedHasMPI) << "Invalid walkers configuration: WALKERS_MPI flag requires MPI compilation";
+    plumed_assert(Communicator::initialized()) << "Invalid walkers configuration: WALKERS_MPI needs the communicator correctly initialized.";
+  }
   
   // Flying Gaussian
   parseFlag("FLYING_GAUSSIAN", flying_);

--- a/src/tools/Communicator.cpp
+++ b/src/tools/Communicator.cpp
@@ -28,6 +28,13 @@
 
 namespace PLMD {
 
+const bool Communicator::PlumedHasMPI=
+#ifdef __PLUMED_HAS_MPI
+    true;
+#else
+     false;
+#endif
+
 Communicator::Communicator()
 #ifdef __PLUMED_HAS_MPI
   : communicator(MPI_COMM_SELF)

--- a/src/tools/Communicator.h
+++ b/src/tools/Communicator.h
@@ -121,6 +121,8 @@ class Communicator {
     }
   };
 public:
+  ///Runtime acces to the __PLUMED_HAS_MPI definition
+  static const bool PlumedHasMPI;
 /// Wrapper class for MPI_Status
   class Status {
     int Get_count(MPI_Datatype)const;

--- a/unittest/.gitignore
+++ b/unittest/.gitignore
@@ -1,0 +1,4 @@
+*
+!Makefile
+!*.cpp
+!.gitignore

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -1,0 +1,18 @@
+
+tests := $(patsubst %.cpp,%,$(wildcard *.cpp))
+#needs plumed installed with the environmnet variables set up to work (eg with a module)
+.PHONY: all $(run)
+
+all: $(tests)
+	@for test in $^ ;do \
+	printf  "%-20s: " "$${test}"; \
+	if ! ./$$test > /dev/null; then echo "fail"; \
+	else echo "success"; fi ;\
+	done
+
+%:%.cpp
+	$(CXX) -lplumed -lplumedKernel $< -o $@
+
+clean:
+	rm $(tests)
+	rm *.log

--- a/unittest/testWALKERS_MPI.cpp
+++ b/unittest/testWALKERS_MPI.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+
+#include "plumed/wrapper/Plumed.h"
+#include "plumed/tools/Communicator.h"
+
+
+int main(int, char**){
+    //GIVEN an installation without MPI
+    if (PLMD::Communicator::PlumedHasMPI) {;
+        return 0; //no problem: passing
+    }
+    //AND GIVEN an initialized Plumed interface 
+    PLMD::Plumed plumed;
+    //intitalize the interpreter
+    unsigned int natoms=10;
+
+    std::vector<double> positions(3*natoms,0.0);
+    for(unsigned i=0;i<3*natoms;i++) positions[i]=i;
+    std::vector<double> masses(natoms,1.0);
+    std::vector<double> forces(3*natoms,0.0);
+    std::vector<double> box(9,0.0);
+    std::vector<double> virial(9,0.0);
+    plumed.cmd("setNatoms",&natoms);
+    plumed.cmd("setLogFile","test.log");
+    plumed.cmd("init");
+    plumed.cmd("readInputLine","d: DISTANCE ATOMS=1,2");
+    plumed.cmd("readInputLine","d1: DISTANCE ATOMS={1 2}");
+    //WHEN the user give an input file with WALKERS_MPI keyword in it
+    
+    const std::string mokedLine=
+    "METAD ARG=d,d1 SIGMA=0.1,0.2 HEIGHT=0.1 PACE=2 RESTART=YES WALKERS_MPI";
+    //THEN plumed should gracefully exit with a clear error message
+    try{
+        plumed.cmd("readInputLine",mokedLine.c_str());
+    } catch(PLMD::Plumed::ExceptionError &e){//correct throw, we are happy
+        std::string exceptionText{e.what()};
+        if (exceptionText.find("requires MPI compilation") != std::string::npos) {
+            //throws with the wanted message and we are happy
+           return 0;
+        }
+        std::cout << "Exception thrown, wrong message: "
+                  << e.what() << '\n';
+        return 1;
+    }
+    std::cout << "Exception not thrown\n";
+    return 1;
+}

--- a/unittest/testWALKERS_MPI.cpp
+++ b/unittest/testWALKERS_MPI.cpp
@@ -3,6 +3,9 @@
 #include "plumed/wrapper/Plumed.h"
 #include "plumed/tools/Communicator.h"
 
+//When the user aks for a WALKERS_MPI in the METAD action, 
+//if MPI is not installed then the user must be informed
+//if MPI is installed then the comunications must be already set up
 
 int main(int, char**){
     //GIVEN an initialized Plumed interface 
@@ -21,19 +24,19 @@ int main(int, char**){
     plumed.cmd("init");
     plumed.cmd("readInputLine","d: DISTANCE ATOMS=1,2");
     plumed.cmd("readInputLine","d1: DISTANCE ATOMS={1 2}");
-
-    //WHEN the user give ask for a METAD with WALKERS_MPI keyword in it
-    
+   
     const std::string mokedLine=
     "METAD ARG=d,d1 SIGMA=0.1,0.2 HEIGHT=0.1 PACE=2 RESTART=YES WALKERS_MPI";
     
-    //THEN plumed should gracefully exit with a clear error message    
+    //WHEN PLUMED is not compiled with MPI or the MPI routines are not initialized
     std::string expectedMessage="WALKERS_MPI flag requires MPI compilation";
     if (PLMD::Communicator::PlumedHasMPI){
         expectedMessage="WALKERS_MPI needs the communicator correctly initialized";
     }
     try{
+        //WHEN the user give ask for a METAD with WALKERS_MPI keyword in it
         plumed.cmd("readInputLine",mokedLine.c_str());
+        //THEN plumed should gracefully exit with a clear error message 
     } catch(PLMD::Plumed::ExceptionError &e){//correct throw, we are happy
         std::string exceptionText{e.what()};
         


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

<!-- describe here your pull request -->
This should resolve #926: 

METAD now throws if the user ask for WALKERS_MPI without a MPI installation and also if the MPI routines are not set up.

I wanted the changes testable so:

- I added a static variable to the Communicator to have the user access to the information "plumed is compiled with MPI" at runtime.
- I created a small non standard reg test to test the error thrown without using external tools and that tests exactly the needed messages
- I added the thrown exceptions with the messages set up to pass the new test

This is a draft because I wanted to show the solution that I have found, and I have not added the new test to the github workflow

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
