### PR TITLE
Pw patch masses

### DIFF
--- a/patches/qespresso-6.2.diff/PW/src/plugin_ext_forces.f90
+++ b/patches/qespresso-6.2.diff/PW/src/plugin_ext_forces.f90
@@ -25,13 +25,14 @@ SUBROUTINE plugin_ext_forces()
   !
   IMPLICIT NONE
   !
-  INTEGER:: i,j
+  INTEGER:: i,j,ia
   REAL(DP) :: at_plumed(3,3)
   REAL(DP) :: virial(3,3)
   REAL(DP) :: volume
   REAL(DP), ALLOCATABLE :: tau_plumed(:,:)
-  REAL(DP) :: masses_plumed(nat) = 0.0_DP
+  REAL(DP) :: masses_plumed(nat)
   !
+  masses_plumed = 0.0_DP
   IF(use_plumed) then
     IF(ionode)THEN
       at_plumed=alat*at;  ! the cell, rescaled properly

--- a/patches/qespresso-6.2.diff/PW/src/plugin_ext_forces.f90
+++ b/patches/qespresso-6.2.diff/PW/src/plugin_ext_forces.f90
@@ -18,7 +18,7 @@ SUBROUTINE plugin_ext_forces()
   USE plugin_flags
   !
   USE cell_base,        ONLY : alat, at
-  USE ions_base,        ONLY : tau, nat,amass
+  USE ions_base,        ONLY : tau, nat, amass, ityp
   USE force_mod,        ONLY : force,sigma
   USE control_flags,    ONLY : istep
   USE ener,             ONLY : etot 
@@ -30,6 +30,7 @@ SUBROUTINE plugin_ext_forces()
   REAL(DP) :: virial(3,3)
   REAL(DP) :: volume
   REAL(DP), ALLOCATABLE :: tau_plumed(:,:)
+  REAL(DP) :: masses_plumed(nat) = 0.0_DP
   !
   IF(use_plumed) then
     IF(ionode)THEN
@@ -43,9 +44,11 @@ SUBROUTINE plugin_ext_forces()
              -at_plumed(1,2)*at_plumed(3,3)*at_plumed(2,1) &
              -at_plumed(1,3)*at_plumed(3,1)*at_plumed(2,2) 
       virial=-sigma*volume
-
+      do ia=1,nat
+        masses_plumed(ia)=amass(ityp(ia))
+      end do
       CALL plumed_f_gcmd("setStep"//char(0),istep)
-      CALL plumed_f_gcmd("setMasses"//char(0),amass)
+      CALL plumed_f_gcmd("setMasses"//char(0),masses_plumed)
       CALL plumed_f_gcmd("setForces"//char(0),force)
       CALL plumed_f_gcmd("setPositions"//char(0),tau_plumed)
       CALL plumed_f_gcmd("setBox"//char(0),at_plumed)

--- a/patches/qespresso-6.2.diff/PW/src/plugin_ext_forces.f90
+++ b/patches/qespresso-6.2.diff/PW/src/plugin_ext_forces.f90
@@ -44,6 +44,7 @@ SUBROUTINE plugin_ext_forces()
              -at_plumed(1,2)*at_plumed(3,3)*at_plumed(2,1) &
              -at_plumed(1,3)*at_plumed(3,1)*at_plumed(2,2) 
       virial=-sigma*volume
+      ! the masses in QE are stored per type, see q-e//Modules/ions_base.f90
       do ia=1,nat
         masses_plumed(ia)=amass(ityp(ia))
       end do

--- a/patches/qespresso-7.0.diff/PW/src/plugin_ext_forces.f90
+++ b/patches/qespresso-7.0.diff/PW/src/plugin_ext_forces.f90
@@ -18,7 +18,7 @@ SUBROUTINE plugin_ext_forces()
   USE plugin_flags,     ONLY : use_plumed
   !
   USE cell_base,        ONLY : alat, at
-  USE ions_base,        ONLY : tau, nat,amass
+  USE ions_base,        ONLY : tau, nat, amass, ityp
   USE force_mod,        ONLY : force,sigma
   USE control_flags,    ONLY : istep
   USE ener,             ONLY : etot 
@@ -27,12 +27,14 @@ SUBROUTINE plugin_ext_forces()
   !
   IMPLICIT NONE
   !
-  INTEGER:: i,j
+  INTEGER:: i,j,ia
   REAL(DP) :: at_plumed(3,3)
   REAL(DP) :: virial(3,3)
   REAL(DP) :: volume
   REAL(DP), ALLOCATABLE :: tau_plumed(:,:)
+  REAL(DP) :: masses_plumed(nat)
   !
+  masses_plumed = 0.0_DP
   IF(use_plumed) then
     IF(ionode)THEN
       at_plumed=alat*at;  ! the cell, rescaled properly
@@ -46,8 +48,13 @@ SUBROUTINE plugin_ext_forces()
              -at_plumed(1,3)*at_plumed(3,1)*at_plumed(2,2) 
       virial=-sigma*volume
 
+      ! the masses in QE are stored per type, see q-e//Modules/ions_base.f90
+      do ia=1,nat
+        masses_plumed(ia)=amass(ityp(ia))
+      end do
+
       CALL plumed_f_gcmd("setStep"//char(0),istep)
-      CALL plumed_f_gcmd("setMasses"//char(0),amass)
+      CALL plumed_f_gcmd("setMasses"//char(0),masses_plumed)
       CALL plumed_f_gcmd("setForces"//char(0),force)
       CALL plumed_f_gcmd("setPositions"//char(0),tau_plumed)
       CALL plumed_f_gcmd("setBox"//char(0),at_plumed)


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

I Think I solved the problem with quantum espresso's pw don't communicating the correct masses of the atoms. I need the CI to test the patch

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I may need to rebase these commit on 2.8 or older version, since the code change is very small

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
