### PR TITLE
fixed a typo?

### DIFF
--- a/src/gridtools/FindContourSurface.cpp
+++ b/src/gridtools/FindContourSurface.cpp
@@ -212,11 +212,11 @@ void FindContourSurface::compute( const unsigned& current, MultiValue& myvals ) 
   std::vector<unsigned> neighbours; unsigned num_neighbours; unsigned nfound=0; double minp=0;
   std::vector<unsigned> bins_n( ingrid->getNbin() ); unsigned shiftn=current;
   std::vector<unsigned> ind( ingrid->getDimension() ); std::vector<double> point( ingrid->getDimension() );
-#ifndef DNDEBUG
+#ifndef NDEBUG
   std::vector<unsigned> oind( mygrid->getDimension() ); mygrid->getIndices( current, oind );
 #endif
   for(unsigned i=0; i<bins_n[dir_n]; ++i) {
-#ifndef DNDEBUG
+#ifndef NDEBUG
     std::vector<unsigned> base_ind( ingrid->getDimension() ); ingrid->getIndices( shiftn, base_ind );
     for(unsigned j=0; j<gdirs.size(); ++j) plumed_dbg_assert( base_ind[gdirs[j]]==oind[j] );
 #endif


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

I found two `#ifndef DNDEBUG` in gridtools: I think this is a typo for `#ifndef NDEBUG`, since if I do a grep searching for `DNDEBUG` I only find results with the command line definition for `NDEBUG` (`-DNDEBUG` and not `-DDNDEBUG`).

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
This is a really small bugfix I think it should be compatible with v2.8 and subsequents

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [X] changes to a module not authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
