### PR TITLE
Adding a small header to the benchmark utility

### DIFF
--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -484,7 +484,7 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
     log.link(log_dev_null.get());
   }
   log.setLinePrefix("BENCH:  ");
-
+  log <<"Welcome to PLUMED benchmark\n";
   std::vector<Kernel> kernels;
 
   // perform comparative analysis
@@ -589,6 +589,7 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
     {
       std::string paths;
       parse("--kernel",paths);
+      log <<"Using --kernel=" << paths << "\n";
       allpaths=Tools::getWords(paths,":");
     }
 
@@ -596,6 +597,7 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
     {
       std::string paths;
       parse("--plumed",paths);
+      log <<"Using --plumed=" << paths << "\n";
       allplumed=Tools::getWords(paths,":");
     }
 
@@ -628,18 +630,26 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
   // read other flags:
   bool shuffled=false;
   parseFlag("--shuffled",shuffled);
+  if (shuffled)
+    log << "Using --shuffled\n";
   int nf; parse("--nsteps",nf);
+  log << "Using --nsteps=" << nf << "\n";
   unsigned natoms; parse("--natoms",natoms);
-
+  log << "Using --natoms=" << natoms << "\n";
   double maxtime; parse("--maxtime",maxtime);
+  log << "Using --maxtime=" << maxtime << "\n";
 
   bool domain_decomposition=false;
   parseFlag("--domain-decomposition",domain_decomposition);
+  if (domain_decomposition)
+    log << "Using --domain-decomposition\n";
+
   if(pc.Get_size()>1) domain_decomposition=true;
   if(domain_decomposition) shuffled=true;
 
   double timeToSleep;
   parse("--sleep",timeToSleep);
+  log << "Using --sleep=" << timeToSleep << "\n";
 
   std::vector<int> shuffled_indexes;
 
@@ -647,8 +657,9 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
     std::string atomicDistr;
     parse("--atom-distribution",atomicDistr);
     distribution = getAtomDistribution(atomicDistr);
+    log << "Using --atom-distribution=" << atomicDistr << "\n";
   }
-
+  log <<"Initializing the setup of the kernel(s)\n";
   const auto initial_time=std::chrono::high_resolution_clock::now();
 
   for(auto & k : kernels) {
@@ -689,7 +700,6 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
   log<<"Use CTRL+C to stop at any time and collect timers (not working in MPI runs)\n";
   // trap signals:
   SignalHandlerGuard sigIntGuard(SIGINT, signalHandler);
-
 
   for(int step=0; nf<0 || step<nf; ++step) {
     std::shuffle(kernels_ptr.begin(),kernels_ptr.end(),rng);


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

I have been digging into many benchmarks lately, and this small addition eases the work for me and will be useful for any benchmark user in the future.
Now the first output of the benchmark will be something like this:
```
BENCH:  Welcome to PLUMED benchmark
BENCH:  Using --kernel=this
BENCH:  Using --plumed=plumed.dat
BENCH:  Using --nsteps=2000
BENCH:  Using --natoms=100000
BENCH:  Using --maxtime=-1
BENCH:  Using --sleep=0
BENCH:  Using --atom-distribution=line
BENCH:  Initializing the setup of the kernel(s)
```
That is for a run here is `plumed benchmark` with no options given, if an option like `--shuffled` is given a line with `BENCH:  Using --shuffled` will appear.

I find this useful for reproducing the bench later, or to share a clearer file. 
It may also be useful in the case of postprocessing benchmarks without needing to rely on inventing filenames that contain all the selected options.


##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
