### PR TITLE
Use process group signal handling to reach past the shell

### DIFF
--- a/src/tools/Subprocess.cpp
+++ b/src/tools/Subprocess.cpp
@@ -51,19 +51,19 @@ public:
   void stop() noexcept {
     // Signals give problems with MPI on Travis.
     // I disable them for now.
-    if(SubprocessPidGetenvSignals()) kill(pid,SIGSTOP);
+    if(SubprocessPidGetenvSignals()) kill(-pid,SIGSTOP);
   }
   void cont() noexcept {
     // Signals give problems with MPI on Travis.
     // I disable them for now.
-    if(SubprocessPidGetenvSignals()) kill(pid,SIGCONT);
+    if(SubprocessPidGetenvSignals()) kill(-pid,SIGCONT);
   }
   ~SubprocessPid() {
     // the destructor implies we do not need the subprocess anymore, so SIGKILL
     // is the fastest exit.
     // if we want to gracefully kill the process with a delay, it would be cleaner
     // to have another member function
-    kill(pid,SIGKILL);
+    kill(-pid,SIGINT);
     // Wait for the child process to terminate
     // This is anyway required to avoid leaks
     int status;
@@ -99,6 +99,7 @@ Subprocess::Subprocess(const std::string & cmd) {
     if(dup(pc[0])<0) plumed_error()<<"error duplicating file";
     if(close(pc[1])<0) plumed_error()<<"error closing file";
     if(close(cp[0])<0) plumed_error()<<"error closing file";
+    if(setpgid(0,0)<0) plumed_error()<<"error setting process group";;
     auto err=execv(arr[0],arr);
     plumed_error()<<"error in script file " << cmd << ", execv returned "<<err;
   }


### PR DESCRIPTION
Spawn processes is their own process group and then signal the process group intstead of just the process we spawned to ensure the signals also reach any subprocesses started by the process we spawned (which is always the case as we are wrapping all our processes spawning with "/bin/sh -c ...").

This make sending SIGINT work again, so revert back to that instead of SIGKILL. The reason SIGINT wasn't working was the shell logic is that this is expected to be sent to the process group, so it doesn't need to pass it along or anything. See the bash signals documentation page for more details

https://www.gnu.org/software/bash/manual/html_node/Signals.html

<!--
  Feel free to delete not relevant sections below
-->

##### Description

<!-- describe here your pull request -->

##### Target release

It doesn't matter to me.

##### Type of contribution

- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).