### PR TITLE
Removed py37 and py38 from macports CI

### DIFF
--- a/.github/workflows/macWF.yml
+++ b/.github/workflows/macWF.yml
@@ -22,7 +22,7 @@ jobs:
         variant: [ "" , "+allmodules" ]
         # see https://github.community/t/how-to-conditionally-include-exclude-items-in-matrix-eg-based-on-branch/16853/6 for possible exclusions
     env:
-      PYVERS: "py38 py39 py310"
+      PYVERS: "py39 py310"
     steps:
     - uses: actions/checkout@v3
     - uses: actions/cache@v3

--- a/.github/workflows/macWF.yml
+++ b/.github/workflows/macWF.yml
@@ -22,7 +22,7 @@ jobs:
         variant: [ "" , "+allmodules" ]
         # see https://github.community/t/how-to-conditionally-include-exclude-items-in-matrix-eg-based-on-branch/16853/6 for possible exclusions
     env:
-      PYVERS: "py37 py38 py39 py310"
+      PYVERS: "py38 py39 py310"
     steps:
     - uses: actions/checkout@v3
     - uses: actions/cache@v3


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

In #967, related to the EOL of python3.7, I lost the "py37" in the macports-CI, here I removed it

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
