### PR TITLE
Fixes to documentation generators for PlumedToHTML

### DIFF
--- a/src/cltools/Driver.cpp
+++ b/src/cltools/Driver.cpp
@@ -787,16 +787,16 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
           }
           ActionWithValue* av=dynamic_cast<ActionWithValue*>(pp.get());
           if( av && av->getNumberOfComponents()>0 ) {
-            Keywords keys; p.getKeywordsForAction( av->getName(), keys ); 
+            Keywords keys; p.getKeywordsForAction( av->getName(), keys );
             if( firsta ) { valuefile.printf("  \"%s\" : {\n    \"action\" : \"%s\"", av->getLabel().c_str(), keys.getDisplayName().c_str() ); firsta=false; }
             else valuefile.printf(",\n  \"%s\" : {\n    \"action\" : \"%s\"", av->getLabel().c_str(), keys.getDisplayName().c_str() );
             for(unsigned i=0; i<av->getNumberOfComponents(); ++i) {
-              Value* myval = av->copyOutput(i); std::string compname = myval->getName(), description; 
+              Value* myval = av->copyOutput(i); std::string compname = myval->getName(), description;
               if( av->getLabel()==compname ) {
-                  description = keys.getOutputComponentDescription(".#!value");
+                description = keys.getOutputComponentDescription(".#!value");
               } else {
-                  std::size_t dot=compname.find(av->getLabel() + "."); std::string cname = compname.substr(dot + av->getLabel().length() + 1); 
-                  description = av->getOutputComponentDescription( cname, keys );
+                std::size_t dot=compname.find(av->getLabel() + "."); std::string cname = compname.substr(dot + av->getLabel().length() + 1);
+                description = av->getOutputComponentDescription( cname, keys );
               }
               if( description.find("\\")!=std::string::npos ) error("found invalid backslash character in documentation for component " + compname + " in action " + av->getName() + " with label " + av->getLabel() );
               valuefile.printf(",\n    \"%s\" : { \"type\": \"%s\", \"description\": \"%s\" }", myval->getName().c_str(), myval->getValueType().c_str(), description.c_str() );
@@ -810,7 +810,7 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
 
             if( firsta ) { valuefile.printf("  \"shortcut_%s\" : {\n    \"action\" : \"%s\"", as->getShortcutLabel().c_str(), as->getName().c_str() ); firsta=false; }
             else valuefile.printf(",\n  \"shortcut_%s\" : {\n    \"action\" : \"%s\"", as->getShortcutLabel().c_str(), as->getName().c_str() );
-            Keywords keys; p.getKeywordsForAction( as->getName(), keys ); 
+            Keywords keys; p.getKeywordsForAction( as->getName(), keys );
             for(unsigned i=0; i<cnames.size(); ++i) {
               ActionWithValue* av2=p.getActionSet().selectWithLabel<ActionWithValue*>( cnames[i] );
               if( !av2 ) plumed_merror("could not find value created by shortcut with name " + cnames[i] );
@@ -822,13 +822,13 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
                 valuefile.printf(",\n    \"%s\" : { \"type\": \"%s\", \"description\": \"%s\" }", myval->getName().c_str(), myval->getValueType().c_str(), description.c_str() );
               } else {
                 for(unsigned j=0; j<av2->getNumberOfComponents(); ++j) {
-                  Value* myval = av2->copyOutput(j); std::string compname = myval->getName(), description; 
+                  Value* myval = av2->copyOutput(j); std::string compname = myval->getName(), description;
                   if( av2->getLabel()==compname ) {
-                      plumed_merror("should not be outputting description of value from action when using shortcuts");
+                    plumed_merror("should not be outputting description of value from action when using shortcuts");
                   } else {
-                      std::size_t dot=compname.find(av2->getLabel() + "."); std::string cname = compname.substr(dot+av2->getLabel().length() + 1); 
-                      description = av2->getOutputComponentDescription( cname, keys );
-                  } 
+                    std::size_t dot=compname.find(av2->getLabel() + "."); std::string cname = compname.substr(dot+av2->getLabel().length() + 1);
+                    description = av2->getOutputComponentDescription( cname, keys );
+                  }
                   if( description.find("\\")!=std::string::npos ) error("found invalid backslash character in documentation for component " + compname + " in action " + av2->getName() + " with label " + av2->getLabel() );
                   valuefile.printf(",\n    \"%s\" : { \"type\": \"%s\", \"description\": \"%s\" }", myval->getName().c_str(), myval->getValueType().c_str(), description.c_str() );
                 }

--- a/src/cltools/Driver.cpp
+++ b/src/cltools/Driver.cpp
@@ -791,10 +791,13 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
             if( firsta ) { valuefile.printf("  \"%s\" : {\n    \"action\" : \"%s\"", av->getLabel().c_str(), keys.getDisplayName().c_str() ); firsta=false; }
             else valuefile.printf(",\n  \"%s\" : {\n    \"action\" : \"%s\"", av->getLabel().c_str(), keys.getDisplayName().c_str() );
             for(unsigned i=0; i<av->getNumberOfComponents(); ++i) {
-              Value* myval = av->copyOutput(i); std::string compname = myval->getName(), description; std::size_t dot=compname.find(".");
-              if( dot!=std::string::npos ) {
-                std::string cname = compname.substr(dot+1); description = av->getOutputComponentDescription( cname, keys );
-              } else description = keys.getOutputComponentDescription(".#!value");
+              Value* myval = av->copyOutput(i); std::string compname = myval->getName(), description; 
+              if( av->getLabel()==compname ) {
+                  description = keys.getOutputComponentDescription(".#!value");
+              } else {
+                  std::size_t dot=compname.find(av->getLabel() + "."); std::string cname = compname.substr(dot + av->getLabel().length() + 1); 
+                  description = av->getOutputComponentDescription( cname, keys );
+              }
               if( description.find("\\")!=std::string::npos ) error("found invalid backslash character in documentation for component " + compname + " in action " + av->getName() + " with label " + av->getLabel() );
               valuefile.printf(",\n    \"%s\" : { \"type\": \"%s\", \"description\": \"%s\" }", myval->getName().c_str(), myval->getValueType().c_str(), description.c_str() );
             }
@@ -819,10 +822,13 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
                 valuefile.printf(",\n    \"%s\" : { \"type\": \"%s\", \"description\": \"%s\" }", myval->getName().c_str(), myval->getValueType().c_str(), description.c_str() );
               } else {
                 for(unsigned j=0; j<av2->getNumberOfComponents(); ++j) {
-                  Value* myval = av2->copyOutput(j); std::string compname = myval->getName(), description; std::size_t dot=compname.find(".");
-                  if( dot!=std::string::npos ) {
-                    std::string cname = compname.substr(dot+1); description = av2->getOutputComponentDescription( cname, keys );
-                  } else plumed_merror("should not be outputting description of value from action when using shortcuts");
+                  Value* myval = av2->copyOutput(j); std::string compname = myval->getName(), description; 
+                  if( av2->getLabel()==compname ) {
+                      plumed_merror("should not be outputting description of value from action when using shortcuts");
+                  } else {
+                      std::size_t dot=compname.find(av2->getLabel() + "."); std::string cname = compname.substr(dot+av2->getLabel().length() + 1); 
+                      description = av2->getOutputComponentDescription( cname, keys );
+                  } 
                   if( description.find("\\")!=std::string::npos ) error("found invalid backslash character in documentation for component " + compname + " in action " + av2->getName() + " with label " + av2->getLabel() );
                   valuefile.printf(",\n    \"%s\" : { \"type\": \"%s\", \"description\": \"%s\" }", myval->getName().c_str(), myval->getValueType().c_str(), description.c_str() );
                 }

--- a/src/cltools/Driver.cpp
+++ b/src/cltools/Driver.cpp
@@ -27,7 +27,6 @@
 #include "core/ActionWithValue.h"
 #include "core/ActionWithVirtualAtom.h"
 #include "core/ActionShortcut.h"
-#include "core/ActionRegister.h"
 #include "tools/Communicator.h"
 #include "tools/Random.h"
 #include "tools/Pbc.h"
@@ -788,7 +787,7 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
           }
           ActionWithValue* av=dynamic_cast<ActionWithValue*>(pp.get());
           if( av && av->getNumberOfComponents()>0 ) {
-            Keywords keys; actionRegister().getKeywords( av->getName(), keys );
+            Keywords keys; p.getKeywordsForAction( av->getName(), keys ); 
             if( firsta ) { valuefile.printf("  \"%s\" : {\n    \"action\" : \"%s\"", av->getLabel().c_str(), keys.getDisplayName().c_str() ); firsta=false; }
             else valuefile.printf(",\n  \"%s\" : {\n    \"action\" : \"%s\"", av->getLabel().c_str(), keys.getDisplayName().c_str() );
             for(unsigned i=0; i<av->getNumberOfComponents(); ++i) {
@@ -808,7 +807,7 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
 
             if( firsta ) { valuefile.printf("  \"shortcut_%s\" : {\n    \"action\" : \"%s\"", as->getShortcutLabel().c_str(), as->getName().c_str() ); firsta=false; }
             else valuefile.printf(",\n  \"shortcut_%s\" : {\n    \"action\" : \"%s\"", as->getShortcutLabel().c_str(), as->getName().c_str() );
-            Keywords keys; actionRegister().getKeywords( as->getName(), keys );
+            Keywords keys; p.getKeywordsForAction( as->getName(), keys ); 
             for(unsigned i=0; i<cnames.size(); ++i) {
               ActionWithValue* av2=p.getActionSet().selectWithLabel<ActionWithValue*>( cnames[i] );
               if( !av2 ) plumed_merror("could not find value created by shortcut with name " + cnames[i] );

--- a/src/core/Action.cpp
+++ b/src/core/Action.cpp
@@ -97,7 +97,7 @@ Action::Action(const ActionOptions&ao):
   if(label.length()==0) {
     std::string s; Tools::convert(plumed.getActionSet().size()-plumed.getActionSet().select<ActionForInterface*>().size(),s);
     label="@"+s;
-  }
+  } else if ( label.find(".")!=std::string::npos ) warning("using full stop in an action label should be avaoided as . has a special meaning in PLUMED action labels");
   if( plumed.getActionSet().selectWithLabel<Action*>(label) ) error("label " + label + " has been already used");
   if( !keywords.exists("NO_ACTION_LOG") ) log.printf("  with label %s\n",label.c_str());
   if ( keywords.exists("UPDATE_FROM") ) parse("UPDATE_FROM",update_from);

--- a/src/core/ActionRegister.cpp
+++ b/src/core/ActionRegister.cpp
@@ -93,4 +93,8 @@ bool ActionRegister::getKeywords(const std::string& action, Keywords& keys) {
   return false;
 }
 
+void ActionRegister::getKeywords(const std::vector<void*> & images, const std::string& action, Keywords& keys) {
+  auto content=get(images,action); keys.thisactname = action; content.keys(keys);
+}
+
 }

--- a/src/core/ActionRegister.h
+++ b/src/core/ActionRegister.h
@@ -64,6 +64,7 @@ public:
   bool printManual(const std::string& action, const bool& vimout, const bool& spellout);
 /// Retrieve a keywords object for a particular action
   bool getKeywords( const std::string& action, Keywords& keys );
+  void getKeywords(const std::vector<void*> & images, const std::string& action, Keywords& keys);
 /// Print out a template command for an action
   bool printTemplate(const std::string& action, bool include_optional);
   std::vector<std::string> getActionNames() const;

--- a/src/core/ActionWithValue.cpp
+++ b/src/core/ActionWithValue.cpp
@@ -170,7 +170,6 @@ void ActionWithValue::addComponentWithDerivatives( const std::string& name, cons
 
 std::string ActionWithValue::getOutputComponentDescription( const std::string& cname, const Keywords& keys ) const {
   std::size_t und=cname.find_last_of("_"); std::size_t hyph=cname.find_first_of("-");
-  if( und!=std::string::npos && hyph!=std::string::npos ) plumed_merror("cannot use underscore and hyphen in name");
   if( und!=std::string::npos ) return keys.getOutputComponentDescription(cname.substr(und)) + " This particular component measures this quantity for the input CV named " + cname.substr(0,und);
   if( hyph!=std::string::npos ) return keys.getOutputComponentDescription(cname.substr(0,hyph)) + "  This is the " + cname.substr(hyph+1) + "th of these quantities";
   plumed_massert( keys.outputComponentExists(cname), "component " + cname + " does not exist in " + keys.getDisplayName() + " if the component names are customizable then you should override this function" );

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -1488,6 +1488,10 @@ bool PlumedMain::parseOnlyMode() const {
   return doParseOnly;
 }
 
+void PlumedMain::getKeywordsForAction( const std::string& action, Keywords& keys ) const {
+  actionRegister().getKeywords( dlloader.getHandles(), action, keys ); 
+}
+
 #ifdef __PLUMED_HAS_PYTHON
 // This is here to stop cppcheck throwing an error
 #endif

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -1489,7 +1489,7 @@ bool PlumedMain::parseOnlyMode() const {
 }
 
 void PlumedMain::getKeywordsForAction( const std::string& action, Keywords& keys ) const {
-  actionRegister().getKeywords( dlloader.getHandles(), action, keys ); 
+  actionRegister().getKeywords( dlloader.getHandles(), action, keys );
 }
 
 #ifdef __PLUMED_HAS_PYTHON

--- a/src/core/PlumedMain.h
+++ b/src/core/PlumedMain.h
@@ -68,6 +68,7 @@ class FileBase;
 class TypesafePtr;
 class IFile;
 class Units;
+class Keywords;
 class DataPassingTools;
 
 /**
@@ -523,6 +524,8 @@ public:
   void plumedQuantityToMD( const std::string& unit, const double& eng, const TypesafePtr & m) const ;
 /// Take a typesafe pointer from the MD code and convert it to a double
   double MDQuantityToPLUMED( const std::string& unit, const TypesafePtr & m) const ;
+/// Get the keywords for a particular action
+  void getKeywordsForAction( const std::string& action, Keywords& keys ) const ;
 };
 
 /////

--- a/src/multicolvar/XAngle.cpp
+++ b/src/multicolvar/XAngle.cpp
@@ -76,7 +76,7 @@ XAngle::XAngle(const ActionOptions& ao):
   ActionShortcut(ao)
 {
   // Create distances
-  std::string dline = getShortcutLabel() + ": DISTANCE COMPONENTS";
+  std::string dline = getShortcutLabel() + "_dists: DISTANCE COMPONENTS";
   for(unsigned i=1;; ++i) {
     std::string atstring; parseNumbered("ATOMS",i,atstring);
     if( atstring.length()==0 ) break;
@@ -85,11 +85,11 @@ XAngle::XAngle(const ActionOptions& ao):
   }
   readInputLine( dline );
   // Normalize the vectors
-  readInputLine( getShortcutLabel() + "_norm2: COMBINE ARG=" + getShortcutLabel() + ".x" + "," + getShortcutLabel() + ".y," + getShortcutLabel() + ".z POWERS=2,2,2 PERIODIC=NO");
+  readInputLine( getShortcutLabel() + "_norm2: COMBINE ARG=" + getShortcutLabel() + "_dists.x" + "," + getShortcutLabel() + "_dists.y," + getShortcutLabel() + "_dists.z POWERS=2,2,2 PERIODIC=NO");
   readInputLine( getShortcutLabel() + "_norm: CUSTOM ARG=" + getShortcutLabel() + "_norm2 FUNC=sqrt(x) PERIODIC=NO");
-  readInputLine( getShortcutLabel() + "_norm_x: CUSTOM ARG=" + getShortcutLabel() + ".x," + getShortcutLabel() + "_norm FUNC=x/y PERIODIC=NO");
-  readInputLine( getShortcutLabel() + "_norm_y: CUSTOM ARG=" + getShortcutLabel() + ".y," + getShortcutLabel() + "_norm FUNC=x/y PERIODIC=NO");
-  readInputLine( getShortcutLabel() + "_norm_z: CUSTOM ARG=" + getShortcutLabel() + ".z," + getShortcutLabel() + "_norm FUNC=x/y PERIODIC=NO");
+  readInputLine( getShortcutLabel() + "_norm_x: CUSTOM ARG=" + getShortcutLabel() + "_dists.x," + getShortcutLabel() + "_norm FUNC=x/y PERIODIC=NO");
+  readInputLine( getShortcutLabel() + "_norm_y: CUSTOM ARG=" + getShortcutLabel() + "_dists.y," + getShortcutLabel() + "_norm FUNC=x/y PERIODIC=NO");
+  readInputLine( getShortcutLabel() + "_norm_z: CUSTOM ARG=" + getShortcutLabel() + "_dists.z," + getShortcutLabel() + "_norm FUNC=x/y PERIODIC=NO");
   // Now compute the angles with matheval
   if( getName()=="XANGLES" ) readInputLine( getShortcutLabel() + "_ang: CUSTOM FUNC=acos(x) PERIODIC=NO ARG=" + getShortcutLabel() + "_norm_x");
   if( getName()=="YANGLES" ) readInputLine( getShortcutLabel() + "_ang: CUSTOM FUNC=acos(x) PERIODIC=NO ARG=" + getShortcutLabel() + "_norm_y");


### PR DESCRIPTION
##### Description

I have been doing some work on improving the PlumedToHTML code that generates the annotated input files for the tutorials and nest.  The work is described in [this PR](https://github.com/plumed-nest/plumed-nest/pull/118).  As part of this I have had to make some modifications to PLUMED.  In particular, when you call PLUMED driver in parse only mode you can ask it to output two json dictionaries that contain:

1. How any shortcut keywords are expanded into the longer input
2. The definitions of the quantities that have labels in the input file

Getting the definitions of the labels directly from plumed when you run driver is superior to getting this information from the syntax file as:

1. You are able to distinguish whether objects are scalars, vectors, matrices etc this way.
2. You can find what the labels for actions that have custom labels (i.e. labels that depend on the arguments).
3. This way you can get the meanings of components that are created by files that are created by LOAD actions.

I tested the new version of PlumedTo HTML on all the inputs in the plumed nest and found a small number places where the new code does not work.  This PR fixes those problems.

@GiovanniBussi can you please check whether I have done the code for the first commit correctly?  The problem here is that I need to call registerKeywords for all the actions defined in the input file.  This will not work if you do:

```` 
actionRegister().getKeywords( name, keys )
````

The problem with that is that the code for the actions in LOAD is not accessible that way.  I thus came up with a way of doing by looking at what you did for creating actions.  I hope this is correct.  The tests that were not working now run.

Also note that I found one input in the nest like this:  

```` 
d1.mydist: DISTANCE ATOMS=1,2
PRINT ARG=* 
````

I managed to get it working but I also put a warning in about putting a . in the names of actions.  I think this is a recipe for trouble.  Not sure if we should make that an error.  What do you think?

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
