### PR TITLE
Split list of forced actions from list of non-forced actions in domain decomposition

### DIFF
--- a/src/core/ActionAtomistic.cpp
+++ b/src/core/ActionAtomistic.cpp
@@ -201,6 +201,7 @@ bool ActionAtomistic::actionHasForces() {
   ActionWithValue* av = castToActionWithValue();
   if( av ) return !av->doNotCalculateDerivatives();
   if( indexes.size()>0 ) plumed_merror("you have to overwrite the function actionHasForce to tell plumed if you method applies forces");
+  return true;
 }
 
 void ActionAtomistic::parseAtomList(const std::string&key, std::vector<AtomNumber> &t) {

--- a/src/core/ActionAtomistic.cpp
+++ b/src/core/ActionAtomistic.cpp
@@ -197,6 +197,12 @@ void ActionAtomistic::calculateAtomicNumericalDerivatives( ActionWithValue* a, c
   }
 }
 
+bool ActionAtomistic::actionHasForces() {
+  ActionWithValue* av = castToActionWithValue();
+  if( av ) return !av->doNotCalculateDerivatives();
+  if( indexes.size()>0 ) plumed_merror("you have to overwrite the function actionHasForce to tell plumed if you method applies forces");
+}
+
 void ActionAtomistic::parseAtomList(const std::string&key, std::vector<AtomNumber> &t) {
   parseAtomList(key,-1,t);
 }

--- a/src/core/ActionAtomistic.h
+++ b/src/core/ActionAtomistic.h
@@ -188,6 +188,7 @@ public:
 /// Transfer the gradients
   void getGradient( const unsigned& ind, Vector& deriv, std::map<AtomNumber,Vector>& gradients ) const ;
   ActionAtomistic* castToActionAtomistic() noexcept final { return this; }
+  virtual bool actionHasForces();
 };
 
 inline

--- a/src/core/DomainDecomposition.cpp
+++ b/src/core/DomainDecomposition.cpp
@@ -211,7 +211,7 @@ void DomainDecomposition::setAtomsGatindex(const TypesafePtr & g,bool fortran) {
   for(unsigned i=0; i<gatindex.size(); i++) g2l[gatindex[i]]=i;
   // keep in unique only those atoms that are local
   for(unsigned i=0; i<actions.size(); i++) actions[i]->unique_local_needs_update=true;
-  unique.clear();
+  unique.clear(); forced_unique.clear();
 }
 
 void DomainDecomposition::setAtomsContiguous(int start) {
@@ -222,17 +222,19 @@ void DomainDecomposition::setAtomsContiguous(int start) {
   if(gatindex.size()<getNumberOfAtoms()) shuffledAtoms=1;
   // keep in unique only those atoms that are local
   for(unsigned i=0; i<actions.size(); i++) actions[i]->unique_local_needs_update=true;
-  unique.clear();
+  unique.clear(); forced_unique.clear();
 }
 
 void DomainDecomposition::shareAll() {
-  unique.clear(); int natoms = getNumberOfAtoms();
+  unique.clear(); forced_unique.clear(); int natoms = getNumberOfAtoms();
   if( dd && shuffledAtoms>0 ) {
     for(int i=0; i<natoms; ++i) if( g2l[i]>=0 ) unique.push_back( AtomNumber::index(i) );
   } else {
     unique.resize(natoms);
     for(int i=0; i<natoms; i++) unique[i]=AtomNumber::index(i);
   }
+  forced_unique.resize( unique.size() );
+  for(unsigned i=0; i<unique.size(); ++i) forced_unique[i] = unique[i];
   share(unique);
 }
 
@@ -270,19 +272,29 @@ void DomainDecomposition::share() {
       if( actions[i]->unique_local_needs_update ) actions[i]->updateUniqueLocal( !(dd && shuffledAtoms>0), g2l );
     }
     // Now reset unique for the new step
-    gch::small_vector<const std::vector<AtomNumber>*,32> vectors;
-    vectors.reserve(actions.size());
+    gch::small_vector<const std::vector<AtomNumber>*,32> forced_vectors;
+    gch::small_vector<const std::vector<AtomNumber>*,32> nonforced_vectors;
+    forced_vectors.reserve(actions.size()); nonforced_vectors.reserve(actions.size());
     for(unsigned i=0; i<actions.size(); i++) {
       if(actions[i]->isActive()) {
         if(!actions[i]->getUnique().empty()) {
           // unique are the local atoms
-          vectors.push_back(&actions[i]->getUniqueLocal());
+          if( actions[i]->actionHasForces() ) forced_vectors.push_back(&actions[i]->getUniqueLocal());
+          else nonforced_vectors.push_back(&actions[i]->getUniqueLocal());
         }
       }
     }
-    if(!vectors.empty()) atomsNeeded=true;
-    unique.clear();
-    mergeVectorTools::mergeSortedVectors(vectors.data(),vectors.size(),unique);
+    if( !(forced_vectors.empty() && nonforced_vectors.empty()) ) atomsNeeded=true;
+    // Merge the atoms from the atoms that have a force on
+    forced_unique.clear();
+    mergeVectorTools::mergeSortedVectors(forced_vectors.data(),forced_vectors.size(),forced_unique);
+    // Merge the atoms from the actions that don't apply forces
+    std::vector<AtomNumber> nonforced_unique;
+    mergeVectorTools::mergeSortedVectors(nonforced_vectors.data(),nonforced_vectors.size(),nonforced_unique);
+    // Get unique by merging the forced and unforced atoms
+    unique.clear(); gch::small_vector<const std::vector<AtomNumber>*,32> allvectors; allvectors.reserve(2);
+    allvectors.push_back(&forced_unique); allvectors.push_back(&nonforced_unique);
+    mergeVectorTools::mergeSortedVectors(allvectors.data(),allvectors.size(),unique);
   } else {
     for(unsigned i=0; i<actions.size(); i++) {
       if(actions[i]->isActive()) {
@@ -401,12 +413,18 @@ unsigned DomainDecomposition::getNumberOfForcesToRescale() const {
 }
 
 void DomainDecomposition::apply() {
+  std::vector<unsigned> forced_uniq_index(forced_unique.size());
+  if(!(int(gatindex.size())==getNumberOfAtoms() && shuffledAtoms==0)) {
+    for(unsigned i=0; i<forced_unique.size(); i++) forced_uniq_index[i]=g2l[forced_unique[i].index()];
+  } else {
+    for(unsigned i=0; i<forced_unique.size(); i++) forced_uniq_index[i]=forced_unique[i].index();
+  }
   for(const auto & ip : inputs) {
     if( !(ip->getPntrToValue())->forcesWereAdded() || ip->noforce ) {
       continue;
     } else if( ip->wasscaled || (!unique_serial && int(gatindex.size())==getNumberOfAtoms() && shuffledAtoms==0) ) {
       (ip->mydata)->add_force( gatindex, ip->getPntrToValue() );
-    } else { (ip->mydata)->add_force( unique, uniq_index, ip->getPntrToValue() ); }
+    } else { (ip->mydata)->add_force( forced_unique, forced_uniq_index, ip->getPntrToValue() ); }
   }
 }
 

--- a/src/core/DomainDecomposition.cpp
+++ b/src/core/DomainDecomposition.cpp
@@ -286,15 +286,11 @@ void DomainDecomposition::share() {
     }
     if( !(forced_vectors.empty() && nonforced_vectors.empty()) ) atomsNeeded=true;
     // Merge the atoms from the atoms that have a force on
-    forced_unique.clear();
+    unique.clear(); forced_unique.clear(); 
     mergeVectorTools::mergeSortedVectors(forced_vectors.data(),forced_vectors.size(),forced_unique);
-    // Merge the atoms from the actions that don't apply forces
-    std::vector<AtomNumber> nonforced_unique;
-    mergeVectorTools::mergeSortedVectors(nonforced_vectors.data(),nonforced_vectors.size(),nonforced_unique);
-    // Get unique by merging the forced and unforced atoms
-    unique.clear(); gch::small_vector<const std::vector<AtomNumber>*,32> allvectors; allvectors.reserve(2);
-    allvectors.push_back(&forced_unique); allvectors.push_back(&nonforced_unique);
-    mergeVectorTools::mergeSortedVectors(allvectors.data(),allvectors.size(),unique);
+    // Merge all the atoms
+    nonforced_vectors.push_back( &forced_unique );
+    mergeVectorTools::mergeSortedVectors(nonforced_vectors.data(),nonforced_vectors.size(),unique);
   } else {
     for(unsigned i=0; i<actions.size(); i++) {
       if(actions[i]->isActive()) {

--- a/src/core/DomainDecomposition.cpp
+++ b/src/core/DomainDecomposition.cpp
@@ -286,7 +286,7 @@ void DomainDecomposition::share() {
     }
     if( !(forced_vectors.empty() && nonforced_vectors.empty()) ) atomsNeeded=true;
     // Merge the atoms from the atoms that have a force on
-    unique.clear(); forced_unique.clear(); 
+    unique.clear(); forced_unique.clear();
     mergeVectorTools::mergeSortedVectors(forced_vectors.data(),forced_vectors.size(),forced_unique);
     // Merge all the atoms
     nonforced_vectors.push_back( &forced_unique );

--- a/src/core/DomainDecomposition.h
+++ b/src/core/DomainDecomposition.h
@@ -66,6 +66,8 @@ private:
 /// This holds the list of unique atoms
   std::vector<AtomNumber> unique;
   std::vector<unsigned> uniq_index;
+/// This holds the list of atoms that have a force on
+  std::vector<AtomNumber> forced_unique;
 /// This holds the list of actions that are set from this action
   std::vector<ActionToPutData*> inputs;
 /// This holds all the actions that read atoms

--- a/src/generic/DumpAtoms.cpp
+++ b/src/generic/DumpAtoms.cpp
@@ -138,6 +138,7 @@ public:
   ~DumpAtoms();
   static void registerKeywords( Keywords& keys );
   void calculateNumericalDerivatives( ActionWithValue* a=NULL ) override;
+  bool actionHasForces() override { return false; }
   void lockRequests() override;
   void unlockRequests() override;
   void calculate() override {}

--- a/src/generic/DumpMassCharge.cpp
+++ b/src/generic/DumpMassCharge.cpp
@@ -86,6 +86,7 @@ public:
   explicit DumpMassCharge(const ActionOptions&);
   ~DumpMassCharge();
   static void registerKeywords( Keywords& keys );
+  bool actionHasForces() override { return false; }
   void prepare() override;
   void calculate() override {}
   void apply() override {}

--- a/src/generic/FitToTemplate.cpp
+++ b/src/generic/FitToTemplate.cpp
@@ -194,6 +194,7 @@ class FitToTemplate:
 public:
   explicit FitToTemplate(const ActionOptions&ao);
   static void registerKeywords( Keywords& keys );
+  bool actionHasForces() override { return true; }
   void calculate() override;
   void apply() override;
   unsigned getNumberOfDerivatives() override {plumed_merror("You should not call this function");};

--- a/src/generic/Plumed.cpp
+++ b/src/generic/Plumed.cpp
@@ -168,6 +168,7 @@ public:
   unsigned getNumberOfDerivatives() override {
     return 0;
   }
+  bool actionHasForces() override { return true; }
 };
 
 PLUMED_REGISTER_ACTION(Plumed,"PLUMED")

--- a/src/generic/PrintNDX.cpp
+++ b/src/generic/PrintNDX.cpp
@@ -50,6 +50,7 @@ public:
   std::string writeInGraph() const override;
   explicit PrintNDX(const ActionOptions&);
   static void registerKeywords(Keywords& keys);
+  bool actionHasForces() override { return false; }
   void calculateNumericalDerivatives( ActionWithValue* a=NULL ) override { plumed_error(); }
   void lockRequests() override;
   void unlockRequests() override;

--- a/src/generic/WholeMolecules.cpp
+++ b/src/generic/WholeMolecules.cpp
@@ -110,6 +110,7 @@ class WholeMolecules:
 public:
   explicit WholeMolecules(const ActionOptions&ao);
   static void registerKeywords( Keywords& keys );
+  bool actionHasForces() override { return false; }
   void calculate() override;
   void apply() override {}
 };

--- a/src/generic/WrapAround.cpp
+++ b/src/generic/WrapAround.cpp
@@ -156,6 +156,7 @@ class WrapAround:
 public:
   explicit WrapAround(const ActionOptions&ao);
   static void registerKeywords( Keywords& keys );
+  bool actionHasForces() override { return false; }
   void calculate() override;
   void apply() override {}
 };


### PR DESCRIPTION


##### Description

This is my try at the rework of the stuff for speeding up the applying of forces in domain decomposition.  I have tried to do  this in the way we discussed in the meeting on Wednesday.  You can see it speeds up the ally force part.  However, the sharing of data is slowed down.  I think this may because I have not made the changes to DomainDecomposition correctly.

Can you take a look @GiovanniBussi and let me know if I am doing anything wrong.

````
BENCH:  Kernel:      this
BENCH:  Input:       plumed.dat
BENCH:  Comparative: 1.000 +- 0.000
BENCH:                                                Cycles        Total      Average      Minimum      Maximum
BENCH:  A Initialization                                   1     0.006875     0.006875     0.006875     0.006875
BENCH:  B0 First step                                      1     0.000716     0.000716     0.000716     0.000716
BENCH:  B1 Warm-up                                       399     0.093572     0.000235     0.000223     0.000263
BENCH:  B2 Calculation part 1                            800     0.188908     0.000236     0.000228     0.000284
BENCH:  B3 Calculation part 2                            800     0.190237     0.000238     0.000229     0.000285
PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
PLUMED:                                                    1     0.479767     0.479767     0.479767     0.479767
PLUMED: 1 Prepare dependencies                          2000     0.000242     0.000000     0.000000     0.000009
PLUMED: 2 Sharing data                                  2000     0.193900     0.000097     0.000091     0.000266
PLUMED: 3 Waiting for data                              2000     0.000633     0.000000     0.000000     0.000005
PLUMED: 4 Calculating (forward loop)                    2000     0.256157     0.000128     0.000120     0.000165
PLUMED: 5 Applying (backward loop)                      2000     0.001365     0.000001     0.000000     0.000293
PLUMED: 6 Update                                        2000     0.000811     0.000000     0.000000     0.000006
BENCH:  
BENCH:  Kernel:      libplumedKernel.dylib
BENCH:  Input:       plumed.dat
BENCH:  Comparative: 0.947 +- 0.001
BENCH:                                                Cycles        Total      Average      Minimum      Maximum
BENCH:  A Initialization                                   1     0.006509     0.006509     0.006509     0.006509
BENCH:  B0 First step                                      1     0.000614     0.000614     0.000614     0.000614
BENCH:  B1 Warm-up                                       399     0.088491     0.000222     0.000212     0.000267
BENCH:  B2 Calculation part 1                            800     0.178787     0.000223     0.000216     0.000275
BENCH:  B3 Calculation part 2                            800     0.180250     0.000225     0.000216     0.000264
PLUMED:                                               Cycles        Total      Average      Minimum      Maximum
PLUMED:                                                    1     0.453969     0.453969     0.453969     0.453969
PLUMED: 1 Prepare dependencies                          2000     0.000310     0.000000     0.000000     0.000010
PLUMED: 2 Sharing data                                  2000     0.118912     0.000059     0.000056     0.000223
PLUMED: 3 Waiting for data                              2000     0.000627     0.000000     0.000000     0.000014
PLUMED: 4 Calculating (forward loop)                    2000     0.256020     0.000128     0.000121     0.000179
PLUMED: 5 Applying (backward loop)                      2000     0.050735     0.000025     0.000024     0.000236
PLUMED: 6 Update                                        2000     0.000820     0.000000     0.000000     0.000014
````

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
