### PR TITLE
Benchmark distributions

### DIFF
--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -261,7 +261,7 @@ struct Kernel :
   }
 };
 
-namespace benchDistributions {
+namespace  {
 
 class UniformSphericalVector {
   //double rminCub;
@@ -409,7 +409,7 @@ struct tiledSimpleCubic:public AtomDistribution {
 
   }
 };
-std::unique_ptr<AtomDistribution> getDistribution(std::string_view atomicDistr) {
+std::unique_ptr<AtomDistribution> getAtomDistribution(std::string_view atomicDistr) {
   std::unique_ptr<AtomDistribution> distribution;
   if(atomicDistr == "line") {
     distribution = std::make_unique<theLine>();
@@ -427,7 +427,7 @@ std::unique_ptr<AtomDistribution> getDistribution(std::string_view atomicDistr) 
   }
   return distribution;
 }
-} //namespace  benchDistributions
+} //anonymus namespace for benchmark distributions
 class Benchmark:
   public CLTool
 {
@@ -466,7 +466,7 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
   // deterministic initializations to avoid issues with MPI
   generator rng;
   PLMD::Random atomicGenerator;
-  std::unique_ptr<benchDistributions::AtomDistribution> distribution;
+  std::unique_ptr<AtomDistribution> distribution;
 
   struct FileDeleter {
     void operator()(FILE*f) const noexcept {
@@ -645,7 +645,7 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
   {
     std::string atomicDistr;
     parse("--atom-distribution",atomicDistr);
-    distribution = benchDistributions::getDistribution(atomicDistr);
+    distribution = getAtomDistribution(atomicDistr);
   }
 
   const auto initial_time=std::chrono::high_resolution_clock::now();

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -495,7 +495,7 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
     if(f->empty()) {
       return;
     }
-    generator deleterRng;
+    generator bootstrapRng;
 
     const auto size=f->back().timings.size();
     //B are the bootstrap iterations
@@ -540,7 +540,7 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
 
         //B are the bootstrap iterations
         for(unsigned b=0; b<B; b++) {
-          for(auto & c : choice) c=distrib(deleterRng);
+          for(auto & c : choice) c=distrib(bootstrapRng);
           long long int reference=0;
           for(auto & c : choice) {
             reference+=blocks[0][c];
@@ -548,7 +548,7 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
           for(auto i=0ULL; i<blocks.size(); i++) {
             long long int estimate=0;
             // this would lead to separate bootstrap samples for each estimate:
-            // for(auto & c : choice){c=distrib(deleterRng);}
+            // for(auto & c : choice){c=distrib(bootstrapRng);}
             for(auto & c : choice) {
               estimate+=blocks[i][c];
             }

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -263,10 +263,10 @@ struct Kernel :
 
 namespace benchDistributions {
 
-  class UniformSphericalVector {
-    //double rminCub;
-    double rCub;
-    
+class UniformSphericalVector {
+  //double rminCub;
+  double rCub;
+
 public:
   //assuming rmin=0
   UniformSphericalVector(const double rmax):
@@ -294,9 +294,9 @@ struct theLine:public AtomDistribution {
   void positions(std::vector<Vector>& posToUpdate, unsigned step, Random&rng) override {
     auto nat = posToUpdate.size();
     UniformSphericalVector usv(0.5);
-    // enough to overcome the cost of the vtable that I added
-    for (unsigned i=0; i<nat; ++i) {  
-posToUpdate[i] = Vector(i, 0, 0) + usv(rng);
+
+    for (unsigned i=0; i<nat; ++i) {
+      posToUpdate[i] = Vector(i, 0, 0) + usv(rng);
     }
   }
 };
@@ -330,7 +330,7 @@ struct twoGlobs: public AtomDistribution {
   virtual void positions(std::vector<Vector>& posToUpdate, unsigned /*step*/, Random&rng) {
     //I am using two unigform spheres and 2V=n
     const double rmax= std::cbrt ((3.0/(8.0*PLMD::pi)) * posToUpdate.size());
-    
+
     UniformSphericalVector usv(rmax);
     std::array<Vector,2> centers{
       PLMD::Vector{0.0,0.0,0.0},
@@ -338,11 +338,10 @@ struct twoGlobs: public AtomDistribution {
       PLMD::Vector{2.0*rmax,2.0*rmax,2.0*rmax}
     };
     std::generate(posToUpdate.begin(),posToUpdate.end(),[&]() {
+      //RandInt is only declared
+      // return usv (rng) + centers[rng.RandInt(1)];
       return usv (rng) + centers[rng.RandU01()>0.5];
     });
-    // std::generate(posToUpdate.begin(),posToUpdate.end(),[&]() {
-    //   return usv (rng) + centers[rng.RandInt(1)];
-    // });
   }
 
   virtual void box(std::vector<double>& box, unsigned natoms, unsigned /*step*/, Random&) {
@@ -358,8 +357,8 @@ struct uniformCube:public AtomDistribution {
   void positions(std::vector<Vector>& posToUpdate, unsigned /*step*/, Random& rng) override {
     //giving more or less a cubic udm of volume for each atom: V = nat
     const double rmax = std::cbrt(static_cast<double>(posToUpdate.size()));
-    
-    
+
+
 
     // std::generate(posToUpdate.begin(),posToUpdate.end(),[&]() {
     //   return Vector (rndR(rng),rndR(rng),rndR(rng));
@@ -393,9 +392,9 @@ struct tiledSimpleCubic:public AtomDistribution {
     auto e=posToUpdate.end();
     //I am using the iterators:this is slightly faster,
     // enough to overcome the cost of the vtable that I added
-    for (unsigned k=0; k<rmax; ++k) {
-      for (unsigned j=0; j<rmax; ++j) {
-        for (unsigned i=0; i<rmax; ++i) {
+    for (unsigned k=0; k<rmax&&s!=e; ++k) {
+      for (unsigned j=0; j<rmax&&s!=e; ++j) {
+        for (unsigned i=0; i<rmax&&s!=e; ++i) {
           *s = Vector (i,j,k);
           ++s;
         }
@@ -403,7 +402,6 @@ struct tiledSimpleCubic:public AtomDistribution {
     }
   }
   void box(std::vector<double>& box, unsigned natoms, unsigned /*step*/, Random&) override {
-    //+0.05 to avoid overlap
     const double rmax= std::ceil(std::cbrt(static_cast<double>(natoms)));;
     box[0]=rmax; box[1]=0.0;  box[2]=0.0;
     box[3]=0.0;  box[4]=rmax; box[5]=0.0;
@@ -423,6 +421,9 @@ std::unique_ptr<AtomDistribution> getDistribution(std::string_view atomicDistr) 
     distribution = std::make_unique<twoGlobs>();
   } else if (atomicDistr == "sc") {
     distribution = std::make_unique<tiledSimpleCubic>();
+  } else {
+    plumed_error() << R"(The atomic distribution can be only "line", "cube", "sphere", "globs" and "sc", the input was ")"
+                   << atomicDistr <<'"';
   }
   return distribution;
 }

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -341,7 +341,8 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
     generator deleterRng;
 
     const auto size=f->back().timings.size();
-    constexpr int bootstrapIterations=200;
+    //B are the bootstrap iterations
+    constexpr int B=200;
     const size_t numblocks=size;
     // for some reasons, blocked bootstrap underestimates error
     // For now I keep it off. If I remove it, the code below could be simplified
@@ -376,10 +377,12 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
 
         std::vector<std::vector<double>> ratios(f->size());
         for(auto & r : ratios) {
-          r.resize(bootstrapIterations);
+          //B are the bootstrap iterations
+          r.resize(B);
         }
 
-        for(unsigned b=0; b<bootstrapIterations; b++) {
+        //B are the bootstrap iterations
+        for(unsigned b=0; b<B; b++) {
           for(auto & c : choice) c=distrib(deleterRng);
           long long int reference=0;
           for(auto & c : choice) {
@@ -405,8 +408,9 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
               sum+=r;
               sum2+=r*r;
             }
-            it->comparative_timing=sum/bootstrapIterations;
-            it->comparative_timing_error=std::sqrt(sum2/bootstrapIterations-sum*sum/(bootstrapIterations*bootstrapIterations));
+            //B are the bootstrap iterations
+            it->comparative_timing=sum/B;
+            it->comparative_timing_error=std::sqrt(sum2/B-sum*sum/(B*B));
           }
         }
 

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -431,7 +431,6 @@ std::unique_ptr<AtomDistribution> getDistribution(std::string_view atomicDistr) 
 class Benchmark:
   public CLTool
 {
-  std::unique_ptr<benchDistributions::AtomDistribution> distribution;
 public:
   static void registerKeywords( Keywords& keys );
   explicit Benchmark(const CLToolOptions& co );
@@ -464,9 +463,11 @@ Benchmark::Benchmark(const CLToolOptions& co ):
 
 
 int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
-
-  generator rng; // deterministic initialization to avoid issues with MPI
+  // deterministic initializations to avoid issues with MPI
+  generator rng;
   PLMD::Random atomicGenerator;
+  std::unique_ptr<benchDistributions::AtomDistribution> distribution;
+
   struct FileDeleter {
     void operator()(FILE*f) const noexcept {
       if(f) std::fclose(f);


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

I did some modification to the Benchmark.
After removing a few warnings and adding some `const`, I added a few options for the "simulated atoms" and changed how existing one, "the line", works.

The options that I added are:
- *an uniform distributed cube*
- *an uniform distributed sphere*
- *two uniform distributed sphere that should not touch each other*
- *a static "simple cubic"* distribution

the distributed ones are randomly generated at each step, so I think that are not suited to test a neigbour list
the simple cubic do not change with advancing steps, but I may add to it a way to make the atoms "oscillate" around their positions

The original line was adjusted from 
```c++
for(unsigned j=0; j<natoms; ++j)
  pos[j] = Vector(step*j, step*j+1, step*j+2);
```
to
```c++
for(unsigned j=0; j<natoms; ++j)
  pos[j] = Vector(j,0,0)+oscillation(step);
```
because the first version produces on step 0 all atoms in the same `(0,1,2)` position, and then a series of atoms each one at distance `(s,s,s)` from the previous one, where `s` is the current step number, and this brings some actions, like COORDINATION, to skip the costly part of the calculation.
I think keeping "the line" is important to check that that component in some actions works.

These modifications also add a "contract" with the user: the uniformly distributed configuration are made such that in average each atom has a volume of 1: with `nat` being the number of atoms, the volume of the cube is `nat`, the volume of the sphere is `nat` and the sum of the volumes of the two spheres is again `nat`.
Similarly the atoms on the line oscillate on a linear grid with step `1` and the `a` for the grid of the simple cubic is `1`.

All the distribution, except from the line now return a box.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->


---

unrelated: `Random::RandInt` is declared, but not implemented