### PR TITLE
Added a simple module map

### DIFF
--- a/regtest/basic/rt-make-moduleMap/Makefile
+++ b/regtest/basic/rt-make-moduleMap/Makefile
@@ -1,0 +1,1 @@
+include ../../scripts/test.make

--- a/regtest/basic/rt-make-moduleMap/config
+++ b/regtest/basic/rt-make-moduleMap/config
@@ -1,0 +1,1 @@
+type=make

--- a/regtest/basic/rt-make-moduleMap/main.cpp
+++ b/regtest/basic/rt-make-moduleMap/main.cpp
@@ -1,0 +1,19 @@
+#include "plumed/core/ModuleMap.h"
+#include "plumed/core/ActionRegister.h"
+
+#include <fstream>
+
+
+int main(){
+  const auto actionList=PLMD::actionRegister().getActionNames();
+  //just checking that all the default-registered actions are in the module map;
+  //output should be empty, the diff will be clear
+  //this test may break in case of adding a new LOAD mechanism on startup
+  std::ofstream file("output");
+  for (const auto & name: actionList){
+    if(PLMD::getModuleMap().count(name)==0){
+      file << name << "is not in the ModuleMap\n";
+    }
+  }
+  return 0;
+}

--- a/regtest/basic/rt-make-moduleMap/main.cpp
+++ b/regtest/basic/rt-make-moduleMap/main.cpp
@@ -12,7 +12,7 @@ int main(){
   std::ofstream file("output");
   for (const auto & name: actionList){
     if(PLMD::getModuleMap().count(name)==0){
-      file << name << "is not in the ModuleMap\n";
+      file << name << " is not in the ModuleMap\n";
     }
   }
   return 0;

--- a/src/core/Makefile
+++ b/src/core/Makefile
@@ -3,7 +3,7 @@ USE=config tools lepton
 # generic makefile
 include ../maketools/make.module
 
-CLEANLIST:=$(CLEANLIST) PlumedMainMap.inc PlumedMainEnum.inc GREXMap.inc GREXEnum.inc CLToolMainMap.inc CLToolMainEnum.inc
+CLEANLIST:=$(CLEANLIST) PlumedMainMap.inc PlumedMainEnum.inc GREXMap.inc GREXEnum.inc CLToolMainMap.inc CLToolMainEnum.inc ModuleMap.inc
 
 PlumedMain.o: PlumedMainMap.inc PlumedMainEnum.inc
 
@@ -29,3 +29,7 @@ CLToolMainMap.inc: CLToolMain.cpp
 CLToolMainEnum.inc: CLToolMain.cpp
 	../maketools/makecmd enum < CLToolMain.cpp > CLToolMainEnum.inc
 
+ModuleMap.o: ModuleMap.inc
+
+ModuleMap.inc: ../*/*.cpp
+	../maketools/makeModuleMap > $@

--- a/src/core/ModuleMap.cpp
+++ b/src/core/ModuleMap.cpp
@@ -1,0 +1,31 @@
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+   Copyright (c) 2024-2024 The plumed team
+   (see the PEOPLE file at the root of the distribution for a list of names)
+
+   See http://www.plumed.org for more information.
+
+   This file is part of plumed, version 2.
+
+   plumed is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   plumed is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with plumed.  If not, see <http://www.gnu.org/licenses/>.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#include "ModuleMap.h"
+
+namespace PLMD {
+const std::map<std::string,std::string> & getModuleMap() {
+  static const std::map<std::string,std::string> actionToModule= {
+#include "ModuleMap.inc"
+  };
+  return actionToModule;
+}
+} // namespace PLMD

--- a/src/core/ModuleMap.h
+++ b/src/core/ModuleMap.h
@@ -22,6 +22,7 @@
 #ifndef __PLUMED_core_ModuleMap_h
 #define __PLUMED_core_ModuleMap_h
 #include <map>
+#include <string>
 namespace PLMD {
 const std::map<std::string,std::string> & getModuleMap();
 } // namespace PLMD

--- a/src/core/ModuleMap.h
+++ b/src/core/ModuleMap.h
@@ -1,0 +1,29 @@
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+   Copyright (c) 2024-2024 The plumed team
+   (see the PEOPLE file at the root of the distribution for a list of names)
+
+   See http://www.plumed.org for more information.
+
+   This file is part of plumed, version 2.
+
+   plumed is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   plumed is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with plumed.  If not, see <http://www.gnu.org/licenses/>.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#ifndef __PLUMED_core_ModuleMap_h
+#define __PLUMED_core_ModuleMap_h
+#include <map>
+namespace PLMD {
+const std::map<std::string,std::string> & getModuleMap();
+} // namespace PLMD
+
+#endif //__PLUMED_core_ModuleMap_h

--- a/src/maketools/makeModuleMap
+++ b/src/maketools/makeModuleMap
@@ -1,0 +1,59 @@
+#! /usr/bin/env bash
+# shellcheck disable=SC2059
+
+problems=""
+toPrint='  {"%s", "%s"}'
+#regex are scary, here's a link with the flow of the regex
+# https://regexper.com/#PLUMED_REGISTER_ACTION%5Cs*%5C%28%5Cs*%5B0-9a-zA-Z_%5D%2B%5Cs*%2C%5Cs*%22%28%5B0-9a-zA-Z_%5D%2B%29%22%5Cs*%5C%29
+regex='PLUMED_REGISTER_ACTION\s*\(\s*[0-9a-zA-Z_]+\s*,\s*"([0-9a-zA-Z_]+)"\s*\)'
+
+for module in ../*/module.type; do
+  moduledir=${module%%/module.type}
+  modulename=${moduledir##*/}
+  {
+    for file in "$moduledir"/*.cpp; do
+      if grep -q PLUMED_REGISTER_ACTION "${file}"; then
+        # gawk and perl implementation in case your bash dialect do not process correctly the regex
+        # actionName=$(gawk 'match($0,/PLUMED_REGISTER_ACTION\s*\(\s*[0-9_a-zA-Z]+\s*,\s*"([0-9a-zA-Z_]+)"\s*\)/, captured){print captured[1]}' "${file}" )
+        # # in case gawk does not work, here's the perl implementation:
+        # # actionName=$(perl -ln -e'print $1 if /PLUMED_REGISTER_ACTION\s*\(\s*[0-9_a-zA-Z]+\s*,\s*"([0-9a-zA-Z_]+)"\s*\)/'  "${file}")
+        # ng=$(grep -c PLUMED_REGISTER_ACTION "${file}")
+        # nawk=$(
+        #           cat <<EOF | wc -l
+        # $b
+        # EOF
+        #         )
+        #         if [[ $ng -ne $nawk ]]; then
+        #           problems="$problems ${modulename}:${file}"
+        #         fi
+        # for a in $actionName; do
+        #   printf  "$toPrint" "$a" "$modulename"
+        #   # echo -ne "$init  {\"$a\", \"$modulename\"}"
+        #   toPrint=',\n  {"%s", "%s"}'
+        # done
+        # fi
+
+        grep PLUMED_REGISTER_ACTION "${file}" | while read -r action; do
+          # echo $action
+          if [[ $action =~ $regex ]]; then
+            actionName=${BASH_REMATCH[1]}
+            printf "$toPrint" "$actionName" "$modulename"
+            
+            toPrint=',\n  {"%s", "%s"}'
+          fi
+        done
+        #also here becasue while spawns a subshell and toPrint do not get updated
+        toPrint=',\n  {"%s", "%s"}'
+      fi
+    done
+  }
+
+done
+echo -e '\n'
+if [[ -n $problems ]]; then
+  echo >&2 some problems in the following:
+  for p in $problems; do
+    echo >&2 $p
+  done
+  exit 1
+fi

--- a/src/maketools/makeModuleMap
+++ b/src/maketools/makeModuleMap
@@ -4,8 +4,8 @@
 problems=""
 toPrint='  {"%s", "%s"}'
 #regex are scary, here's a link with the flow of the regex
-# https://regexper.com/#PLUMED_REGISTER_ACTION%5Cs*%5C%28%5Cs*%5B0-9a-zA-Z_%5D%2B%5Cs*%2C%5Cs*%22%28%5B0-9a-zA-Z_%5D%2B%29%22%5Cs*%5C%29
-regex='PLUMED_REGISTER_ACTION\s*\(\s*[0-9a-zA-Z_]+\s*,\s*"([0-9a-zA-Z_]+)"\s*\)'
+# https://regexper.com/#PLUMED_REGISTER_ACTION%20*%5C%28%20*%5B0-9a-zA-Z_%5D%2B%20*%2C%20*%22%28%5B0-9a-zA-Z_%5D%2B%29%22%20*%5C%29
+regex='PLUMED_REGISTER_ACTION *\( *[0-9a-zA-Z_]+ *, *"([0-9a-zA-Z_]+)" *\)'
 
 for module in ../*/module.type; do
   moduledir=${module%%/module.type}
@@ -14,9 +14,9 @@ for module in ../*/module.type; do
     for file in "$moduledir"/*.cpp; do
       if grep -q PLUMED_REGISTER_ACTION "${file}"; then
         # gawk and perl implementation in case your bash dialect do not process correctly the regex
-        # actionName=$(gawk 'match($0,/PLUMED_REGISTER_ACTION\s*\(\s*[0-9_a-zA-Z]+\s*,\s*"([0-9a-zA-Z_]+)"\s*\)/, captured){print captured[1]}' "${file}" )
+        # actionName=$(gawk 'match($0,/PLUMED_REGISTER_ACTION *\( *[0-9_a-zA-Z]+ *, *"([0-9a-zA-Z_]+)" *\)/, captured){print captured[1]}' "${file}" )
         # # in case gawk does not work, here's the perl implementation:
-        # # actionName=$(perl -ln -e'print $1 if /PLUMED_REGISTER_ACTION\s*\(\s*[0-9_a-zA-Z]+\s*,\s*"([0-9a-zA-Z_]+)"\s*\)/'  "${file}")
+        # # actionName=$(perl -ln -e'print $1 if /PLUMED_REGISTER_ACTION *\( *[0-9_a-zA-Z]+ *, *"([0-9a-zA-Z_]+)" *\)/'  "${file}")
         # ng=$(grep -c PLUMED_REGISTER_ACTION "${file}")
         # nawk=$(
         #           cat <<EOF | wc -l


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

@gtribello, @GiovanniBussi I have set up a simple module map
It can be used as `PLMD::getModuleMap().at("actionName")`[^1] to return the name of the module that includes that action (even if the module is not active in the current installation)

for 2.10 it is possible to add also an extra function that returns a `std::optional` with the module name to not doing the `.count("actionname")` before calling the at (that may throw), since `std::optional` is c++17

Since regex are scary I put a link to a site tha visualize the one used in the new maketool script
The new maketool script uses pure bash, I think there should not be problem between bash versions for the regex that I used, and I used pure bash to avoid having the user to install gawk or perl
I do not know if you like the requirements for the `.inc` file
[^1]:`operator[]` has no `const` overloads for `std::map` and `std::unordered_map`
##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.9

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
