### PR TITLE
small changes in the openMP settings

### DIFF
--- a/regtest/.gitignore
+++ b/regtest/.gitignore
@@ -33,6 +33,7 @@
 !/s2cm
 !/pytorch
 !/membranefusion
+!/unittest
 # These files we just want to ignore completely
 tmp
 report.txt

--- a/regtest/unittest/Makefile
+++ b/regtest/unittest/Makefile
@@ -1,0 +1,2 @@
+include ../scripts/module.make
+

--- a/regtest/unittest/rt-getGoodNumThreads/Makefile
+++ b/regtest/unittest/rt-getGoodNumThreads/Makefile
@@ -1,0 +1,1 @@
+include ../../scripts/test.make

--- a/regtest/unittest/rt-getGoodNumThreads/config
+++ b/regtest/unittest/rt-getGoodNumThreads/config
@@ -1,0 +1,4 @@
+type=make
+
+export PLUMED_NUM_THREADS=4
+export PLUMED_CACHELINE_SIZE=128

--- a/regtest/unittest/rt-getGoodNumThreads/output.reference
+++ b/regtest/unittest/rt-getGoodNumThreads/output.reference
@@ -1,0 +1,11 @@
+Plumed reads "PLUMED_CACHELINE_SIZE" correctly: true
+Plumed reads "PLUMED_NUM_THREADS": correctly: true
+Checking getGoodNumThreads
+std::vector version:
+getGoodNumThreads with a small vector returns 1: true
+getGoodNumThreads with returns "PLUMED_NUM_THREADS": true
+Pointer version:
+getGoodNumThreads(pointer) with a small vector returns 1: true
+getGoodNumThreads(pointer) with returns "PLUMED_NUM_THREADS": true
+After setting the number of threads to 3:
+getNumThreads reaturns 3: true

--- a/regtest/unittest/rt-getGoodNumThreads/testNumThreads.cpp
+++ b/regtest/unittest/rt-getGoodNumThreads/testNumThreads.cpp
@@ -1,0 +1,53 @@
+#include <cstdlib>
+#include <fstream>
+#include <vector>
+
+#include "plumed/tools/OpenMP.h"
+#include "plumed/tools/Tools.h"
+
+using namespace PLMD;
+
+int main(int, char **) {
+  unsigned cachelineSize;
+  Tools::convert(std::getenv("PLUMED_CACHELINE_SIZE"), cachelineSize);
+
+  unsigned requestedThreads;
+  Tools::convert(std::getenv("PLUMED_NUM_THREADS"), requestedThreads);
+
+  std::ofstream out("output");
+  out << "Plumed reads \"PLUMED_CACHELINE_SIZE\" correctly: "
+      << (OpenMP::getCachelineSize() == cachelineSize ? "true" : "false")
+      << "\n";
+  out << "Plumed reads \"PLUMED_NUM_THREADS\": correctly: "
+      << (OpenMP::getNumThreads() == requestedThreads ? "true" : "false")
+      << "\n";
+  // constexpr auto size_ofDouble= sizeof(double);
+  // out << size_ofDouble <<'\n';
+  out << "Checking getGoodNumThreads\n";
+  out << "std::vector version:\n";
+  std::vector<double> smallv(1);
+  out << "getGoodNumThreads with a small vector returns 1: "
+      << (OpenMP::getGoodNumThreads(smallv) == 1 ? "true" : "false") << '\n';
+  std::vector<double> bigv(cachelineSize);
+  out << "getGoodNumThreads with returns \"PLUMED_NUM_THREADS\": "
+      << (OpenMP::getGoodNumThreads(bigv) == requestedThreads ? "true"
+                                                              : "false")
+      << '\n';
+  out << "Pointer version:\n";
+  // getGoodNumThreads does not access to the values pointed, so passing a
+  // nullptr should not give errors
+  double *ptd = nullptr;
+
+  out << "getGoodNumThreads(pointer) with a small vector returns 1: "
+      << (OpenMP::getGoodNumThreads(ptd, 1) == 1 ? "true" : "false") << '\n';
+  out << "getGoodNumThreads(pointer) with returns \"PLUMED_NUM_THREADS\": "
+      << (OpenMP::getGoodNumThreads(ptd, cachelineSize) == requestedThreads
+              ? "true"
+              : "false")
+      << '\n';
+  out << "After setting the number of threads to 3:\n";
+  OpenMP::setNumThreads(3);
+  out << "getNumThreads reaturns 3: "
+      << (OpenMP::getNumThreads() == 3 ? "true" : "false")
+      << "\n";
+}

--- a/src/tools/OpenMP.cpp
+++ b/src/tools/OpenMP.cpp
@@ -42,6 +42,8 @@ struct OpenMPVars {
   }
 private:
   OpenMPVars()=default;
+  OpenMPVars(OpenMPVars&)=delete;
+  OpenMPVars& operator=(OpenMPVars&&)=delete;
 };
 
 void setNumThreads(const unsigned nt) {

--- a/src/tools/OpenMP.cpp
+++ b/src/tools/OpenMP.cpp
@@ -29,40 +29,46 @@
 
 namespace PLMD {
 
-
+namespace OpenMP {
+///singleton struct to treat the openMP setting as a global variables, but with a layer of encapsulation
 struct OpenMPVars {
   unsigned cacheline_size=512;
   bool cache_set=false;
   unsigned num_threads=1;
   bool nt_env_set=false;
+  static OpenMPVars & get() {
+    static OpenMPVars vars;
+    return vars;
+  }
+private:
+  OpenMPVars()=default;
 };
 
-static OpenMPVars & getOpenMPVars() {
-  static OpenMPVars vars;
-  return vars;
+void setNumThreads(const unsigned nt) {
+  OpenMPVars::get().num_threads=nt;
 }
 
-void OpenMP::setNumThreads(const unsigned nt) {
-  getOpenMPVars().num_threads=nt;
-}
-
-unsigned OpenMP::getCachelineSize() {
-  if(!getOpenMPVars().cache_set) {
-    if(std::getenv("PLUMED_CACHELINE_SIZE")) Tools::convert(std::getenv("PLUMED_CACHELINE_SIZE"),getOpenMPVars().cacheline_size);
-    getOpenMPVars().cache_set = true;
+unsigned getCachelineSize() {
+  if(!OpenMPVars::get().cache_set) {
+    if(std::getenv("PLUMED_CACHELINE_SIZE")) {
+      Tools::convert(std::getenv("PLUMED_CACHELINE_SIZE"),OpenMPVars::get().cacheline_size);
+    }
+    OpenMPVars::get().cache_set = true;
   }
-  return getOpenMPVars().cacheline_size;
+  return OpenMPVars::get().cacheline_size;
 }
 
-unsigned OpenMP::getNumThreads() {
-  if(!getOpenMPVars().nt_env_set) {
-    if(std::getenv("PLUMED_NUM_THREADS")) Tools::convert(std::getenv("PLUMED_NUM_THREADS"),getOpenMPVars().num_threads);
-    getOpenMPVars().nt_env_set = true;
+unsigned getNumThreads() {
+  if(!OpenMPVars::get().nt_env_set) {
+    if(std::getenv("PLUMED_NUM_THREADS")) {
+      Tools::convert(std::getenv("PLUMED_NUM_THREADS"),OpenMPVars::get().num_threads);
+    }
+    OpenMPVars::get().nt_env_set = true;
   }
-  return getOpenMPVars().num_threads;
+  return OpenMPVars::get().num_threads;
 }
 
-unsigned OpenMP::getThreadNum() {
+unsigned getThreadNum() {
 #if defined(_OPENMP)
   return omp_get_thread_num();
 #else
@@ -70,9 +76,5 @@ unsigned OpenMP::getThreadNum() {
 #endif
 }
 
-
-
-}
-
-
-
+}//namespace OpenMP
+}//namespace PLMD

--- a/src/tools/OpenMP.h
+++ b/src/tools/OpenMP.h
@@ -57,7 +57,7 @@ unsigned getGoodNumThreads(const T* /*getTheType*/,unsigned n) {
   return m;
 }
 
-/// Get a reasonable number of threads so as to access to vector v;
+/// Get a reasonable number of threads so as to access to vector v
 template<typename T>
 unsigned getGoodNumThreads(const std::vector<T> & v) {
   if(v.size()==0) return 1;

--- a/src/tools/OpenMP.h
+++ b/src/tools/OpenMP.h
@@ -52,6 +52,8 @@ unsigned getGoodNumThreads(const T* /*getTheType*/,unsigned n) {
   if(m>=numThreads) {
     m=numThreads;
   } else {
+    //it is better to use either all the active threads or only one
+    //this solves a performance problem as explained in issue #415
     m=1;
   }
   return m;

--- a/src/tools/OpenMP.h
+++ b/src/tools/OpenMP.h
@@ -42,14 +42,18 @@ unsigned getCachelineSize();
 
 /// Get a reasonable number of threads so as to access to an array of size s located at x
 template<typename T>
-unsigned getGoodNumThreads(const T* /*x*/,unsigned n) {
-  //this is more or less the equivalent of writing "unsigned getGoodNumThreads<T>(unsigned n)"
+unsigned getGoodNumThreads(const T* /*getTheType*/,unsigned n) {
+  // this is more or less the equivalent of writing "unsigned getGoodNumThreads<T>(unsigned n)"
+  
   // a factor two is necessary since there is no guarantee that x is aligned
   // to cache line boundary
   unsigned m=n*sizeof(T)/(2*getCachelineSize());
   unsigned numThreads=getNumThreads();
-  if(m>=numThreads) m=numThreads;
-  else m=1;
+  if(m>=numThreads) {
+    m=numThreads;
+  } else {
+    m=1;
+  }
   return m;
 }
 

--- a/src/tools/OpenMP.h
+++ b/src/tools/OpenMP.h
@@ -44,7 +44,7 @@ unsigned getCachelineSize();
 template<typename T>
 unsigned getGoodNumThreads(const T* /*getTheType*/,unsigned n) {
   // this is more or less the equivalent of writing "unsigned getGoodNumThreads<T>(unsigned n)"
-  
+
   // a factor two is necessary since there is no guarantee that x is aligned
   // to cache line boundary
   unsigned m=n*sizeof(T)/(2*getCachelineSize());

--- a/src/tools/OpenMP.h
+++ b/src/tools/OpenMP.h
@@ -26,38 +26,26 @@
 
 namespace PLMD {
 
-class OpenMP {
-
-public:
+namespace OpenMP {
 
 /// Set number of threads that can be used by openMP
-  static void setNumThreads(const unsigned nt);
+void setNumThreads(const unsigned nt);
 
 /// Get number of threads that can be used by openMP
-  static unsigned getNumThreads();
+unsigned getNumThreads();
 
 /// Returns a unique thread identification number within the current team
-  static unsigned getThreadNum();
+unsigned getThreadNum();
 
 /// get cacheline size
-  static unsigned getCachelineSize();
+unsigned getCachelineSize();
 
 /// Get a reasonable number of threads so as to access to an array of size s located at x
-  template<typename T>
-  static unsigned getGoodNumThreads(const T*x,unsigned s);
-
-/// Get a reasonable number of threads so as to access to vector v;
-  template<typename T>
-  static unsigned getGoodNumThreads(const std::vector<T> & v);
-
-};
-
 template<typename T>
-unsigned OpenMP::getGoodNumThreads(const T*x,unsigned n) {
-  unsigned long long p=(unsigned long long) x;
-  (void) p; // this is not to have warnings. notice that the pointer location is not used actually.
-// a factor two is necessary since there is no guarantee that x is aligned
-// to cache line boundary
+unsigned getGoodNumThreads(const T* /*x*/,unsigned n) {
+  //this is more or less the equivalent of writing "unsigned getGoodNumThreads<T>(unsigned n)"
+  // a factor two is necessary since there is no guarantee that x is aligned
+  // to cache line boundary
   unsigned m=n*sizeof(T)/(2*getCachelineSize());
   unsigned numThreads=getNumThreads();
   if(m>=numThreads) m=numThreads;
@@ -65,14 +53,14 @@ unsigned OpenMP::getGoodNumThreads(const T*x,unsigned n) {
   return m;
 }
 
-
+/// Get a reasonable number of threads so as to access to vector v;
 template<typename T>
-unsigned OpenMP::getGoodNumThreads(const std::vector<T> & v) {
+unsigned getGoodNumThreads(const std::vector<T> & v) {
   if(v.size()==0) return 1;
   else return getGoodNumThreads(&v[0],v.size());
 }
 
-
-}
+}//namespace OpenMP
+}//namespace PLMD
 
 #endif


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

I checked out that the class `PLMD::OpenMP` was been used as a namespace: it only has static methods and no members
I think these small modifications may improve code readability: 
 - `PLMD::OpenMP` is now a namespace
 - the warning workaround in `PLMD::getGoodNumThreads` is now a commented input instead of a C-style cast, so there is no unused variable to throw a warning
 - in Tools/OpenMP.cpp `OpenMPVars` is now explicitly a singleton with a line of documentation and a private constructor

A question: reading `PLMD::getGoodNumThreads(T*,unsigned)`, it looks like it returns either `getNumThreads()` or `1`, is this the wanted behaviour? If yes I'm updating the documentation, there should be a unit test to check that the wanted  behaviour is present.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __XXXXX__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
