### PR TITLE
It looks like this test does not really use MPI

### DIFF
--- a/regtest/multicolvar/rt-link/config
+++ b/regtest/multicolvar/rt-link/config
@@ -1,2 +1,1 @@
-mpiprocs=2
 type=make

--- a/regtest/multicolvar/rt-link/main.cpp
+++ b/regtest/multicolvar/rt-link/main.cpp
@@ -1,4 +1,3 @@
-#include "mpi.h"
 #include "plumed/tools/Communicator.h"
 #include "plumed/tools/Tools.h"
 #include "plumed/tools/Vector.h"


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

@gtribello it looks like this test is not using MPI. Is this change ok?

To use MPI in a `make`-type regtest, you need to explicitly call `MPI_Init` and `MPI_Finalize` (see e.g. [here](https://github.com/plumed/plumed2/blob/b20517e8f0d1d7ecf1650d0b39c11e6f8a43a363/regtest/basic/rt-make-2/main.cpp#L143-L153)).

Actually, these two tests are those causing [this problem on Rockylinux](https://github.com/plumed/plumed2/pull/933#issuecomment-1556302511). With this change I guess only the `rt-make-2` test will fail. I am still investigating on the reason.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.8__
