### PR TITLE
Fix building shared libraries on macOS with `--enable-libtorch`

### DIFF
--- a/configure
+++ b/configure
@@ -2341,7 +2341,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 # PLUMED_CHECK_LDFLAGS(flag)
-# use it to check if a flag is available on this compiler
+# use it to check if a flag is available for linking
 
 
 # PLUMED_SEARCH_LIBS(function,search-libs[,action-if-found][,action-if-not-found][,other-libraries])
@@ -9664,24 +9664,11 @@ fi
 if test $libtorch = true ; then
   # disable as-needed in linking libraries (both static and shared)
 
-  save_CXXFLAGS="$CXXFLAGS"
-  CXXFLAGS="$CXXFLAGS -Wl,--no-as-needed"
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CXX accepts -Wl,--no-as-needed" >&5
-$as_echo_n "checking whether $CXX accepts -Wl,--no-as-needed... " >&6; }
+  save_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether LDFLAGS can contain -Wl,--no-as-needed" >&5
+$as_echo_n "checking whether LDFLAGS can contain -Wl,--no-as-needed... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
@@ -9696,20 +9683,12 @@ if ac_fn_cxx_try_link "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: not linking" >&5
-$as_echo "not linking" >&6; }; CXXFLAGS="$save_CXXFLAGS"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }; LDFLAGS="$save_LDFLAGS"
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }; CXXFLAGS="$save_CXXFLAGS"
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-  LDSHARED="$LDSHARED -Wl,--no-as-needed "
 
   # CUDA and CPU libtorch libs have different libraries
   # first test CUDA program

--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ AC_DEFUN([PLUMED_CHECK_CFLAG], [
 ])
 
 # PLUMED_CHECK_LDFLAGS(flag)
-# use it to check if a flag is available on this compiler
+# use it to check if a flag is available for linking
 AC_DEFUN([PLUMED_CHECK_LDFLAGS], [
   save_LDFLAGS="$LDFLAGS"
   LDFLAGS="$LDFLAGS $1"
@@ -935,8 +935,7 @@ fi
 #added by luigibonati
 if test $libtorch = true ; then 
   # disable as-needed in linking libraries (both static and shared)
-  PLUMED_CHECK_CXXFLAG([-Wl,--no-as-needed])
-  LDSHARED="$LDSHARED -Wl,--no-as-needed "
+  PLUMED_CHECK_LDFLAGS([-Wl,--no-as-needed])
 
   # CUDA and CPU libtorch libs have different libraries
   # first test CUDA program


### PR DESCRIPTION
##### Description

The configure code was unconditionally adding `-Wl;--no-as-needed` to the flags, even though these are not valid on macOS.

I'm not sure why this needs `--no-as-needed` on linux on the first place, @luigibonati do you remember why this is the case? 

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [x] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
