### PR TITLE
Replaced some bottleneck loop with blas

### DIFF
--- a/src/core/Makefile
+++ b/src/core/Makefile
@@ -1,4 +1,4 @@
-USE=config tools lepton small_vector
+USE=config tools lepton small_vector blas
 
 # generic makefile
 include ../maketools/make.module


### PR DESCRIPTION
I am working with this input file:
```
WHOLEMOLECULES ENTITY0=1-100000
c: CENTER ATOMS=1-100000
pos: POSITION ATOM=c
RESTRAINT ARG=pos.x AT=0.0 KAPPA=1
```

By just replacing a loop with a blas call I can see a significant gain. I only tried in my laptop, but I guess this could be quite general (when optimized blas are available).

Below the full results, comparing: v2.9, master before this commit, and master with this commit.
The slowdown wrt v2.9 is reduced from 26% to 18%


```
BENCH:  Kernel:      /Users/bussi/plumed2/tmp/v2.9-mpi-ref/lib/libplumedKernel.dylib
BENCH:  Input:       plumed.dat
BENCH:  Comparative: 1.000 +- 0.000
BENCH:                                                Cycles        Total      Average      Minimum      Maximum
BENCH:  A Initialization                                   1     0.162258     0.162258     0.162258     0.162258
BENCH:  B0 First step                                      1     0.008525     0.008525     0.008525     0.008525
BENCH:  B1 Warm-up                                        99     0.459748     0.004644     0.004194     0.008631
BENCH:  B2 Calculation part 1                            200     0.898147     0.004491     0.004087     0.004991
BENCH:  B3 Calculation part 2                            200     0.900684     0.004503     0.004103     0.005355
PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
PLUMED:                                                    1     2.426477     2.426477     2.426477     2.426477
PLUMED: 1 Prepare dependencies                           500     0.001066     0.000002     0.000001     0.000013
PLUMED: 2 Sharing data                                   500     0.142706     0.000285     0.000233     0.000956
PLUMED: 3 Waiting for data                               500     0.000290     0.000001     0.000000     0.000008
PLUMED: 4 Calculating (forward loop)                     500     1.655126     0.003310     0.002919     0.007286
PLUMED: 5 Applying (backward loop)                       500     0.457173     0.000914     0.000828     0.001423
PLUMED: 6 Update                                         500     0.000556     0.000001     0.000001     0.000012
BENCH:  
BENCH:  Kernel:      /Users/bussi/plumed2/tmp/reference/lib/libplumedKernel.dylib
BENCH:  Input:       plumed.dat
BENCH:  Comparative: 1.260 +- 0.004
BENCH:                                                Cycles        Total      Average      Minimum      Maximum
BENCH:  A Initialization                                   1     0.171702     0.171702     0.171702     0.171702
BENCH:  B0 First step                                      1     0.011417     0.011417     0.011417     0.011417
BENCH:  B1 Warm-up                                        99     0.569624     0.005754     0.005128     0.007905
BENCH:  B2 Calculation part 1                            200     1.135651     0.005678     0.005146     0.007376
BENCH:  B3 Calculation part 2                            200     1.130528     0.005653     0.005228     0.006545
PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
PLUMED:                                                    1     3.016210     3.016210     3.016210     3.016210
PLUMED: 1 Prepare dependencies                           500     0.001550     0.000003     0.000002     0.000018
PLUMED: 2 Sharing data                                   500     0.170590     0.000341     0.000289     0.000747
PLUMED: 3 Waiting for data                               500     0.001610     0.000003     0.000001     0.000048
PLUMED: 4 Calculating (forward loop)                     500     1.898306     0.003797     0.003423     0.008020
PLUMED: 5 Applying (backward loop)                       500     0.763545     0.001527     0.001363     0.002595
PLUMED: 6 Update                                         500     0.002246     0.000004     0.000003     0.000032
BENCH:  
BENCH:  Kernel:      /Users/bussi/plumed2/src/lib/libplumedKernel.dylib
BENCH:  Input:       plumed.dat
BENCH:  Comparative: 1.182 +- 0.004
BENCH:                                                Cycles        Total      Average      Minimum      Maximum
BENCH:  A Initialization                                   1     0.172252     0.172252     0.172252     0.172252
BENCH:  B0 First step                                      1     0.010180     0.010180     0.010180     0.010180
BENCH:  B1 Warm-up                                        99     0.533851     0.005392     0.004919     0.007108
BENCH:  B2 Calculation part 1                            200     1.063894     0.005319     0.004862     0.006318
BENCH:  B3 Calculation part 2                            200     1.062286     0.005311     0.004843     0.006118
PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
PLUMED:                                                    1     2.840387     2.840387     2.840387     2.840387
PLUMED: 1 Prepare dependencies                           500     0.001577     0.000003     0.000001     0.000011
PLUMED: 2 Sharing data                                   500     0.168367     0.000337     0.000287     0.000634
PLUMED: 3 Waiting for data                               500     0.001345     0.000003     0.000001     0.000012
PLUMED: 4 Calculating (forward loop)                     500     1.893861     0.003788     0.003393     0.007536
PLUMED: 5 Applying (backward loop)                       500     0.594073     0.001188     0.001054     0.002308
PLUMED: 6 Update                                         500     0.002268     0.000005     0.000003     0.000026
```

