### PR TITLE
Optimized getOutputQuantity to avoid string copies

### DIFF
--- a/src/core/ActionWithValue.h
+++ b/src/core/ActionWithValue.h
@@ -27,6 +27,7 @@
 #include "tools/Exception.h"
 #include <vector>
 #include <memory>
+#include <cstring>
 
 namespace PLMD {
 
@@ -185,9 +186,13 @@ double ActionWithValue::getOutputQuantity(const unsigned j) const {
 
 inline
 double ActionWithValue::getOutputQuantity( const std::string& name ) const {
-  std::string thename; thename=getLabel() + "." + name;
+  int offset=getLabel().size();
   for(unsigned i=0; i<values.size(); ++i) {
-    if( values[i]->name==thename ) return values[i]->get();
+    const std::string & valname=values[i]->name;
+    if(valname.size()>offset+1 && valname[offset]=='.' ) {
+      plumed_dbg_assert(Tools::startWith(valname,getLabel()));
+      if(!std::strcmp(valname.c_str()+offset+1,name.c_str())) return values[i]->get();
+    }
   }
   return 0.0;
 }


### PR DESCRIPTION
This change leads to a 4% speedup on my laptop with the small benchmark (20 atoms, 4 of which biased)

@gtribello can you confirm this is correct? Can I correctly assume that, if the `values[i]->name` is longer than `getLabe()`, than it starts with `getLabel()+'.'`? In this way I avoid creating a new std::string and directly compare the remaining part.

If not I can add a separate check on the first part of the string as well. In any case this will allow me to save the allocation.

