### PR TITLE
mklib deletes tmp files also in case of failure

### DIFF
--- a/scripts/mklib.sh
+++ b/scripts/mklib.sh
@@ -1,77 +1,82 @@
 #! /usr/bin/env bash
 
-if [ "$1" = --description ] ; then
-  echo "compile a .cpp file into a shared library"
+if [ "$1" = --description ]; then
+  echo "compile one or more *.cpp files into a shared library"
   exit 0
 fi
 
-if [ "$1" = --options ] ; then
+if [ "$1" = --options ]; then
   echo "--description --options"
   exit 0
 fi
 
-source "$PLUMED_ROOT"/src/config/compile_options.sh
-
-if [ $# == 0 ]
-then
+if [ $# == 0 ]; then
   echo "ERROR"
   echo "type 'plumed mklib file1.cpp [file2.cpp etc]'"
   exit 1
 fi
 
+source "$PLUMED_ROOT"/src/config/compile_options.sh
+
 lib="${1%%.cpp}".$soext
 rm -f "$lib"
 
+toRemove=""
+remover() {
+  #if compilation fails or crashes the trap will delete the temporary files
+  for f in $toRemove; do
+    rm -f "${f}"
+  done
+}
+trap "remover" EXIT
 objs=""
 
-for file
-do
+for file; do
 
-  if [[ "$file" != *.cpp ]] ;
-  then
+  if [[ "$file" != *.cpp ]]; then
     echo "ERROR"
     echo "type 'plumed mklib file1.cpp [file2.cpp etc]'"
     exit 1
   fi
 
   obj="${file%%.cpp}".o
-  
-  if [ ! -f "$file" ]
-  then
+
+  if [ ! -f "$file" ]; then
     echo "ERROR: I cannot find file $file"
     exit 1
   fi
   #adding a simple tmpfile, to preprocess "in place" the input file,
   #this assumes the user has write permission in the current directory
   #which should be true since we are going to compile and output something here
-  tmpfile=$(mktemp ${file%.cpp}.XXXXXX).cpp
+  tmpfile=$(mktemp "${file%.cpp}.XXXXXX")
+  mv "${tmpfile}" "${tmpfile}.cpp"
+  tmpfile=${tmpfile}.cpp
   cp "${file}" "${tmpfile}"
-  
-  if grep -q '^#include "\(bias\|colvar\|function\|sasa\|vatom\)\/ActionRegister.h"' "${tmpfile}"; then
-     >&2 echo 'WARNING: using a legacy ActionRegister.h include path, please use <<#include "core/ActionRegister.h">>'
-     sed -i.bak 's%^#include ".*/ActionRegister.h"%#include "core/ActionRegister.h"%g' "${tmpfile}"
-  fi
-  
-  if grep -q '^#include "\(cltools\)\/CLToolRegister.h"' "${tmpfile}"; then
-     >&2  echo 'WARNING: using a legacy  CLToolRegister.h include path, please use <<#include "core/CLToolRegister.h">>'
-     sed -i.bak 's%^#include ".*/CLToolRegister.h"%#include "core/CLToolRegister.h"%g' "${tmpfile}"
-  fi
-  
-  rm -f "$obj"
+  toRemove="${toRemove} ${tmpfile} ${tmpfile}.bak"
 
-  eval "$compile" "$PLUMED_MKLIB_CFLAGS" -o "$obj" "$tmpfile" || {
+  if grep -q '^#include "\(bias\|colvar\|function\|sasa\|vatom\)\/ActionRegister.h"' "${tmpfile}"; then
+    echo >&2 'WARNING: using a legacy ActionRegister.h include path, please use <<#include "core/ActionRegister.h">>'
+    sed -i.bak 's%^#include ".*/ActionRegister.h"%#include "core/ActionRegister.h"%g' "${tmpfile}"
+  fi
+
+  if grep -q '^#include "\(cltools\)\/CLToolRegister.h"' "${tmpfile}"; then
+    echo >&2 'WARNING: using a legacy  CLToolRegister.h include path, please use <<#include "core/CLToolRegister.h">>'
+    sed -i.bak 's%^#include ".*/CLToolRegister.h"%#include "core/CLToolRegister.h"%g' "${tmpfile}"
+  fi
+
+  rm -f "$obj"
+  eval "$compile" "$PLUMED_MKLIB_CFLAGS" "$tmpfile" -o "$obj" || {
     echo "ERROR: compiling $file"
     exit 1
   }
 
-  rm -f ${tmpfile} ${tmpfile}.bak ${tmpfile%.cpp}
   objs="$objs $obj"
-
 done
 
-if test "$PLUMED_IS_INSTALLED" = yes ; then
-  eval "$link_installed" "$PLUMED_MKLIB_LDFLAGS" -o "$lib" "$objs"
-else
-  eval "$link_uninstalled" "$PLUMED_MKLIB_LDFLAGS" -o "$lib" "$objs"
+link_command="$link_uninstalled"
+
+if test "$PLUMED_IS_INSTALLED" = yes; then
+  link_command="$link_installed"
 fi
 
+eval "$link_command" "$PLUMED_MKLIB_LDFLAGS" $objs -o "$lib"

--- a/scripts/mklib.sh
+++ b/scripts/mklib.sh
@@ -1,18 +1,19 @@
 #! /usr/bin/env bash
 
-if [ "$1" = --description ]; then
+if [ "$1" = --description ] ; then
   echo "compile one or more *.cpp files into a shared library"
   echo " you can create and export the variable PLUMED_MKLIB_CFLAGS with some extra compile time flags to be used"
   echo " you can create and export the variable PLUMED_MKLIB_LDFLAGS with some extra link time flags (and libraries) to be used"
   exit 0
 fi
 
-if [ "$1" = --options ]; then
+if [ "$1" = --options ] ; then
   echo "--description --options"
   exit 0
 fi
 
-if [ $# == 0 ]; then
+if [ $# == 0 ]
+then
   echo "ERROR"
   echo "type 'plumed mklib file1.cpp [file2.cpp etc]'"
   exit 1
@@ -33,17 +34,20 @@ remover() {
 trap "remover" EXIT
 objs=""
 
-for file; do
+for file
+do
 
-  if [[ "$file" != *.cpp ]]; then
+  if [[ "$file" != *.cpp ]] ;
+  then
     echo "ERROR"
     echo "type 'plumed mklib file1.cpp [file2.cpp etc]'"
     exit 1
   fi
 
   obj="${file%%.cpp}".o
-
-  if [ ! -f "$file" ]; then
+  
+  if [ ! -f "$file" ]
+  then
     echo "ERROR: I cannot find file $file"
     exit 1
   fi
@@ -57,22 +61,24 @@ for file; do
   toRemove="${toRemove} ${tmpfile} ${tmpfile}.bak"
 
   if grep -q '^#include "\(bias\|colvar\|function\|sasa\|vatom\)\/ActionRegister.h"' "${tmpfile}"; then
-    echo >&2 'WARNING: using a legacy ActionRegister.h include path, please use <<#include "core/ActionRegister.h">>'
-    sed -i.bak 's%^#include ".*/ActionRegister.h"%#include "core/ActionRegister.h"%g' "${tmpfile}"
+     >&2 echo 'WARNING: using a legacy ActionRegister.h include path, please use <<#include "core/ActionRegister.h">>'
+     sed -i.bak 's%^#include ".*/ActionRegister.h"%#include "core/ActionRegister.h"%g' "${tmpfile}"
   fi
-
+  
   if grep -q '^#include "\(cltools\)\/CLToolRegister.h"' "${tmpfile}"; then
-    echo >&2 'WARNING: using a legacy  CLToolRegister.h include path, please use <<#include "core/CLToolRegister.h">>'
-    sed -i.bak 's%^#include ".*/CLToolRegister.h"%#include "core/CLToolRegister.h"%g' "${tmpfile}"
+     >&2  echo 'WARNING: using a legacy  CLToolRegister.h include path, please use <<#include "core/CLToolRegister.h">>'
+     sed -i.bak 's%^#include ".*/CLToolRegister.h"%#include "core/CLToolRegister.h"%g' "${tmpfile}"
   fi
-
+  
   rm -f "$obj"
-  eval "$compile" "$PLUMED_MKLIB_CFLAGS" "$tmpfile" -o "$obj" || {
+
+  eval "$compile" "$PLUMED_MKLIB_CFLAGS" -o "$obj" "$tmpfile" || {
     echo "ERROR: compiling $file"
     exit 1
   }
 
   objs="$objs $obj"
+
 done
 
 link_command="$link_uninstalled"

--- a/scripts/mklib.sh
+++ b/scripts/mklib.sh
@@ -2,6 +2,8 @@
 
 if [ "$1" = --description ]; then
   echo "compile one or more *.cpp files into a shared library"
+  echo " you can create and export the variable PLUMED_MKLIB_CFLAGS with some extra compile time flags to be used"
+  echo " you can create and export the variable PLUMED_MKLIB_LDFLAGS with some extra link time flags (and libraries) to be used"
   exit 0
 fi
 


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

I added a trap into mklib.sh so that if anything happens during the execution the temporary files will be automatically removed.


##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
