### PR TITLE
Optimized EMST setup

### DIFF
--- a/src/tools/Tree.cpp
+++ b/src/tools/Tree.cpp
@@ -49,13 +49,19 @@ std::vector<AtomNumber> Tree::getTree(std::vector<AtomNumber> atoms)
   // clear root_ vector
   root_.clear();
 
+  std::vector<Vector> positions;
+
   // remove atoms not in PDB file
   std::vector<AtomNumber> addtotree, addtoroot;
   std::vector<AtomNumber> newatoms;
   newatoms.reserve(atoms.size());
+  positions.reserve(atoms.size());
+  tree.reserve(atoms.size());
+  root_.reserve(atoms.size());
   if(!moldat_->checkForAtom(atoms[0])) plumed_merror("The first atom in the list should be present in the PDB file");
   // store first atom
   newatoms.push_back(atoms[0]);
+  positions.push_back(moldat_->getPosition(atoms[0]));
   for(unsigned i=1; i<atoms.size(); ++i) {
     if(!moldat_->checkForAtom(atoms[i])) {
       // store this atom for later
@@ -64,6 +70,7 @@ std::vector<AtomNumber> Tree::getTree(std::vector<AtomNumber> atoms)
       addtoroot.push_back(atoms[i-1]);
     } else {
       newatoms.push_back(atoms[i]);
+      positions.push_back(moldat_->getPosition(atoms[i]));
     }
   }
   // reassign atoms
@@ -88,7 +95,7 @@ std::vector<AtomNumber> Tree::getTree(std::vector<AtomNumber> atoms)
     double minroot = std::numeric_limits<double>::max();
     int iroot = -1;
     for(unsigned j=0; j<atoms.size(); ++j) {
-      double dist = delta(moldat_->getPosition(atoms[selected_vertex]), moldat_->getPosition(atoms[j])).modulo2();
+      double dist = delta(positions[selected_vertex], positions[j]).modulo2();
       if(dist < mindist[j]) mindist[j] = dist;
       if(dist < minroot && intree[j] && dist>0.0) {
         minroot = dist;


### PR DESCRIPTION
Avoid doing searches by atom number in the PDB for every distance calculation. 

Only relevant for startup, not for the following calculation, but given the scaling of the EMST calculation with the number of atoms I think it's relevant. I didn't make precise timings, but my understanding is that:

- before this, time scales as `N_wholemolecules * N_wholemolecules * log(N_PDB)`
- after this, time scales as `N_wholemolecules * N_wholemolecules`

The additional `*log(N_PDB)` comes from the need to search the index of each atoms in the PDB in the inner loop. 

I tested on this input:

```
MOLINFO STRUCTURE=1s72.pdb WHOLE # big PDB with ~ 90k atoms
WHOLEMOLECULES ENTITY0=1-100000 EMST
```

Startup time decreases from ~ 12 minutes to ~ 25 seconds. 

@maxbonomi let me know if you have any concerns with merging this



##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.10__
