### PR TITLE
Memory view (for pycv)  and adding constexpr in Tools::pbc

### DIFF
--- a/plugins/pycv/PlumedPythonEmbeddedModule.cpp
+++ b/plugins/pycv/PlumedPythonEmbeddedModule.cpp
@@ -151,24 +151,12 @@ PYBIND11_EMBEDDED_MODULE(plumedCommunications, m) {
   /***********************************PLMD::Pbc********************************/
   py::class_<PLMD::Pbc>(m, "Pbc")
   //.def(py::init<>())
-  .def("apply",[](const PLMD::Pbc* self, py::array_t<double>& deltas) -> py::array_t<double> {
+  .def("apply",[](const PLMD::Pbc* self, py::array_t<double, py::array::c_style | py::array::forcecast>& deltas) -> py::array_t<double> {
     //TODO:shape check
-    //TODO: this may be set up to modify the passed deltas, so no new intialization
+    //TODO: this modifies the passed deltas, so no new intialization
     //      ^this needs to be VERY clear to te user
-    auto accessor = deltas.unchecked<2>();
-    auto nat=deltas.shape(0);
-    py::array_t<double> toRet({nat,deltas.shape(1)});
-    auto retAccessor = toRet.mutable_unchecked<2>();
-    for (decltype(nat) i=0; i < nat; ++i) {
-      auto t= self->distance(PLMD::Vector(0.0,0.0,0.0),
-                             //I think this may be slow, but serves as a demonstration as a base for the tests
-                             PLMD::Vector(accessor(i,0),accessor(i,1),accessor(i,2)),
-                             nullptr);
-      retAccessor(i,0) = t[0];
-      retAccessor(i,1) = t[1];
-      retAccessor(i,2) = t[2];
-    }
-    return toRet;
+    self->apply(PLMD::VectorView(deltas.mutable_unchecked<2>().mutable_data(0,0),deltas.shape(0)));
+    return deltas;
   },
   "Apply PBC to a set of positions or distance vectors")
 

--- a/src/tools/Pbc.cpp
+++ b/src/tools/Pbc.cpp
@@ -170,10 +170,16 @@ void Pbc::apply(std::vector<Vector>& dlist, unsigned max_index) const {
       while(dlist[k][2]<=mdiag[2])  dlist[k][2]+=diag[2];
     }
 #else
-    for(unsigned k=0; k<max_index; ++k) for(int i=0; i<3; i++) dlist[k][i]=Tools::pbc(dlist[k][i]*invBox(i,i))*box(i,i);
+    for(unsigned k=0; k<max_index; ++k) {
+      for(int i=0; i<3; i++) {
+        dlist[k][i]=Tools::pbc(dlist[k][i]*invBox(i,i))*box(i,i);
+      }
+    }
 #endif
   } else if(type==generic) {
-    for(unsigned k=0; k<max_index; ++k) dlist[k]=distance(Vector(0.0,0.0,0.0),dlist[k]);
+    for(unsigned k=0; k<max_index; ++k) {
+      dlist[k]=distance(Vector(0.0,0.0,0.0),dlist[k]);
+    }
   } else plumed_merror("unknown pbc type");
 }
 

--- a/src/tools/Pbc.cpp
+++ b/src/tools/Pbc.cpp
@@ -185,7 +185,7 @@ void Pbc::apply(VectorView dlist, unsigned max_index) const {
       //Inlining by hand this part of function from distance speeds up by about 20-30%
       //against the previos version, and 60-80% agains this version non inlined.
       //I do not think is the `if(nshifts) *nshifts+=myshifts.size();`,
-      //but that the compiler now see how we are juggling with the memory and it 
+      //but that the compiler now see how we are juggling with the memory and it
       //does its magic
 
       //I tried writing VectorGeneric<3> matmul(const MemoryView<3UL> a,const TensorGeneric<3,3>&b)

--- a/src/tools/Pbc.cpp
+++ b/src/tools/Pbc.cpp
@@ -182,8 +182,14 @@ void Pbc::apply(VectorView dlist, unsigned max_index) const {
 #endif
   } else if(type==generic) {
     for(unsigned k=0; k<max_index; ++k) {
-      //I wrote VectorGeneric<3> matmul(const MemoryView<3UL> a,const TensorGeneric<3,3>&b)
-      // by copy-pasting the original vector-tensor, but this is 10% faster... (on gcc9)
+      //Inlining by hand this part of function from distance speeds up by about 20-30%
+      //against the previos version, and 60-80% agains this version non inlined.
+      //I do not think is the `if(nshifts) *nshifts+=myshifts.size();`,
+      //but that the compiler now see how we are juggling with the memory and it 
+      //does its magic
+
+      //I tried writing VectorGeneric<3> matmul(const MemoryView<3UL> a,const TensorGeneric<3,3>&b)
+      // by copy-pasting the original vector-tensor, but slows down this method by 10%... (on gcc9)
       Vector s=matmul(Vector{dlist[k][0],dlist[k][1],dlist[k][2]},invReduced);
       // bring to -0.5,+0.5 region in scaled coordinates:
       for(int i=0; i<3; ++i) {

--- a/src/tools/Pbc.cpp
+++ b/src/tools/Pbc.cpp
@@ -156,31 +156,7 @@ double Pbc::distance( const bool pbc, const Vector& v1, const Vector& v2 ) const
 }
 
 void Pbc::apply(std::vector<Vector>& dlist, unsigned max_index) const {
-  if (max_index==0) max_index=dlist.size();
-  if(type==unset) {
-    // do nothing
-  } else if(type==orthorombic) {
-#ifdef __PLUMED_PBC_WHILE
-    for(unsigned k=0; k<max_index; ++k) {
-      while(dlist[k][0]>hdiag[0])   dlist[k][0]-=diag[0];
-      while(dlist[k][0]<=mdiag[0])  dlist[k][0]+=diag[0];
-      while(dlist[k][1]>hdiag[1])   dlist[k][1]-=diag[1];
-      while(dlist[k][1]<=mdiag[1])  dlist[k][1]+=diag[1];
-      while(dlist[k][2]>hdiag[2])   dlist[k][2]-=diag[2];
-      while(dlist[k][2]<=mdiag[2])  dlist[k][2]+=diag[2];
-    }
-#else
-    for(unsigned k=0; k<max_index; ++k) {
-      for(int i=0; i<3; i++) {
-        dlist[k][i]=Tools::pbc(dlist[k][i]*invBox(i,i))*box(i,i);
-      }
-    }
-#endif
-  } else if(type==generic) {
-    for(unsigned k=0; k<max_index; ++k) {
-      dlist[k]=distance(Vector(0.0,0.0,0.0),dlist[k]);
-    }
-  } else plumed_merror("unknown pbc type");
+  apply(mdMemoryView< -1,3>(&dlist[0][0],dlist.size()),max_index);
 }
 
 void Pbc::apply(mdMemoryView< -1,3>dlist, unsigned max_index) const {
@@ -215,14 +191,12 @@ void Pbc::apply(mdMemoryView< -1,3>dlist, unsigned max_index) const {
   } else plumed_merror("unknown pbc type");
 }
 
-Vector Pbc::distance(const Vector&v1,const Vector&v2,int*nshifts)const {
-  //move should enforce the move ctor instead of the copy one
-  Vector d=std::move(delta(v1,v2));
-  //I'd like to change the signature to:
-  //because with the original we are calling already a ctor and here would be only 3 subtration and assignments:
-  //need to measure
-  //Vector Pbc::distance(const Vector&v1,Vector d,int*nshifts)const {
-  //d-=v1;
+Vector Pbc::distance(const Vector&v1, Vector d,int*nshifts)const {
+  //d is copy/move constructed
+  //when possible d will be RVOed 
+  //it is equivalent to declare Vector d ad assigning it to the difference
+  //between the inputs
+  d-=v1;
   if(type==unset) {
     // do nothing
   } else if(type==orthorombic) {

--- a/src/tools/Pbc.cpp
+++ b/src/tools/Pbc.cpp
@@ -183,7 +183,7 @@ void Pbc::apply(std::vector<Vector>& dlist, unsigned max_index) const {
   } else plumed_merror("unknown pbc type");
 }
 
-void Pbc::apply(MemoryView<3> dlist, unsigned max_index) const {
+void Pbc::apply(mdMemoryView< -1,3>dlist, unsigned max_index) const {
   if (max_index==0) max_index=dlist.size();
   if(type==unset) {
     // do nothing

--- a/src/tools/Pbc.cpp
+++ b/src/tools/Pbc.cpp
@@ -159,7 +159,7 @@ void Pbc::apply(std::vector<Vector>& dlist, unsigned max_index) const {
   apply(mdMemoryView< -1,3>(&dlist[0][0],dlist.size()),max_index);
 }
 
-void Pbc::apply(mdMemoryView< -1,3>dlist, unsigned max_index) const {
+void Pbc::apply(mdMemoryView< -1,3> dlist, unsigned max_index) const {
   if (max_index==0) max_index=dlist.size();
   if(type==unset) {
     // do nothing
@@ -183,7 +183,7 @@ void Pbc::apply(mdMemoryView< -1,3>dlist, unsigned max_index) const {
   } else if(type==generic) {
     for(unsigned k=0; k<max_index; ++k) {
       auto t =distance(Vector(0.0,0.0,0.0),
-                         Vector(dlist[k][0],dlist[k][1],dlist[k][2]));
+      {dlist[k][0],dlist[k][1],dlist[k][2]});
       dlist[k][0]  = t[0];
       dlist[k][1]  = t[1];
       dlist[k][2]  = t[2];
@@ -191,9 +191,9 @@ void Pbc::apply(mdMemoryView< -1,3>dlist, unsigned max_index) const {
   } else plumed_merror("unknown pbc type");
 }
 
-Vector Pbc::distance(const Vector&v1, Vector d,int*nshifts)const {
+Vector Pbc::distance(const Vector&v1, Vector d, int*nshifts) const {
   //d is copy/move constructed
-  //when possible d will be RVOed 
+  //when possible d will be RVOed
   //it is equivalent to declare Vector d ad assigning it to the difference
   //between the inputs
   d-=v1;

--- a/src/tools/Pbc.h
+++ b/src/tools/Pbc.h
@@ -30,25 +30,33 @@
 namespace PLMD {
 
 //this more or less mocks c++20 span with fixed size
-template < int N=3>
-  class MemoryView {
-    double *ptr_;
-    public:
-    MemoryView(double* p) :ptr_(p){}
-    constexpr size_t size()const {return N;}
-    double & operator[](size_t i) { return ptr_ [i];}
-  };
+template < std::size_t N=3>
+class MemoryView {
+  double *ptr_;
+public:
+  MemoryView(double* p) :ptr_(p) {}
+  constexpr size_t size()const {return N;}
+  constexpr size_t extent = N;
+  double & operator[](size_t i) { return ptr_[i];}
+};
 
-//this more or less mocks c++23 mdspan
-template < int N=-1,int STRIDE=3>
-  class mdMemoryView {
-    double *ptr_;
-    size_t size_;
-    public:
-    mdMemoryView(double* p, size_t s) :ptr_(p), size_(s){}
-    size_t size()const {return size_;}
-    MemoryView<STRIDE> operator[](size_t i) { return MemoryView<STRIDE>(ptr_ + i *N);}
-  };
+//this more or less mocks c++23 mdspan without the fancy multi-indexed operator[]
+//the idea is to take an address that you know to be strided in a certain way and 
+//make it avaiable to any interface (like using the data from a nunmpy.ndarray in
+//a function thought for a std::vector<PLMD::Vector> )
+//the N=-1 is there for mocking the run time size from the span (where a 
+//dynamic extent is size_t(-))
+template < std::size_t N=-1, std::size_t STRIDE=3>
+class mdMemoryView {
+  double *ptr_;
+  size_t size_;
+public:
+  mdMemoryView(double* p, size_t s) :ptr_(p), size_(s) {}
+  size_t size()const {return size_;}
+  constexpr size_t extent = N;
+  constexpr size_t stride = STRIDE;
+  MemoryView<STRIDE> operator[](size_t i) { return MemoryView<STRIDE>(ptr_ + i * STRIDE);}
+};
 
 /*
 Tool to deal with periodic boundary conditions.

--- a/src/tools/Pbc.h
+++ b/src/tools/Pbc.h
@@ -68,10 +68,8 @@ public:
 /// Compute modulo of (v2-v1), using or not pbc depending on bool pbc.
   double distance( const bool pbc, const Vector& v1, const Vector& v2 ) const;
 /// Computes v2-v1, using minimal image convention
-  Vector distance(const Vector& v1,const Vector& v2)const;
-/// version of distance which also returns the number
-/// of attempted shifts
-  Vector distance(const Vector&,const Vector&,int*nshifts)const;
+/// if specified, also returns the number of attempted shifts
+  Vector distance(const Vector&,const Vector&,int*nshifts=nullptr)const;
 /// Apply PBC to a set of positions or distance vectors
   void apply(std::vector<Vector>&dlist, unsigned max_index=0) const;
 /// Set the lattice vectors.
@@ -96,11 +94,6 @@ public:
 /// Returns true if box is set and non zero
   bool isSet()const;
 };
-
-inline
-Vector Pbc::distance(const Vector& v1,const Vector& v2)const {
-  return distance(v1,v2,NULL);
-}
 
 inline
 bool Pbc::isSet()const {

--- a/src/tools/Pbc.h
+++ b/src/tools/Pbc.h
@@ -63,6 +63,18 @@ class Pbc {
 /// a distance vector.
   void buildShifts(std::vector<Vector> shifts[2][2][2])const;
 public:
+  template < int N=3>
+  class MemoryView {
+  
+    double *ptr_;
+    size_t size_;
+    public:
+    MemoryView(double* p, size_t s) :ptr_(p), size_(s){}
+    size_t size()const {return size_;}
+    double * operator[](size_t i) { return ptr_ + i *N;}
+
+  };
+
 /// Constructor
   Pbc();
 /// Compute modulo of (v2-v1), using or not pbc depending on bool pbc.
@@ -71,6 +83,7 @@ public:
 /// if specified, also returns the number of attempted shifts
   Vector distance(const Vector&,const Vector&,int*nshifts=nullptr)const;
 /// Apply PBC to a set of positions or distance vectors
+  void apply(MemoryView<3> dlist, unsigned max_index=0) const;
   void apply(std::vector<Vector>&dlist, unsigned max_index=0) const;
 /// Set the lattice vectors.
 /// b[i][j] is the j-th component of the i-th vector

--- a/src/tools/Pbc.h
+++ b/src/tools/Pbc.h
@@ -90,7 +90,7 @@ public:
   double distance( const bool pbc, const Vector& v1, const Vector& v2 ) const;
 /// Computes v2-v1, using minimal image convention
 /// if specified, also returns the number of attempted shifts
-  Vector distance(const Vector&,const Vector&,int*nshifts=nullptr)const;
+  Vector distance(const Vector&, Vector,int*nshifts=nullptr)const;
 /// Apply PBC to a set of positions or distance vectors
   void apply(mdMemoryView< -1,3> dlist, unsigned max_index=0) const;
   void apply(std::vector<Vector>&dlist, unsigned max_index=0) const;

--- a/src/tools/Pbc.h
+++ b/src/tools/Pbc.h
@@ -29,6 +29,27 @@
 
 namespace PLMD {
 
+//this more or less mocks c++20 span with fixed size
+template < int N=3>
+  class MemoryView {
+    double *ptr_;
+    public:
+    MemoryView(double* p) :ptr_(p){}
+    constexpr size_t size()const {return N;}
+    double & operator[](size_t i) { return ptr_ [i];}
+  };
+
+//this more or less mocks c++23 mdspan
+template < int N=-1,int STRIDE=3>
+  class mdMemoryView {
+    double *ptr_;
+    size_t size_;
+    public:
+    mdMemoryView(double* p, size_t s) :ptr_(p), size_(s){}
+    size_t size()const {return size_;}
+    MemoryView<STRIDE> operator[](size_t i) { return MemoryView<STRIDE>(ptr_ + i *N);}
+  };
+
 /*
 Tool to deal with periodic boundary conditions.
 
@@ -63,18 +84,6 @@ class Pbc {
 /// a distance vector.
   void buildShifts(std::vector<Vector> shifts[2][2][2])const;
 public:
-  template < int N=3>
-  class MemoryView {
-  
-    double *ptr_;
-    size_t size_;
-    public:
-    MemoryView(double* p, size_t s) :ptr_(p), size_(s){}
-    size_t size()const {return size_;}
-    double * operator[](size_t i) { return ptr_ + i *N;}
-
-  };
-
 /// Constructor
   Pbc();
 /// Compute modulo of (v2-v1), using or not pbc depending on bool pbc.
@@ -83,7 +92,7 @@ public:
 /// if specified, also returns the number of attempted shifts
   Vector distance(const Vector&,const Vector&,int*nshifts=nullptr)const;
 /// Apply PBC to a set of positions or distance vectors
-  void apply(MemoryView<3> dlist, unsigned max_index=0) const;
+  void apply(mdMemoryView< -1,3> dlist, unsigned max_index=0) const;
   void apply(std::vector<Vector>&dlist, unsigned max_index=0) const;
 /// Set the lattice vectors.
 /// b[i][j] is the j-th component of the i-th vector

--- a/src/tools/Tools.h
+++ b/src/tools/Tools.h
@@ -392,12 +392,12 @@ double Tools::pbc(double x) {
   while (x<-0.5) x+=1.0;
   return x;
 #else
-  if(std::numeric_limits<int>::round_style == std::round_toward_zero) {
-    const double offset=100.0;
+  if constexpr (std::numeric_limits<int>::round_style == std::round_toward_zero) {
+    constexpr double offset=100.0;
     const double y=x+offset;
     if(y>=0) return y-int(y+0.5);
     else     return y-int(y-0.5);
-  } else if(std::numeric_limits<int>::round_style == std::round_to_nearest) {
+  } else if constexpr (std::numeric_limits<int>::round_style == std::round_to_nearest) {
     return x-int(x);
   } else return x-floor(x+0.5);
 #endif


### PR DESCRIPTION
##### Description

As suggested in the review of #1001 I implemented a "memory view" for Pbc::apply.
Now Pbc::apply can be used with any data stored in a "xyzxyzxyz..." fashion (aligned like a `std::vector<PLMD::Vector>`): Plumed will process it like a `std::vector<PLMD::Vector>`.

It is "zero cost abstraction" in the sense that you may pay little more compilation time but there should be no cost at runtime.

And as now the memory view is in a very crude status, with only the parts useful to make Pbc::apply work.
It may need to be relocated in ad ad hoc header.

You should note that I inlined the "generic" branch of Pbc::distance into Pbc::apply. Because calling the original Pbc::distance from Pbc::apply with the new changes results in a heavy slow down.

Now Pbc::apply is 20-30% faster when using non orthogonal pbcs, as you can see in the graphs:

![image](https://github.com/plumed/plumed2/assets/5535617/b5dc75f0-0f0f-47e8-a2d6-e5015aa361b6)
note that the time scale is logarithmic, the  numbers are:
| what: | 10(ns) | 100(ns) | 1000(ns) | 10000(ns) | 
| --- | --- | --- | --- | --- |
| master[ortho]: | 4875589 | 31115489 | 292556383 | 2901822551 |
| arrayLatest[ortho]: | 4838736 | 30786646 | 290585504 | 2899403853 |
| master[generic]:| 12096329 | 100735040 | 982072095 | 9793919925 |
| arrayLatest[generic]:| 9092234 | 73282452 | 709869215 | 7111919112 |

master is updated to commit ed060dd96
and the bench is:
```c++
void testdistance(int operations, int repeat, const Pbc &pbc,
                  std::ostream &stream) {
  vector<Vector> distances(operations);
  Tensor box = pbc.getBox();
  box /= box.determinant();
  duration d = duration::zero();
  const double t = 1.0 / operations;
  for (auto r = 0u; r < repeat; ++r) {
    for (auto i = 0u; i < operations; ++i) {
      distances[i] = 4 * i * t * box.getRow(i % 3);
    }
    auto beg = perfclock::now();
    for (auto i = 0u; i < operations - 1; ++i) {
      pbc.distance(distances[i], distances[i + 1]);
    }
    auto end = perfclock::now();
    d += std::chrono::duration_cast<duration>(end - beg);
  }
  // stream<< " " << d.count() << " us\n";
  stream << operations << " " << d.count() << "\n";
}
```

NB:I think this speed up is not dependent on the memory view.

NB2:I also tried to wrote the common part between Pbc::apply and Pbc::distance as a single separate function to be called by the two, but that approach slowed down the computation.

---

The modification in Tools::pbc is out of scope of the original intent of the PR. The rationale is: since `std::numeric_limits<int>::round_style` is known at compile time (and actually is [constexpr](https://en.cppreference.com/w/cpp/types/numeric_limits/round_style)), I made the branches `constexpr` to guarantee that are precalculated at compile time.
This unexpectedly gave a slightly (circa 0.5-1%) improvement into the calculation time also for the orthogonal case (at least with gcc 9.4.0).

Modifying Tools:pbc I studied a bit the rounding: it is [possible to change the rounding at runtime](https://en.cppreference.com/w/cpp/numeric/fenv/feround), and `std::numeric_limits<int>::round_style` is known ONLY at compile time.
Meaning that if an external code that is calling plumed changes the rounding style with `#include <cfenv>`, we are stuck with the compile time choice (with or without these changes accepted).
I know this is a 0.000x% scenario, and even more out of scope of the PR, but it is better to be aware of it.

---

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
