### PR TITLE
More helpful exception text for Registerbase

### DIFF
--- a/src/core/CLToolRegister.cpp
+++ b/src/core/CLToolRegister.cpp
@@ -38,11 +38,14 @@ std::unique_ptr<CLTool> CLToolRegister::create(const CLToolOptions&ao) {
   return create(images,ao);
 }
 
-std::unique_ptr<CLTool> CLToolRegister::create(const std::vector<void*> & images,const CLToolOptions&ao) {
+std::unique_ptr<CLTool> CLToolRegister::create(const std::vector<void*> & images,const CLToolOptions&ao) try {
   if(ao.line.size()<1)return nullptr;
   auto & content=get(images,ao.line[0]);
   CLToolOptions nao( ao,content.keys );
   return content.create(nao);
+} catch (PLMD::ExceptionRegisterError &e ) {
+  auto& toolName = e.getMissingKey();
+  throw e <<"CL tool \"" << toolName << "\" is not known.";
 }
 
 CLToolRegister::ID CLToolRegister::add(std::string key,creator_pointer cp,keywords_pointer kp) {

--- a/src/core/RegisterBase.h
+++ b/src/core/RegisterBase.h
@@ -208,7 +208,7 @@ const Content & RegisterBase<Content>::get(const std::vector<void*> & images,con
     auto qualified_key=imageToString(*image) + ":" + key;
     if(m.count(qualified_key)>0) return m.find(qualified_key)->second->content;
   }
-  plumed_assert(m.count(key)>0);
+  plumed_assert(m.count(key)>0) << ", Missing key: \"" << key<<"\"";
   return m.find(key)->second->content;
 }
 
@@ -220,7 +220,7 @@ const std::string & RegisterBase<Content>::getFullPath(const std::vector<void*> 
     auto qualified_key=imageToString(*image) + ":" + key;
     if(m.count(qualified_key)>0) return m.find(qualified_key)->second->fullPath;
   }
-  plumed_assert(m.count(key)>0);
+  plumed_assert(m.count(key)>0) << ", Missing key: \"" << key<<"\"";
   return m.find(key)->second->fullPath;
 }
 
@@ -228,7 +228,7 @@ template<class Content>
 const Content & RegisterBase<Content>::get(const std::string & key) const {
   // lock map for reading
   std::shared_lock<std::shared_mutex> lock(mutex);
-  plumed_assert(m.count(key)>0);
+  plumed_assert(m.count(key)>0) << ", Missing key: \"" << key<<"\"";
   return m.find(key)->second->content;
 }
 
@@ -288,5 +288,3 @@ void RegisterBase<Content>::clearStaged() noexcept {
 }
 
 #endif
-
-

--- a/src/core/RegisterBase.h
+++ b/src/core/RegisterBase.h
@@ -99,13 +99,23 @@ public:
 /// Class representing an error in a register
 class ExceptionRegisterError :
   public Exception {
+  /// The missing key
   std::string missingKey;
 public:
   using Exception::Exception;
+  /// Sets the missing key
+  /// \param key The missing key
+  /// \return This exception
+  ///
+  /// ExceptionRegisterError can be used as a builder pattern:
+  /// `throw ExceptionRegisterError().setMissingKey(key);`
+  ///
+  /// the key can be retrieved with ExceptionRegisterError::getMissingKey()
   ExceptionRegisterError& setMissingKey (std::string_view key) {
     missingKey=key;
     return *this;
   }
+  /// Returns the missing key
   const std::string& getMissingKey() const {return missingKey;}
   template<typename T>
   ExceptionRegisterError& operator<<(const T & x) {

--- a/src/core/RegisterBase.h
+++ b/src/core/RegisterBase.h
@@ -24,6 +24,7 @@
 
 #include "tools/Exception.h"
 #include <string>
+#include <string_view>
 #include <map>
 #include <memory>
 #include <iostream>
@@ -93,6 +94,24 @@ public:
   std::vector<std::string> getKeysWithDLHandle(void* handle) const;
 
   friend std::ostream & operator<<(std::ostream &log,const Register &reg);
+};
+
+/// Class representing an error in a register
+class ExceptionRegisterError :
+  public Exception {
+  std::string missingKey;
+public:
+  using Exception::Exception;
+  ExceptionRegisterError& setMissingKey (std::string_view key) {
+    missingKey=key;
+    return *this;
+  }
+  const std::string& getMissingKey() const {return missingKey;}
+  template<typename T>
+  ExceptionRegisterError& operator<<(const T & x) {
+    *static_cast<Exception*>(this) <<x;
+    return *this;
+  }
 };
 
 /// General register.
@@ -208,7 +227,9 @@ const Content & RegisterBase<Content>::get(const std::vector<void*> & images,con
     auto qualified_key=imageToString(*image) + ":" + key;
     if(m.count(qualified_key)>0) return m.find(qualified_key)->second->content;
   }
-  plumed_assert(m.count(key)>0) << ", Missing key: \"" << key<<"\"";
+  if (m.count(key) == 0 ) {
+    throw ExceptionRegisterError().setMissingKey(key);
+  }
   return m.find(key)->second->content;
 }
 
@@ -220,7 +241,9 @@ const std::string & RegisterBase<Content>::getFullPath(const std::vector<void*> 
     auto qualified_key=imageToString(*image) + ":" + key;
     if(m.count(qualified_key)>0) return m.find(qualified_key)->second->fullPath;
   }
-  plumed_assert(m.count(key)>0) << ", Missing key: \"" << key<<"\"";
+  if (m.count(key) == 0 ) {
+    throw ExceptionRegisterError().setMissingKey(key);
+  }
   return m.find(key)->second->fullPath;
 }
 
@@ -228,7 +251,9 @@ template<class Content>
 const Content & RegisterBase<Content>::get(const std::string & key) const {
   // lock map for reading
   std::shared_lock<std::shared_mutex> lock(mutex);
-  plumed_assert(m.count(key)>0) << ", Missing key: \"" << key<<"\"";
+  if (m.count(key) == 0 ) {
+    throw ExceptionRegisterError().setMissingKey(key);
+  }
   return m.find(key)->second->content;
 }
 


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

I was running some tests on some previous commit (where regtest/clusters/rt-dfg1/config had a wrong module prerequisites instead of `plumed_modules="adjmat clusters"`) and the exception text `+++ assertion failed: m.count(key)>0` felt not helpful.

I think that the text `+++ assertion failed: m.count(key)>0, Missing key is "KEYNAME"` feel a little more helpful.
I think these few lines may help at least in doing a `git grep KEYNAME` in src or a `plumed manual KEYNAME` to find at least which module has not been loaded.

---

An maybe we can use #1063 for giving directly that info, I do not know if directly in the register or also in an ad-hoc cltool or in cltools/Manual.cpp

---

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
