### PR TITLE
Load library version

### DIFF
--- a/scripts/mklib.sh
+++ b/scripts/mklib.sh
@@ -41,7 +41,7 @@ do
       echo "ERROR: Unknown option $opt. Use --help for help."
       exit 1 ;;
     (*)
-      files+="${prefixopt}";;
+      files+=("${prefixopt}");;
   esac
 done
 
@@ -58,7 +58,7 @@ then
 fi
 
 recompile=no
-for file in $files
+for file in "${files[@]}"
 do
   if ! test $lib -nt $file ;
   then
@@ -87,7 +87,7 @@ tmpdir=$(mktemp -d "plumed_mklib.XXXXXX")
 
 toRemove="${toRemove} $tmpdir"
 
-for file in $files
+for file in "${files[@]}"
 do
 
   if [[ "$file" != *.cpp ]] ;

--- a/scripts/mklib.sh
+++ b/scripts/mklib.sh
@@ -12,7 +12,7 @@ if [ "$1" = --help ] ; then
 fi
 
 if [ "$1" = --options ] ; then
-  echo "--description --options --help -o"
+  echo "--description --options --help -o -n"
   exit 0
 fi
 
@@ -27,6 +27,7 @@ source "$PLUMED_ROOT"/src/config/compile_options.sh
 
 prefix=""
 lib=""
+no_clobber=""
 files=() # empty array
 for opt
 do
@@ -37,6 +38,8 @@ do
       prefix="--out=";;
     (--out=*)
       lib="${prefixopt#--out=}";;
+    (-n)
+      no_clobber=yes;;
     (-*)
       echo "ERROR: Unknown option $opt. Use --help for help."
       exit 1 ;;
@@ -65,6 +68,10 @@ do
     recompile=yes
   fi
 done
+
+if test -z "$no_clobber" ; then
+  recompile=yes
+fi
 
 if test $recompile = no ; then
   echo "$lib is already up to date"
@@ -148,5 +155,9 @@ fi
 
 eval "$link_command" "$PLUMED_MKLIB_LDFLAGS" $objs -o "$tmpdir/$lib"
 
-# || true is necessary with recent coreutils
-mv -n "$tmpdir/$lib" $lib || true
+if test -n "$no_clobber" ; then
+  # || true is necessary with recent coreutils
+  mv -n "$tmpdir/$lib" $lib || true
+else
+  mv "$tmpdir/$lib" $lib
+fi

--- a/scripts/mklib.sh
+++ b/scripts/mklib.sh
@@ -4,17 +4,30 @@ if [ "$1" = --description ] ; then
   echo "compile one or more *.cpp files into a shared library"
 fi
 
-if [ "$1" = --help ] ; then
-  echo "compile one or more *.cpp files into a shared library"
-  echo " you can create and export the variable PLUMED_MKLIB_CFLAGS with some extra compile time flags to be used"
-  echo " you can create and export the variable PLUMED_MKLIB_LDFLAGS with some extra link time flags (and libraries) to be used"
-  exit 0
-fi
+MANUAL='Compile one or more *.cpp files into a shared library.
 
-if [ "$1" = --options ] ; then
-  echo "--description --options --help -o -n"
-  exit 0
-fi
+Usage:
+
+  plumed mklib [options] files1.cpp [file2.cpp ...]
+
+Options:
+  -h, --help
+                         Print this help and exit
+  -o LIBNAME, --out LIBNAME
+                         Name of the output library. If missing, the name
+                         of the first input file will me used, with its
+                         suffix properly adjusted.
+  -n                     No-clobber mode, similar to `mv -n`.
+                         Does not overwrite an existing library.
+                         If the library exists when the command is started,
+                         skip also the compilation phase.
+
+Environment variables:
+  PLUMED_MKLIB_CFLAGS    Extra compile time flags to be used
+  PLUMED_MKLIB_LDFLAGS   Extra link time flags (and libraries) to be used
+'
+
+OPTIONS="--description --options -h --help -o --out -n"
 
 if [ $# == 0 ]
 then
@@ -34,12 +47,11 @@ do
   prefixopt="$prefix$opt"
   prefix=""
   case "$prefixopt" in
-    (-o)
-      prefix="--out=";;
-    (--out=*)
-      lib="${prefixopt#--out=}";;
-    (-n)
-      no_clobber=yes;;
+    (-o|--out) prefix="--out=";;
+    (-h|--help) echo "$MANUAL" ; exit ;;
+    (--options) echo "$OPTIONS" ; exit ;;
+    (--out=*) lib="${prefixopt#--out=}";;
+    (-n) no_clobber=yes;;
     (-*)
       echo "ERROR: Unknown option $opt. Use --help for help."
       exit 1 ;;

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -1261,7 +1261,7 @@ void PlumedMain::load(const std::string& fileName) {
 // full path command, including environment setup
 // this will work even if plumed is not in the execution path or if it has been
 // installed with a name different from "plumed"
-      std::string cmd=config::getEnvCommand()+" \""+config::getPlumedRoot()+"\"/scripts/mklib.sh -o "+libName+" "+fileName;
+      std::string cmd=config::getEnvCommand()+" \""+config::getPlumedRoot()+"\"/scripts/mklib.sh -n -o "+libName+" "+fileName;
 
       if(std::getenv("PLUMED_LOAD_ACTION_DEBUG")) log<<"Executing: "<<cmd;
       else log<<"Compiling: "<<fileName<<" to "<<libName;

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -1255,14 +1255,16 @@ void PlumedMain::load(const std::string& fileName) {
       extension=libName.substr(n+1);
     if(n!=std::string::npos && n<libName.length())
       base=libName.substr(0,n);
+
     if(extension=="cpp") {
+      libName="./"+base+"."+config::getVersionLong()+"."+config::getSoExt();
 // full path command, including environment setup
 // this will work even if plumed is not in the execution path or if it has been
 // installed with a name different from "plumed"
-      std::string cmd=config::getEnvCommand()+" \""+config::getPlumedRoot()+"\"/scripts/mklib.sh "+libName;
+      std::string cmd=config::getEnvCommand()+" \""+config::getPlumedRoot()+"\"/scripts/mklib.sh -o "+libName+" "+fileName;
 
       if(std::getenv("PLUMED_LOAD_ACTION_DEBUG")) log<<"Executing: "<<cmd;
-      else log<<"Compiling: "<<libName;
+      else log<<"Compiling: "<<fileName<<" to "<<libName;
 
       if(comm.Get_size()>0) log<<" (only on master node)";
       log<<"\n";
@@ -1280,9 +1282,10 @@ void PlumedMain::load(const std::string& fileName) {
         if(ret!=0) plumed_error() <<"An error happened while executing command "<<cmd<<"\n";
       }
       comm.Barrier();
-      base="./"+base;
+    } else {
+      libName=base+"."+config::getSoExt();
     }
-    libName=base+"."+config::getSoExt();
+
     // If we have multiple threads (each holding a Plumed object), each of them
     // will load the library, but each of them will only see actions registered
     // from the owned library


### PR DESCRIPTION

##### Description

The `plumed mklib` script in v2.10 works as a makefile, so that if a .so is already present it is not recompiled. This is necessary for thread safety. This however causes a problem in the plumed nest where the .so file produced by v2.9 is not regenerated when using master. One possible solution is to encode the version name in the .so file.

With this PR, when using
```
LOAD FILE=file.cpp
```

A `.so` file will be generated with name `file.2.10-dev.so`.

Notice that the change is apparent only when using `LOAD`, and not when using `plumed mklib` directly. In other words:

```
plumed mklib file.cpp
```

will still generate a file named `file.so`.

I did it in this way, which is completely transparent to users. Indeed, the `.so` file created by `LOAD` is a temporary that is never explicitly mentioned by the user. However, it would also be possible to encode the version directly in every use of `plumed mklib`, which I think is what python does when compiling extensions. This would however create problems if someone uses scripts such as:

```
plumed mklib file.cpp
cat << EOF > plumed.dat
LOAD FILE=file.so # wrong name here!
EOF 
```

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.10__
