### PR TITLE
Do not hold Python's GIL when running commands

### DIFF
--- a/python/cplumed.pxd
+++ b/python/cplumed.pxd
@@ -31,7 +31,7 @@ cdef extern from "Plumed.h":
         size_t nelem
         size_t* shape
         size_t flags
-        # ignore other 
+        # ignore other
     ctypedef struct plumed_nothrow_handler:
         void* ptr
         void (*handler)(void*,int,const char*,const void*)
@@ -46,12 +46,12 @@ cdef extern from "Plumed.h":
         plumed_error_filesystem_path path1
         plumed_error_filesystem_path path2
         # ignore other members
-    void plumed_cmd_safe_nothrow(plumed p,const char*key,plumed_safeptr safe,plumed_nothrow_handler nothrow)
-    void plumed_error_set(void*ptr,int code,const char*what,const void* opt)
-    void plumed_error_init(plumed_error* error)
-    void plumed_error_finalize(plumed_error error)
-    plumed plumed_create()
-    plumed plumed_create_dlopen(const char*path)
-    plumed plumed_create_invalid()
-    void plumed_finalize(plumed p)
-    int plumed_valid(plumed p)
+    void plumed_cmd_safe_nothrow(plumed p,const char*key,plumed_safeptr safe,plumed_nothrow_handler nothrow) nogil
+    void plumed_error_set(void*ptr,int code,const char*what,const void* opt) nogil
+    void plumed_error_init(plumed_error* error) nogil
+    void plumed_error_finalize(plumed_error error) nogil
+    plumed plumed_create() nogil
+    plumed plumed_create_dlopen(const char*path) nogil
+    plumed plumed_create_invalid() nogil
+    void plumed_finalize(plumed p) nogil
+    int plumed_valid(plumed p) nogil

--- a/python/plumed.pyx
+++ b/python/plumed.pyx
@@ -36,6 +36,7 @@ import sys
 import warnings
 import types
 
+import cython
 from cython.operator import dereference
 
 if sys.version_info < (3,):
@@ -185,7 +186,8 @@ cdef class Plumed:
          cplumed.plumed_error_init(&error)
          nothrow.ptr=&error
          nothrow.handler=cplumed.plumed_error_set
-         cplumed.plumed_cmd_safe_nothrow(self.c_plumed,ckey,safe,nothrow)
+         with cython.nogil():
+            cplumed.plumed_cmd_safe_nothrow(self.c_plumed,ckey,safe,nothrow)
          if(error.code):
            try:
              self.raise_exception(error)
@@ -507,7 +509,7 @@ def read_as_pandas(file_or_path,enable_constants=True,enable_conversion=True,ker
         convert=_build_convert_function(kernel)
 # if necessary, set convert_all
         if enable_conversion=='all': convert_all=convert
-         
+
 # handle file
     file_or_path=_fix_file(file_or_path,'rt')
 
@@ -588,7 +590,7 @@ def write_pandas(df,file_or_path=None):
        colvar=plumed.read_as_colvar("COLVAR")
        colvar["distance"]=colvar["distance"]*2
        plumed.write_pandas(colvar)
-      
+
     """
 # importing pandas is pretty slow, so we only do it when needed
     import pandas as pd
@@ -787,7 +789,7 @@ def _readvimdict(plumedroot=None,kernel=None):
 # read dictionary
         for opt in plumedDictionary[action]:
 # skip label (it is added automatically)
-            if opt["menu"] != "(label)":                
+            if opt["menu"] != "(label)":
                 ret[action][re.sub("=$","",opt["word"])]=opt["menu"]
     return ret,doc
 
@@ -916,7 +918,7 @@ def _format_at_one_residue(builder,name,residue,chain):
         return "@" + name + "-" + chain + str(residue)
       else:
         assert False
-    
+
 def _format_at_one_chain(builder,name,residue,chain):
       res=""
       if hasattr(residue,'__iter__') and not isinstance(residue,str):
@@ -924,7 +926,7 @@ def _format_at_one_chain(builder,name,residue,chain):
               res+=builder._separator + _format_at_one_residue(builder,name,x,chain)
       else:
         res+=builder._separator + _format_at_one_residue(builder,name,residue,chain)
-              
+
       return res
 
 def _format_at(builder,name,residue,chain=""):
@@ -1074,7 +1076,7 @@ def _format_anything(builder,name,arg):
    ret=""
    if name == "verbatim":
        ret+=_format_verbatim(builder,arg)
-   elif isinstance(arg,bool) : 
+   elif isinstance(arg,bool) :
        ret+=_format_flag(builder,name,arg)
    elif isinstance(arg,_numbered):
        ret+=_format_numbered(builder,name,arg)
@@ -1236,6 +1238,3 @@ class InputBuilder:
         Accepts a list/tuple.
         """
         return _replicas(arg)
-
-
-


### PR DESCRIPTION
##### Description

Fixes #1128. I can confirm this fixes the issue for `metatensor` actions.

However, I'm not sure how to test that `pycv` still works fine, is it included in the CI test suite?

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
