### PR TITLE
DRR: correctly separate the calculate and update

### DIFF
--- a/src/drr/DRR.h
+++ b/src/drr/DRR.h
@@ -310,9 +310,11 @@ public:
     mMaxFactors = maxFactors;
   }
   // Store the "instantaneous" spring force of a point and get ABF bias forces.
-  bool store_getbias(const vector<double> &pos,
-                     const vector<double> &f,
-                     vector<double> &fbias);
+  bool getbias(const vector<double> &pos,
+               const vector<double> &f,
+               vector<double> &fbias) const;
+  void store_force(const vector<double> &pos,
+                   const vector<double> &f);
   static ABF mergewindow(const ABF &aWA, const ABF &aWB);
   ~ABF() {}
 

--- a/src/drr/DynamicReferenceRestraining.cpp
+++ b/src/drr/DynamicReferenceRestraining.cpp
@@ -701,7 +701,6 @@ DynamicReferenceRestraining::DynamicReferenceRestraining(
 }
 
 void DynamicReferenceRestraining::calculate() {
-  long long int step_now = getStep();
   if (firsttime) {
     for (size_t i = 0; i < ndims; ++i) {
       fict[i] = getArgument(i);
@@ -711,6 +710,46 @@ void DynamicReferenceRestraining::calculate() {
     }
     firsttime = false;
   }
+  if (withExternalForce == false) {
+    double ene = 0.0;
+    for (size_t i = 0; i < ndims; ++i) {
+      real[i] = getArgument(i);
+      springlength[i] = difference(i, fict[i], real[i]);
+      fictNoPBC[i] = real[i] - springlength[i];
+      double f = -kappa[i] * springlength[i];
+      ffict_measured[i] = -f;
+      ene += 0.5 * kappa[i] * springlength[i] * springlength[i];
+      setOutputForce(i, f);
+      ffict[i] = -f;
+      fict[i] = fictValue[i]->bringBackInPbc(fict[i]);
+      fictValue[i]->set(fict[i]);
+      vfictValue[i]->set(vfict_laststep[i]);
+      springforceValue[i]->set(ffict_measured[i]);
+      fictNoPBCValue[i]->set(fictNoPBC[i]);
+    }
+    setBias(ene);
+    ABFGrid.getbias(fict, ffict_measured, fbias);
+  } else {
+    for (size_t i = 0; i < ndims; ++i) {
+      real[i] = getArgument(i);
+      ffict_measured[i] = externalForceValue[i]->get();
+      if (withExternalFict) {
+        fictNoPBC[i] = externalFictValue[i]->get();
+      }
+      springforceValue[i]->set(ffict_measured[i]);
+      fictNoPBCValue[i]->set(fictNoPBC[i]);
+    }
+    ABFGrid.getbias(real, ffict_measured, fbias);
+    if (!nobias) {
+      for (size_t i = 0; i < ndims; ++i) {
+        setOutputForce(i, fbias[i]);
+      }
+    }
+  }
+}
+
+void DynamicReferenceRestraining::update() {
+  const long long int step_now = getStep();
   if (step_now != 0) {
     if ((step_now % int(outputfreq)) == 0) {
       save(outputname, step_now);
@@ -748,40 +787,18 @@ void DynamicReferenceRestraining::calculate() {
     }
   }
   if (withExternalForce == false) {
-    double ene = 0.0;
     for (size_t i = 0; i < ndims; ++i) {
       real[i] = getArgument(i);
       springlength[i] = difference(i, fict[i], real[i]);
-      fictNoPBC[i] = real[i] - springlength[i];
-      double f = -kappa[i] * springlength[i];
-      ffict_measured[i] = -f;
-      ene += 0.5 * kappa[i] * springlength[i] * springlength[i];
-      setOutputForce(i, f);
-      ffict[i] = -f;
-      fict[i] = fictValue[i]->bringBackInPbc(fict[i]);
-      fictValue[i]->set(fict[i]);
-      vfictValue[i]->set(vfict_laststep[i]);
-      springforceValue[i]->set(ffict_measured[i]);
-      fictNoPBCValue[i]->set(fictNoPBC[i]);
+      ffict_measured[i] = kappa[i] * springlength[i];
     }
-    setBias(ene);
-    ABFGrid.store_getbias(fict, ffict_measured, fbias);
+    ABFGrid.store_force(fict, ffict_measured);
   } else {
     for (size_t i = 0; i < ndims; ++i) {
       real[i] = getArgument(i);
       ffict_measured[i] = externalForceValue[i]->get();
-      if (withExternalFict) {
-        fictNoPBC[i] = externalFictValue[i]->get();
-      }
-      springforceValue[i]->set(ffict_measured[i]);
-      fictNoPBCValue[i]->set(fictNoPBC[i]);
     }
-    ABFGrid.store_getbias(real, ffict_measured, fbias);
-    if (!nobias) {
-      for (size_t i = 0; i < ndims; ++i) {
-        setOutputForce(i, fbias[i]);
-      }
-    }
+    ABFGrid.store_force(real, ffict_measured);
   }
   if (useCZARestimator) {
     CZARestimator.store(real, ffict_measured);
@@ -790,9 +807,6 @@ void DynamicReferenceRestraining::calculate() {
     eabf_UI.update_output_filename(outputprefix);
     eabf_UI.update(int(step_now), real, fictNoPBC);
   }
-}
-
-void DynamicReferenceRestraining::update() {
   if (withExternalForce == false) {
     for (size_t i = 0; i < ndims; ++i) {
       // consider additional forces on the fictitious particle


### PR DESCRIPTION
The previous implementation updates the internal states partially in calculate(), which should be done in update(). This commit fixes the issue.

<!--
  Feel free to delete not relevant sections below
-->

##### Description

This PR refactors the DRR implementation by moving the update of the eABF grid and the estimators in the `update()` function from `calculate()`.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.11__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [X] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [X] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
