### PR TITLE
Reuse result from getenv

### DIFF
--- a/src/wrapper/Plumed.h
+++ b/src/wrapper/Plumed.h
@@ -4015,6 +4015,8 @@ void plumed_retrieve_functions(plumed_plumedmain_function_holder* functions, plu
   void* p;
   char* debug;
   int dlopenmode;
+  /* possible value of PLUMED_LOAD_NAMESPACE environment variable */
+  char *load_namespace;
   g.create=__PLUMED_WRAPPER_CXX_NULLPTR;
   g.cmd=__PLUMED_WRAPPER_CXX_NULLPTR;
   g.finalize=__PLUMED_WRAPPER_CXX_NULLPTR;
@@ -4045,7 +4047,8 @@ void plumed_retrieve_functions(plumed_plumedmain_function_holder* functions, plu
     __PLUMED_FPRINTF(stderr,"+++ PLUMED_KERNEL=\"%s\" +++\n",path);
     if(debug) __PLUMED_FPRINTF(stderr,"+++ Loading with mode RTLD_NOW");
     dlopenmode=RTLD_NOW;
-    if(__PLUMED_GETENV("PLUMED_LOAD_NAMESPACE") && !__PLUMED_WRAPPER_STD strcmp(__PLUMED_GETENV("PLUMED_LOAD_NAMESPACE"),"GLOBAL")) {
+    load_namespace = __PLUMED_GETENV("PLUMED_LOAD_NAMESPACE");
+    if(load_namespace && !__PLUMED_WRAPPER_STD strcmp(load_namespace,"GLOBAL")) {
       dlopenmode=dlopenmode|RTLD_GLOBAL;
       if(debug) __PLUMED_FPRINTF(stderr,"|RTLD_GLOBAL");
     } else {
@@ -4151,6 +4154,8 @@ plumed plumed_create(void) {
   plumed p;
   /* pointer to implementation */
   plumed_implementation* pimpl;
+  /* possible value of PLUMED_LOAD_DLCLOSE environment variable */
+  char *load_dlclose;
   /* allocate space for implementation object. this is free-ed in plumed_finalize(). */
   pimpl=plumed_malloc_pimpl();
   /* store pointers in pimpl */
@@ -4161,7 +4166,8 @@ plumed plumed_create(void) {
 #endif
   /* note if handle should not be dlclosed */
   pimpl->dlclose=1;
-  if(__PLUMED_GETENV("PLUMED_LOAD_DLCLOSE") && !__PLUMED_WRAPPER_STD strcmp(__PLUMED_GETENV("PLUMED_LOAD_DLCLOSE"),"no")) pimpl->dlclose=0;
+  load_dlclose = __PLUMED_GETENV("PLUMED_LOAD_DLCLOSE");
+  if(load_dlclose && !__PLUMED_WRAPPER_STD strcmp(load_dlclose,"no")) pimpl->dlclose=0;
   /* in case of failure, return */
   /* the resulting object should be plumed_finalized, though you cannot use plumed_cmd */
   if(!pimpl->functions.create) {


### PR DESCRIPTION
##### Description

In theory, calling getenv a second time could return NULL after previously returning non-NULL, which would be undefined behavior when passed to strcmp. Re-using the non-NULL value is slightly safer, and keeps clang's static analyzer happier.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __XXXXX__

##### Type of contribution

- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
