### PR TITLE
FIX-2.9 Now the forces from LWALLS should be correct 

### DIFF
--- a/src/bias/LWalls.cpp
+++ b/src/bias/LWalls.cpp
@@ -133,7 +133,7 @@ void LWalls::calculate() {
     if( lscale < 0.) {
       const double k=kappa[i];
       const double exponent=exp[i];
-      double power = std::pow( lscale, exponent );
+      double power = std::pow( -lscale, exponent );
       f = -( k / epsilon ) * exponent * power / lscale;
       ene += k * power;
       totf2 += f * f;

--- a/src/bias/LWalls.cpp
+++ b/src/bias/LWalls.cpp
@@ -35,8 +35,14 @@ The restraining potential starts acting on the system when the value of the CV i
 minus an offset \f$o_i\f$ (OFFSET).
 The expression for the bias due to the wall is given by:
 
+for UPPER_WALLS:
 \f$
   \sum_i {k_i}((x_i-a_i+o_i)/s_i)^e_i
+\f$
+
+for LOWER_WALLS:
+\f$
+  \sum_i {k_i}|(x_i-a_i-o_i)/s_i|^e_i
 \f$
 
 \f$k_i\f$ (KAPPA) is an energy constant in internal unit of the code, \f$s_i\f$ (EPS) a rescaling factor and

--- a/src/bias/UWalls.cpp
+++ b/src/bias/UWalls.cpp
@@ -35,8 +35,14 @@ The restraining potential starts acting on the system when the value of the CV i
 minus an offset \f$o_i\f$ (OFFSET).
 The expression for the bias due to the wall is given by:
 
+for UPPER_WALLS:
 \f$
   \sum_i {k_i}((x_i-a_i+o_i)/s_i)^e_i
+\f$
+
+for LOWER_WALLS:
+\f$
+  \sum_i {k_i}|(x_i-a_i-o_i)/s_i|^e_i
 \f$
 
 \f$k_i\f$ (KAPPA) is an energy constant in internal unit of the code, \f$s_i\f$ (EPS) a rescaling factor and


### PR DESCRIPTION


<!--
  Feel free to delete not relevant sections below
-->

##### Description

This is about #1091, now if a lower wall is asked with an odd exponent, it should give the correct force, and I think also the energy because ` ene += k * power;` now will contribute with a positive and repulsive term in any case.

I think we need some more tests to check this.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release v2.9

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
