### PR TITLE
Handler class does not have a `watch` field

### DIFF
--- a/src/tools/Tools.h
+++ b/src/tools/Tools.h
@@ -368,7 +368,7 @@ public:
           section=handler.section;
           key=std::move(handler.key);
         }
-        handler.watch=nullptr;
+        handler.section=nullptr;
         return *this;
       }
       /// Destructor
@@ -517,4 +517,3 @@ std::vector<const T*> Tools::unique2raw(const std::vector<std::unique_ptr<const 
 }
 
 #endif
-


### PR DESCRIPTION
##### Description

Remove extraneous field assignment. This breaks the build for me when trying to compile the master branch using https://github.com/plumed/conda/.

Since this was not caught in the 6 months since this code was introduced, maybe it is not used anywhere in the code base? I'm not sure why this is failing now.

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
