### PR TITLE
deactivate restart during parse only runs

### DIFF
--- a/src/cltools/Driver.cpp
+++ b/src/cltools/Driver.cpp
@@ -513,7 +513,7 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
     if( !Communicator::initialized() ) error("needs mpi for debug-pd");
   }
 
-  PlumedMain p;
+  PlumedMain p; if( parseOnly ) p.activateParseOnlyMode();
   p.cmd("setRealPrecision",(int)sizeof(real));
   int checknatoms=-1;
   long long int step=0;

--- a/src/core/Action.cpp
+++ b/src/core/Action.cpp
@@ -91,7 +91,8 @@ Action::Action(const ActionOptions&ao):
   if ( keywords.exists("RESTART") ) {
     std::string srestart="AUTO";
     parse("RESTART",srestart);
-    if(srestart=="YES") restart=true;
+    if( plumed.parseOnlyMode() ) restart=false;
+    else if(srestart=="YES") restart=true;
     else if(srestart=="NO")  restart=false;
     else if(srestart=="AUTO") {
       // do nothing, this is the default
@@ -195,10 +196,6 @@ void Action::clearOptions() {
 
 void Action::clearDependencies() {
   after.clear();
-}
-
-std::string Action::getDocumentation()const {
-  return std::string("UNDOCUMENTED ACTION");
 }
 
 void Action::checkRead() {

--- a/src/core/Action.h
+++ b/src/core/Action.h
@@ -230,8 +230,6 @@ public:
 /// Tell to the Action to flush open files
   void fflush();
 
-  virtual std::string getDocumentation()const;
-
 /// Returns the label
   const std::string & getLabel()const;
 
@@ -309,11 +307,6 @@ const std::string & Action::getName()const {
 
 template<class T>
 void Action::parse(const std::string&key,T&t) {
-//  if(!Tools::parse(line,key,t)){
-//    log.printf("ERROR parsing keyword %s\n",key.c_str());
-//    log.printf("%s\n",getDocumentation().c_str());
-//    this->exit(1);
-//  }
   // Check keyword has been registered
   plumed_massert(keywords.exists(key),"keyword " + key + " has not been registered");
 
@@ -349,12 +342,6 @@ bool Action::parseNumbered(const std::string&key, const int no, T&t) {
 
 template<class T>
 void Action::parseVector(const std::string&key,std::vector<T>&t) {
-//  if(!Tools::parseVector(line,key,t)){
-//    log.printf("ERROR parsing keyword %s\n",key.c_str());
-//    log.printf("%s\n",getDocumentation().c_str());
-//    this->exit(1);
-//  }
-
   // Check keyword has been registered
   plumed_massert(keywords.exists(key), "keyword " + key + " has not been registered");
   unsigned size=t.size(); bool skipcheck=false;

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -207,6 +207,7 @@ PlumedMain::PlumedMain():
   exchangeStep(false),
   restart(false),
   doCheckPoint(false),
+  doParseOnly(false),
   stopNow(false),
   novirial(false),
   detailedTimers(false),
@@ -1144,6 +1145,14 @@ unsigned PlumedMain::decreaseReferenceCounter() noexcept {
 
 unsigned PlumedMain::useCountReferenceCounter() const noexcept {
   return referenceCounter;
+}
+
+void PlumedMain::activateParseOnlyMode() {
+  doParseOnly=true;
+}
+
+bool PlumedMain::parseOnlyMode() const {
+  return doParseOnly;
 }
 
 #ifdef __PLUMED_HAS_PYTHON

--- a/src/core/PlumedMain.h
+++ b/src/core/PlumedMain.h
@@ -404,7 +404,7 @@ public:
 /// Check if restarting
   bool getRestart()const;
 /// Set restart flag
-  void setRestart(bool f) {restart=f;}
+  void setRestart(bool f) {if(!doParseOnly) restart=f;}
 /// Check if checkpointing
   bool getCPT()const;
 /// Set exchangeStep flag

--- a/src/core/PlumedMain.h
+++ b/src/core/PlumedMain.h
@@ -195,6 +195,9 @@ private:
 /// Flag for checkpointig
   bool doCheckPoint;
 
+/// Flag for parse only mode -- basically just forces restart to turn off
+  bool doParseOnly;
+
 private:
 /// Forward declaration.
   ForwardDecl<TypesafePtr> stopFlag_fwd;
@@ -251,6 +254,15 @@ public:
   */
   void cmd(const std::string&key,const TypesafePtr & val=nullptr) override;
   ~PlumedMain();
+  /**
+    Turn on parse only mode to deactivate restart in all actions.
+    This is only used by plumed driver --parse-only
+  */
+  void activateParseOnlyMode();
+  /**
+    This checks if parse only mode is active and turns off any restart.
+  */
+  bool parseOnlyMode() const ;
   /**
     Read an input file.
     \param str name of the file

--- a/src/setup/Restart.cpp
+++ b/src/setup/Restart.cpp
@@ -114,7 +114,7 @@ Restart::Restart(const ActionOptions&ao):
     if(md) log<<"  Switching off restart\n";
     plumed.setRestart(false);
     log<<"  Not restarting simulation: files will be backed up\n";
-  } else if( !plumed.parseOnlyMode() ) {
+  } else {
     if(!md) log<<"  Switching on restart\n";
     plumed.setRestart(true);
     log<<"  Restarting simulation: files will be appended\n";

--- a/src/setup/Restart.cpp
+++ b/src/setup/Restart.cpp
@@ -114,7 +114,7 @@ Restart::Restart(const ActionOptions&ao):
     if(md) log<<"  Switching off restart\n";
     plumed.setRestart(false);
     log<<"  Not restarting simulation: files will be backed up\n";
-  } else {
+  } else if( !plumed.parseOnlyMode() ) {
     if(!md) log<<"  Switching on restart\n";
     plumed.setRestart(true);
     log<<"  Restarting simulation: files will be appended\n";


### PR DESCRIPTION
##### Description

As discussed in the meeting today, if we make this change many eggs in the nest will pass as the problem with them is that people have upload a PLUMED input file that has RESTART in it but no hills file.  If we thus suppress RESTART when we run parse-only mode the tests should pass.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.9

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
