### PR TITLE
Now the header is correct also in mpi run benchmark run

### DIFF
--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -634,8 +634,7 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
   // read other flags:
   bool shuffled=false;
   parseFlag("--shuffled",shuffled);
-  if (shuffled)
-    log << "Using --shuffled\n";
+
   int nf; parse("--nsteps",nf);
   log << "Using --nsteps=" << nf << "\n";
   unsigned natoms; parse("--natoms",natoms);
@@ -645,11 +644,14 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
 
   bool domain_decomposition=false;
   parseFlag("--domain-decomposition",domain_decomposition);
-  if (domain_decomposition)
-    log << "Using --domain-decomposition\n";
 
   if(pc.Get_size()>1) domain_decomposition=true;
   if(domain_decomposition) shuffled=true;
+
+  if (shuffled)
+    log << "Using --shuffled\n";
+  if (domain_decomposition)
+    log << "Using --domain-decomposition\n";
 
   double timeToSleep;
   parse("--sleep",timeToSleep);


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

Reading the code again, I discovered that shuffled and domain decomposition could be automatically changed without the user input, during the setup of the benchmark,
I changed the output of the header to reflect that.

Sorry for the Friday PR, this is a small thing that I am sure to forget

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
