### PR TITLE
Removing the should from Exception.h

### DIFF
--- a/src/tools/Exception.h
+++ b/src/tools/Exception.h
@@ -381,10 +381,11 @@ public:
 #ifdef NDEBUG
 
 // These are the versions used when compiling with NDEBUG flag.
-// The condition is always true, so that the rest of the statement
-// should be optimized away.
-#define plumed_dbg_assert(test) plumed_assert(true)
-#define plumed_dbg_massert(test,msg) plumed_massert(true,msg)
+// The if constexpr(false) gurarantees that the compiler will optimize away the assertion
+// We are not using an empty macro becasue the user may want to use the << operator
+
+#define plumed_dbg_assert(test) if constexpr(false) plumed_assert(true)
+#define plumed_dbg_massert(test,msg) if constexpr(false) plumed_massert(true,msg)
 
 #else
 


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description
I encoundered a case i which the `if (!(test)) plumed_error() << PLMD::Exception::Assertion(#test)`, the plumed_dbg_massert macro expansion with NDEBUG, is not optimized away, and this patch is the least invasive thing to do:

`if constexpr(false)` is guaranteed to be evaluated at compile time, so that the rest of the line is ignored.

I think helps in improving the code optimization after inlining a function, at least that is what I think it happened in my case

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10/2.9 (this is a single commit, it can be easily rebased on the 2.9)

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
