### PR TITLE
Optimize wholemolecules

### DIFF
--- a/src/core/ActionAtomistic.cpp
+++ b/src/core/ActionAtomistic.cpp
@@ -344,20 +344,6 @@ void ActionAtomistic::makeWhole() {
   }
 }
 
-Vector ActionAtomistic::getForce( const std::pair<std::size_t, std::size_t>& a ) const {
-  Vector f;
-  f[0]=xpos[a.first]->getForce(a.second);
-  f[1]=ypos[a.first]->getForce(a.second);
-  f[2]=zpos[a.first]->getForce(a.second);
-  return f;
-}
-
-void ActionAtomistic::addForce( const std::pair<std::size_t, std::size_t>& a, const Vector& f ) {
-  xpos[a.first]->addForce( a.second, f[0] );
-  ypos[a.first]->addForce( a.second, f[1] );
-  zpos[a.first]->addForce( a.second, f[2] );
-}
-
 void ActionAtomistic::getGradient( const unsigned& ind, Vector& deriv, std::map<AtomNumber,Vector>& gradients ) const {
   std::size_t nn = atom_value_ind[ind].first;
   if( nn==0 ) { gradients[indexes[ind]] += deriv; return; }

--- a/src/core/ActionAtomistic.cpp
+++ b/src/core/ActionAtomistic.cpp
@@ -336,20 +336,6 @@ unsigned ActionAtomistic::getTotAtoms()const {
   return natoms;
 }
 
-Vector ActionAtomistic::getGlobalPosition(const std::pair<std::size_t,std::size_t>& a) const {
-  Vector pos;
-  pos[0]=xpos[a.first]->data[a.second];
-  pos[1]=ypos[a.first]->data[a.second];
-  pos[2]=zpos[a.first]->data[a.second];
-  return pos;
-}
-
-void ActionAtomistic::setGlobalPosition(const std::pair<std::size_t, std::size_t>& a, const Vector& pos ) {
-  xpos[a.first]->data[a.second]=pos[0];
-  ypos[a.first]->data[a.second]=pos[1];
-  zpos[a.first]->data[a.second]=pos[2];
-}
-
 void ActionAtomistic::makeWhole() {
   for(unsigned j=0; j<positions.size()-1; ++j) {
     const Vector & first (positions[j]);

--- a/src/core/ActionAtomistic.cpp
+++ b/src/core/ActionAtomistic.cpp
@@ -112,10 +112,6 @@ void ActionAtomistic::requestAtoms(const std::vector<AtomNumber> & a, const bool
   unique_local_needs_update=true;
 }
 
-Vector ActionAtomistic::pbcDistance(const Vector &v1,const Vector &v2)const {
-  return pbc.distance(v1,v2);
-}
-
 void ActionAtomistic::pbcApply(std::vector<Vector>& dlist, unsigned max_index)const {
   pbc.apply(dlist, max_index);
 }

--- a/src/core/ActionAtomistic.h
+++ b/src/core/ActionAtomistic.h
@@ -287,6 +287,10 @@ void ActionAtomistic::addForce( const std::pair<std::size_t, std::size_t>& a, co
   zpos[a.first]->addForce( a.second, f[2] );
 }
 
+inline
+Vector ActionAtomistic::pbcDistance(const Vector &v1,const Vector &v2)const {
+  return pbc.distance(v1,v2);
+}
 
 }
 #endif

--- a/src/core/ActionAtomistic.h
+++ b/src/core/ActionAtomistic.h
@@ -26,6 +26,7 @@
 #include "tools/Tensor.h"
 #include "tools/Pbc.h"
 #include "tools/ForwardDecl.h"
+#include "Value.h"
 #include <vector>
 #include <map>
 
@@ -253,6 +254,23 @@ inline
 const std::vector<AtomNumber> & ActionAtomistic::getUniqueLocal() const {
   return unique_local;
 }
+
+inline
+Vector ActionAtomistic::getGlobalPosition(const std::pair<std::size_t,std::size_t>& a) const {
+  Vector pos;
+  pos[0]=xpos[a.first]->data[a.second];
+  pos[1]=ypos[a.first]->data[a.second];
+  pos[2]=zpos[a.first]->data[a.second];
+  return pos;
+}
+
+inline
+void ActionAtomistic::setGlobalPosition(const std::pair<std::size_t, std::size_t>& a, const Vector& pos ) {
+  xpos[a.first]->data[a.second]=pos[0];
+  ypos[a.first]->data[a.second]=pos[1];
+  zpos[a.first]->data[a.second]=pos[2];
+}
+
 
 }
 #endif

--- a/src/core/ActionAtomistic.h
+++ b/src/core/ActionAtomistic.h
@@ -271,6 +271,22 @@ void ActionAtomistic::setGlobalPosition(const std::pair<std::size_t, std::size_t
   zpos[a.first]->data[a.second]=pos[2];
 }
 
+inline
+Vector ActionAtomistic::getForce( const std::pair<std::size_t, std::size_t>& a ) const {
+  Vector f;
+  f[0]=xpos[a.first]->getForce(a.second);
+  f[1]=ypos[a.first]->getForce(a.second);
+  f[2]=zpos[a.first]->getForce(a.second);
+  return f;
+}
+
+inline
+void ActionAtomistic::addForce( const std::pair<std::size_t, std::size_t>& a, const Vector& f ) {
+  xpos[a.first]->addForce( a.second, f[0] );
+  ypos[a.first]->addForce( a.second, f[1] );
+  zpos[a.first]->addForce( a.second, f[2] );
+}
+
 
 }
 #endif

--- a/src/generic/FitToTemplate.cpp
+++ b/src/generic/FitToTemplate.cpp
@@ -329,9 +329,10 @@ void FitToTemplate::calculate() {
 }
 
 void FitToTemplate::apply() {
+  auto nat=getTotAtoms();
   if (type=="SIMPLE") {
     Vector totForce;
-    for(unsigned i=0; i<getTotAtoms(); i++) {
+    for(unsigned i=0; i<nat; i++) {
       std::pair<std::size_t,std::size_t> a = getValueIndices( AtomNumber::index(i));
       totForce+=getForce(a);
     }
@@ -340,7 +341,7 @@ void FitToTemplate::apply() {
     for(unsigned i=0; i<p_aligned.size(); ++i) { addForce( p_aligned[i], -totForce*weights[i]); }
   } else if ( type=="OPTIMAL" or type=="OPTIMAL-FAST") {
     Vector totForce;
-    for(unsigned i=0; i<getTotAtoms(); i++) {
+    for(unsigned i=0; i<nat; i++) {
       std::pair<std::size_t,std::size_t> a = getValueIndices( AtomNumber::index(i));
       Vector f=getForce(a);
 // rotate back forces


### PR DESCRIPTION
@gtribello I tried to optimize wholemolecules, it's mostly inlining stuff but you might want to check if I did things right.

What worries me a bit is that even with this impressive improvement (almost a factor 2) I am back to timings pre-htt. Here's my timing (no graphs, but it should be easy to understand):
```
pre htt: 00b63d594487f4445e7d6748ef65c246c7ce3173

PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
PLUMED:                                                    1     2.426496     2.426496     2.426496     2.426496
PLUMED: 1 Prepare dependencies                          2000     0.001444     0.000001     0.000000     0.000012
PLUMED: 2 Sharing data                                  2000     0.493404     0.000247     0.000217     0.001881
PLUMED: 3 Waiting for data                              2000     0.000590     0.000000     0.000000     0.000013
PLUMED: 4 Calculating (forward loop)                    2000     1.376356     0.000688     0.000623     0.002047
PLUMED: 5 Applying (backward loop)                      2000     0.452501     0.000226     0.000200     0.002366
PLUMED: 6 Update                                        2000     0.002034     0.000001     0.000000     0.000078

current master 05fb5480bd42a1d077f564c55460c0d0961469fd

PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
PLUMED:                                                    1     4.537703     4.537703     4.537703     4.537703
PLUMED: 1 Prepare dependencies                          2000     0.002650     0.000001     0.000001     0.000027
PLUMED: 2 Sharing data                                  2000     0.651106     0.000326     0.000256     0.003563
PLUMED: 3 Waiting for data                              2000     0.002185     0.000001     0.000000     0.000048
PLUMED: 4 Calculating (forward loop)                    2000     2.870725     0.001435     0.001229     0.009485
PLUMED: 5 Applying (backward loop)                      2000     0.890085     0.000445     0.000349     0.004437
PLUMED: 6 Update                                        2000     0.002864     0.000001     0.000001     0.000035

optimize-wholemolecules 2daf02676cba141417062cea84baec51590f8b70 

PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
PLUMED:                                                    1     2.434463     2.434463     2.434463     2.434463
PLUMED: 1 Prepare dependencies                          2000     0.001600     0.000001     0.000000     0.000065
PLUMED: 2 Sharing data                                  2000     0.494312     0.000247     0.000216     0.000901
PLUMED: 3 Waiting for data                              2000     0.000606     0.000000     0.000000     0.000008
PLUMED: 4 Calculating (forward loop)                    2000     1.387576     0.000694     0.000602     0.001377
PLUMED: 5 Applying (backward loop)                      2000     0.450181     0.000225     0.000197     0.002094
PLUMED: 6 Update                                        2000     0.002222     0.000001     0.000001     0.000013
```

This is my input file:
```
WHOLEMOLECULES ENTITY0=1-100000
pos: POSITION ATOM=1
RESTRAINT ARG=pos.x AT=0.0 KAPPA=1
```

So far so good, but previous @gtribello 's tests were reporting wholemolecules as being [faster in htt than in master](https://github.com/plumed/plumed2/pull/933#issuecomment-1879661884), whereas I see it slower by a factor ~ 2x (before this modifications).

Is there something that I am missing? I am doing my tests on an intel MacBook Pro.
