### PR TITLE
Mklib deprecation warning for "core/Atoms.h"

### DIFF
--- a/scripts/mklib.sh
+++ b/scripts/mklib.sh
@@ -59,17 +59,23 @@ do
   tmpfile=${tmpfile}.cpp
   cp "${file}" "${tmpfile}"
   toRemove="${toRemove} ${tmpfile} ${tmpfile}.bak"
-
+  #this deprecates the shortcut to action register
   if grep -q '^#include "\(bias\|colvar\|function\|sasa\|vatom\)\/ActionRegister.h"' "${tmpfile}"; then
      >&2 echo 'WARNING: using a legacy ActionRegister.h include path, please use <<#include "core/ActionRegister.h">>'
      sed -i.bak 's%^#include ".*/ActionRegister.h"%#include "core/ActionRegister.h"%g' "${tmpfile}"
   fi
-  
+  #this deprecates the shortcut to CLtoolregister
   if grep -q '^#include "\(cltools\)\/CLToolRegister.h"' "${tmpfile}"; then
      >&2  echo 'WARNING: using a legacy  CLToolRegister.h include path, please use <<#include "core/CLToolRegister.h">>'
      sed -i.bak 's%^#include ".*/CLToolRegister.h"%#include "core/CLToolRegister.h"%g' "${tmpfile}"
   fi
-  
+  #this removes "#include "core/Atoms.h" and makes the compilation failing on the calls of Atoms
+  #instead of on the include
+  if grep -q '^#include\s*"core/Atoms.h"' "${tmpfile}"; then
+     #\s match anly type of white space
+     >&2  echo 'WARNING: "core/Atoms.h" does not exist anymore in  version >=2.10, you should change your code.'
+     sed -i.bak '/^#include\s*"core\/Atoms.h"/d' "${tmpfile}"
+  fi
   rm -f "$obj"
 
   eval "$compile" "$PLUMED_MKLIB_CFLAGS" -o "$obj" "$tmpfile" || {


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

This should address the missing "core/Atoms.h" in the nest, more precisely  it will only state that the header is deprecated, and then make proceed the compilation until there is a failure on an `Atoms` method that does not exists anymore, this may guide to update easier some error in the nest.

I also patched the template cv, so that now it can compiled as it is generated by `plumed newcv`

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
