### PR TITLE
Removed a typo from regtest/scripts/run

### DIFF
--- a/regtest/scripts/run
+++ b/regtest/scripts/run
@@ -164,12 +164,12 @@ if type -t plumed_custom_skip 1>/dev/null ; then
   if plumed_custom_skip ; then
     if [ "$TRAVIS" = true ] || [ "$GITHUB_ACTIONS" = true ] ; then
       if [ -z "$PLUMED_ALLOW_SKIP_ON_TRAVIS" ] ; then
-        echo "NOT_APPLIABLE (plumed_custom_skip)"
+        echo "NOT_APPLICABLE (plumed_custom_skip)"
       else
         echo "SKIP_ON_TRAVIS found!"
       fi
     else
-      echo "NOT_APPLIABLE (plumed_custom_skip)"
+      echo "NOT_APPLICABLE (plumed_custom_skip)"
     fi
     exit 0;
   fi


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

As the title, with this typo, regtest/scripts/check marks as "successful" the few tests that use `plumed_custom_skip` when they are skipped, found while working on #1134

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.9->2.11

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
