### PR TITLE
Setting flags to default true makes no sense so I added a plumed_merr…

### DIFF
--- a/src/cltools/pesmd.cpp
+++ b/src/cltools/pesmd.cpp
@@ -111,7 +111,7 @@ public:
     keys.add("compulsory","idum","0","The random number seed");
     // temporary suppression, this is likely a bug that should be fixed!
     // cppcheck-suppress incorrectStringBooleanError
-    keys.addFlag("periodic","false","are your input coordinates periodic");
+    keys.addFlag("periodic",false,"are your input coordinates periodic");
     keys.add("optional","min","minimum value the coordinates can take for a periodic domain");
     keys.add("optional","max","maximum value the coordinates can take for a periodic domain");
   }

--- a/src/colvar/Template.cpp
+++ b/src/colvar/Template.cpp
@@ -61,7 +61,6 @@ PLUMED_REGISTER_ACTION(Template,"TEMPLATE")
 void Template::registerKeywords(Keywords& keys) {
   Colvar::registerKeywords(keys);
   keys.addFlag("TEMPLATE_DEFAULT_OFF_FLAG",false,"flags that are by default not performed should be specified like this");
-  keys.addFlag("TEMPLATE_DEFAULT_ON_FLAG",true,"flags that are by default performed should be specified like this");
   keys.add("compulsory","TEMPLATE_COMPULSORY","all compulsory keywords should be added like this with a description here");
   keys.add("optional","TEMPLATE_OPTIONAL","all optional keywords that have input should be added like a description here");
   keys.add("atoms","ATOMS","the keyword with which you specify what atoms to use should be added like this");

--- a/src/core/ActionWithValue.cpp
+++ b/src/core/ActionWithValue.cpp
@@ -40,7 +40,7 @@ void ActionWithValue::registerKeywords(Keywords& keys) {
 
 void ActionWithValue::noAnalyticalDerivatives(Keywords& keys) {
   keys.remove("NUMERICAL_DERIVATIVES");
-  keys.addFlag("NUMERICAL_DERIVATIVES",true,"analytical derivatives are not implemented for this keyword so numerical derivatives are always used");
+  keys.addFlag("NUMERICAL_DERIVATIVES",false,"analytical derivatives are not implemented for this keyword so numerical derivatives are always used");
 }
 
 void ActionWithValue::componentsAreNotOptional(Keywords& keys) {

--- a/src/eds/EDS.cpp
+++ b/src/eds/EDS.cpp
@@ -302,7 +302,7 @@ void EDS::registerKeywords(Keywords &keys)
   keys.addFlag("LM", false, "Use Levenberg-Marquadt algorithm along with simultaneous keyword. Otherwise use gradient descent.");
   // temporary suppression, this is likely a bug that should be fixed!
   // cppcheck-suppress incorrectStringBooleanError
-  keys.addFlag("LM_MIXING", "1", "Initial mixing parameter when using Levenberg-Marquadt minimization.");
+  keys.add("compulsory", "LM_MIXING", "1", "Initial mixing parameter when using Levenberg-Marquadt minimization.");
 
   keys.add("optional", "RESTART_FMT", "the format that should be used to output real numbers in EDS restarts");
   keys.add("optional", "OUT_RESTART", "Output file for all information needed to continue EDS simulation. "

--- a/src/function/FuncSumHills.cpp
+++ b/src/function/FuncSumHills.cpp
@@ -215,7 +215,7 @@ void FuncSumHills::registerKeywords(Keywords& keys) {
   keys.add("optional","OUTHISTO"," output file for histogram ");
   keys.add("optional","INITSTRIDE"," stride if you want an initial dump ");
   keys.add("optional","STRIDE"," stride when you do it on the fly ");
-  keys.addFlag("ISCLTOOL",true,"use via plumed command line: calculate at read phase and then go");
+  keys.addFlag("ISCLTOOL",false,"use via plumed command line: calculate at read phase and then go");
   keys.addFlag("PARALLELREAD",false,"read parallel HILLS file");
   keys.addFlag("NEGBIAS",false,"dump  negative bias ( -bias )   instead of the free energy: needed in well tempered with flexible hills ");
   keys.addFlag("NOHISTORY",false,"to be used with INITSTRIDE:  it splits the bias/histogram in pieces without previous history  ");

--- a/src/maze/Optimizer.cpp
+++ b/src/maze/Optimizer.cpp
@@ -52,7 +52,7 @@ void Optimizer::registerKeywords(Keywords& keys) {
 
   keys.addFlag(
     "NLIST",
-    true,
+    false,
     "Use a neighbor list of ligand-protein atom pairs to speed up the "
     "calculating of the distances."
   );

--- a/src/tools/Keywords.cpp
+++ b/src/tools/Keywords.cpp
@@ -207,7 +207,7 @@ void Keywords::add( const std::string & t, const std::string & k, const std::str
 
 void Keywords::addFlag( const std::string & k, const bool def, const std::string & d ) {
   plumed_massert( !exists(k) && !reserved(k), "keyword " + k + " has already been registered");
-  std::string defstr;
+  std::string defstr; plumed_massert( !def, "the second argument to addFlag must be false " + k );
   if( def ) { defstr="( default=on ) "; } else { defstr="( default=off ) "; }
   types.insert( std::pair<std::string,KeyType>(k,KeyType("flag")) );
   documentation.insert( std::pair<std::string,std::string>(k,defstr + d) );


### PR DESCRIPTION
##### Description

Addressing @GiovanniBussi issue #1018. 

I think you are correct @GiovanniBussi that it is not possible to set flags default true.  I thus added a plumed_merror in keywords if anyone does set the second argument to addFlag to true.  The better fix would be to get rid of the second argument but that is a massive change and I can't be bothered. 

##### Target release

I don't particularly mind

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
