### PR TITLE
OPES: second attempt at fixing NaN problem for intel compiler

### DIFF
--- a/src/opes/ECVlinear.cpp
+++ b/src/opes/ECVlinear.cpp
@@ -122,26 +122,11 @@ ECVlinear::ECVlinear(const ActionOptions&ao)
   if(dimensionless)
     beta0_=1;
 
-//workaround needed for intel compiler
-  bool nan_support=true;
-  const double my_nan_value=-42;
-  if(!std::isnan(std::numeric_limits<double>::quiet_NaN()))
-  {
-    nan_support=false;
-    log.printf(" +++ WARNING +++ do not set LAMBDA_MIN/MAX=%g, see https://github.com/plumed/plumed2/pull/990\n", my_nan_value);
-  }
-  auto isNone=[nan_support,my_nan_value](const double value)
-  {
-    if(nan_support)
-      return std::isnan(value);
-    else
-      return value==my_nan_value;
-  };
-
 //parse lambda info
   parse("LAMBDA",lambda0_);
-  double lambda_min=std::numeric_limits<double>::quiet_NaN();
-  double lambda_max=std::numeric_limits<double>::quiet_NaN();
+  const double myNone=std::numeric_limits<double>::lowest(); //quiet_NaN is not supported by some intel compiler
+  double lambda_min=myNone;
+  double lambda_max=myNone;
   parse("LAMBDA_MIN",lambda_min);
   parse("LAMBDA_MAX",lambda_max);
   unsigned lambda_steps=0;
@@ -156,7 +141,7 @@ ECVlinear::ECVlinear(const ActionOptions&ao)
   if(lambdas.size()>0)
   {
     plumed_massert(lambda_steps==0,"cannot set both LAMBDA_STEPS and LAMBDA_SET_ALL");
-    plumed_massert(isNone(lambda_min) && isNone(lambda_max),"cannot set both LAMBDA_SET_ALL and LAMBDA_MIN/MAX");
+    plumed_massert(lambda_min==myNone && lambda_max==myNone,"cannot set both LAMBDA_SET_ALL and LAMBDA_MIN/MAX");
     plumed_massert(lambdas.size()>=2,"set at least 2 lambdas with LAMBDA_SET_ALL");
     for(unsigned k=0; k<lambdas.size()-1; k++)
       plumed_massert(lambdas[k]<=lambdas[k+1],"LAMBDA_SET_ALL must be properly ordered");
@@ -168,12 +153,12 @@ ECVlinear::ECVlinear(const ActionOptions&ao)
   }
   else
   { //get LAMBDA_MIN and LAMBDA_MAX
-    if(isNone(lambda_min))
+    if(lambda_min==myNone)
     {
       lambda_min=0;
       log.printf("  no LAMBDA_MIN provided, using LAMBDA_MIN = %g\n",lambda_min);
     }
-    if(isNone(lambda_max))
+    if(lambda_max==myNone)
     {
       lambda_max=1;
       log.printf("  no LAMBDA_MAX provided, using LAMBDA_MAX = %g\n",lambda_max);

--- a/src/opes/ECVmultiThermalBaric.cpp
+++ b/src/opes/ECVmultiThermalBaric.cpp
@@ -146,22 +146,6 @@ ECVmultiThermalBaric::ECVmultiThermalBaric(const ActionOptions&ao)
   const double kB=plumed.getAtoms().getKBoltzmann();
   const double temp0=kbt_/kB;
 
-//workaround needed for intel compiler
-  bool nan_support=true;
-  const double my_nan_value=-42;
-  if(!std::isnan(std::numeric_limits<double>::quiet_NaN()))
-  {
-    nan_support=false;
-    log.printf(" +++ WARNING +++ do not set PRESSURE_MIN/MAX=%g, see https://github.com/plumed/plumed2/pull/990\n", my_nan_value);
-  }
-  auto isNone=[nan_support,my_nan_value](const double value)
-  {
-    if(nan_support)
-      return std::isnan(value);
-    else
-      return value==my_nan_value;
-  };
-
 //parse temp range
   double temp_min=-1;
   double temp_max=-1;
@@ -175,8 +159,9 @@ ECVmultiThermalBaric::ECVmultiThermalBaric(const ActionOptions&ao)
   geom_spacing_=!geom_spacing_;
 //parse pressures
   parse("PRESSURE",pres0_);
-  double pres_min=std::numeric_limits<double>::quiet_NaN(); //-1 might be a meaningful pressure
-  double pres_max=std::numeric_limits<double>::quiet_NaN();
+  const double myNone=std::numeric_limits<double>::lowest(); //quiet_NaN is not supported by some intel compiler
+  double pres_min=myNone; //-1 might be a meaningful pressure
+  double pres_max=myNone;
   parse("PRESSURE_MIN",pres_min);
   parse("PRESSURE_MAX",pres_max);
   unsigned pres_steps=0;
@@ -197,7 +182,7 @@ ECVmultiThermalBaric::ECVmultiThermalBaric(const ActionOptions&ao)
     plumed_massert(temp_steps==0,"cannot set both SET_ALL_TEMP_PRESSURE and TEMP_STEPS");
     plumed_massert(pres_steps==0,"cannot set both SET_ALL_TEMP_PRESSURE and PRESSURE_STEPS");
     plumed_massert(temp_min==-1 && temp_max==-1,"cannot set both SET_ALL_TEMP_PRESSURE and TEMP_MIN/MAX");
-    plumed_massert(isNone(pres_min) && isNone(pres_max),"cannot set both SET_ALL_TEMP_PRESSURE and PRESSURE_MIN/MAX");
+    plumed_massert(pres_min==myNone && pres_max==myNone,"cannot set both SET_ALL_TEMP_PRESSURE and PRESSURE_MIN/MAX");
     plumed_massert(cut_corner.size()==0,"cannot set both SET_ALL_TEMP_PRESSURE and CUT_CORNER");
 //setup the target temperature-pressure grid
     derECVs_beta_.resize(custom_lambdas_.size());
@@ -273,7 +258,7 @@ ECVmultiThermalBaric::ECVmultiThermalBaric(const ActionOptions&ao)
     if(pres_.size()>0)
     {
       plumed_massert(pres_steps==0,"cannot set both PRESSURE_STEPS and PRESSURE_SET_ALL");
-      plumed_massert(isNone(pres_min) && isNone(pres_max),"cannot set both PRESSURE_SET_ALL and PRESSURE_MIN/MAX");
+      plumed_massert(pres_min==myNone && pres_max==myNone,"cannot set both PRESSURE_SET_ALL and PRESSURE_MIN/MAX");
       plumed_massert(pres_.size()>=2,"set at least 2 pressures");
       for(unsigned kk=0; kk<pres_.size()-1; kk++)
         plumed_massert(pres_[kk]<=pres_[kk+1],"PRESSURE_SET_ALL must be properly ordered");
@@ -282,12 +267,12 @@ ECVmultiThermalBaric::ECVmultiThermalBaric(const ActionOptions&ao)
     }
     else
     { //get PRESSURE_MIN and PRESSURE_MAX
-      if(isNone(pres_min))
+      if(pres_min==myNone)
       {
         pres_min=pres0_;
         log.printf("  no PRESSURE_MIN provided, using PRESSURE_MIN=PRESSURE\n");
       }
-      if(isNone(pres_max))
+      if(pres_max==myNone)
       {
         pres_max=pres0_;
         log.printf("  no PRESSURE_MAX provided, using PRESSURE_MAX=PRESSURE\n");


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description
See https://github.com/plumed/plumed2/pull/990

Unfortunately I cannot test the intel compiler on my machine. My guess is that previous attempt did not work because this line was optimized away 
```
if(!std::isnan(std::numeric_limits<double>::quiet_NaN()))
```

Anyway, I now completely removed any NaN and instead use a very unlikely default value, that in practice will do the same job.

<!-- describe here your pull request -->

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.8__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [x] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
