### PR TITLE
V2.9 - add to OPES same MPI-related error messages of METAD

### DIFF
--- a/src/opes/ECVmultiThermalBaric.cpp
+++ b/src/opes/ECVmultiThermalBaric.cpp
@@ -327,7 +327,7 @@ ECVmultiThermalBaric::ECVmultiThermalBaric(const ActionOptions&ao)
   log.printf("   and a pressure range from PRESSURE_MIN=%g to PRESSURE_MAX=%g\n",pres_min,pres_max);
   if(pres_min==pres_max)
     log.printf(" +++ WARNING +++ if you only need a multithermal simulation it is more efficient to set it up with ECV_MULTITHERMAL\n");
-  if(geom_spacing_)
+  if(!geom_spacing_)
     log.printf(" -- NO_GEOM_SPACING: inverse temperatures will be linearly spaced\n");
   if(coeff_!=0)
     log.printf(" -- CUT_CORNER: ignoring some high temperature and low pressure values\n");

--- a/src/opes/OPESexpanded.cpp
+++ b/src/opes/OPESexpanded.cpp
@@ -251,6 +251,10 @@ OPESexpanded::OPESexpanded(const ActionOptions&ao)
   parseFlag("WALKERS_MPI",walkers_mpi);
   if(walkers_mpi)
   {
+    //If this Action is not compiled with MPI the user is informed and we exit gracefully
+    plumed_massert(Communicator::plumedHasMPI(),"Invalid walkers configuration: WALKERS_MPI flag requires MPI compilation");
+    plumed_massert(Communicator::initialized(),"Invalid walkers configuration: WALKERS_MPI needs the communicator correctly initialized.");
+
     if(comm.Get_rank()==0) //multi_sim_comm works on first rank only
     {
       NumWalkers_=multi_sim_comm.Get_size();

--- a/src/opes/OPESmetad.cpp
+++ b/src/opes/OPESmetad.cpp
@@ -558,6 +558,10 @@ OPESmetad<mode>::OPESmetad(const ActionOptions& ao)
   parseFlag("WALKERS_MPI",walkers_mpi);
   if(walkers_mpi)
   {
+    //If this Action is not compiled with MPI the user is informed and we exit gracefully
+    plumed_massert(Communicator::plumedHasMPI(),"Invalid walkers configuration: WALKERS_MPI flag requires MPI compilation");
+    plumed_massert(Communicator::initialized(),"Invalid walkers configuration: WALKERS_MPI needs the communicator correctly initialized.");
+
     if(comm.Get_rank()==0)//multi_sim_comm works on first rank only
     {
       NumWalkers_=multi_sim_comm.Get_size();

--- a/src/opes/OPESmetad.cpp
+++ b/src/opes/OPESmetad.cpp
@@ -306,7 +306,11 @@ void OPESmetad<mode>::registerKeywords(Keywords& keys)
   keys.use("ARG");
   keys.add("compulsory","TEMP","-1","temperature. If not set, it is taken from MD engine, but not all MD codes provide it");
   keys.add("compulsory","PACE","the frequency for kernel deposition");
-  keys.add("compulsory","SIGMA","ADAPTIVE","the initial widths of the kernels. If not set, adaptive sigma will be used with the given ADAPTIVE_SIGMA_STRIDE");
+  std::string info_sigma("the initial widths of the kernels");
+  if(mode::explore)
+    info_sigma+=", divided by \\f$\\sqrt{\\gamma}\\f$";
+  info_sigma+=". If not set, an adaptive sigma will be used with the given ADAPTIVE_SIGMA_STRIDE";
+  keys.add("compulsory","SIGMA","ADAPTIVE",info_sigma);
   keys.add("compulsory","BARRIER","the free energy barrier to be overcome. It is used to set BIASFACTOR, EPSILON, and KERNEL_CUTOFF to reasonable values");
   keys.add("compulsory","COMPRESSION_THRESHOLD","1","merge kernels if closer than this threshold, in units of sigma");
 //extra options


### PR DESCRIPTION
same as #938 but targeting v2.9