### PR TITLE
Removed call to set that is used in DomainDecomposition.

### DIFF
--- a/src/core/DomainDecomposition.cpp
+++ b/src/core/DomainDecomposition.cpp
@@ -349,8 +349,7 @@ void DomainDecomposition::share(const std::vector<AtomNumber>& unique) {
       for(int i=0; i<tot; i++) {
         int dpoint=0;
         for(unsigned j=0; j<values_to_get.size(); ++j) {
-          values_to_get[j]->set( dd.indexToBeReceived[i], dd.positionsToBeReceived[ndata*i+dpoint] );
-          dpoint++;
+          values_to_get[j]->data[dd.indexToBeReceived[i]] = dd.positionsToBeReceived[ndata*i+dpoint]; dpoint++;
         }
       }
     }


### PR DESCRIPTION
This addresses issues #1025 @GiovanniBussi

##### Description

This commit removes the call to set that is discussed in issue #1025.  I don't see that this making a noticeable difference to performance when compared with master but I am possibly not running on the correct setup.

![timings](https://github.com/plumed/plumed2/assets/4581364/518de104-13f4-4adf-9e6c-d4f92318bc5f)

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
