### PR TITLE
Macro for fasterMulticolvar+named modes

### DIFF
--- a/regtest/crystdistrib/rt-dops-shortcut/config
+++ b/regtest/crystdistrib/rt-dops-shortcut/config
@@ -1,4 +1,4 @@
 type=driver
-plumed_modules=crystdistrib
+plumed_modules="crystdistrib adjmat"
 arg="--plumed plumed.dat --mf_xtc em.xtc --mc mcfile --timestep=0.001 --trajectory-stride=25"
 extra_files="../../trajectories/em.xtc"

--- a/regtest/multicolvar/rt-input/Makefile
+++ b/regtest/multicolvar/rt-input/Makefile
@@ -1,0 +1,1 @@
+include ../../scripts/test.make

--- a/regtest/multicolvar/rt-input/config
+++ b/regtest/multicolvar/rt-input/config
@@ -1,0 +1,1 @@
+type=make

--- a/regtest/multicolvar/rt-input/main.cpp
+++ b/regtest/multicolvar/rt-input/main.cpp
@@ -1,0 +1,201 @@
+#include "plumed/colvar/MultiColvarTemplate.h"
+#include "plumed/tools/Vector.h"
+
+#include <fstream>
+#include <iostream>
+#include <variant>
+#include <vector>
+
+using namespace PLMD;
+using colvar::multiColvars::Input;
+
+template <typename T> void pv(std::ofstream &stream, const std::vector<T> &v) {
+  // todo: put this is a common header
+  std::string div = "";
+  stream << "(" << v.size() << ") ";
+  for (const auto &t : v) {
+    stream << div << t;
+    div = ", ";
+  }
+}
+
+void print(std::ofstream &stream, const std::vector<double> &masses,
+           const std::vector<double> &charges,
+           const std::vector<Vector> positions) {
+  stream << "Masses: ";
+  pv(stream, masses);
+  stream << "\nCharges: ";
+  pv(stream, charges);
+  stream << "\nPositions: ";
+  pv(stream, positions);
+  stream << "\n";
+}
+
+void inputTest(std::ofstream &stream, Input input) {
+  try {
+    const auto &masses = input.masses();
+    stream << " Masses: ";
+    pv(stream, masses);
+    stream << "\n";
+  } catch (std::bad_variant_access &) {
+    stream << " There are no masses\n";
+  }
+
+  try {
+    const auto &charges = input.charges();
+    stream << " Charges: ";
+    pv(stream, charges);
+    stream << "\n";
+  } catch (std::bad_variant_access &) {
+    stream << " There are no charges\n";
+  }
+  try {
+    const auto &positions = input.positions();
+    stream << " Positions: ";
+    pv(stream, positions);
+    stream << "\n";
+  } catch (std::bad_variant_access &) {
+    stream << " There are no positions\n";
+  }
+  stream << std::endl;
+}
+
+void workOnMass(Input input) {
+  auto &masses = input.var_masses();
+  for (auto &m : masses) {
+    m *= 2;
+  }
+}
+
+void workOnCharges(Input input) {
+  auto &charges = input.var_charges();
+  for (auto &c : charges) {
+    c *= 2;
+  }
+}
+
+void workOnPositions(Input input) {
+  auto &pos = input.var_positions();
+  for (auto &p : pos) {
+    p = p * 2.0;
+  }
+}
+
+class testData {
+  using vd = std::vector<double>;
+  using vv = std::vector<Vector>;
+  vv p = {{0, 0, 0}, {1, 1, 1}};
+  vd c = {-1, 1};
+  vd m = {3, 4};
+
+public:
+  testData() = default;
+  vd &masses() { return m; }
+  vd &charges() { return c; }
+  vv &positions() { return p; }
+  const vd &c_masses() const { return m; }
+  const vd &c_charges() const { return c; }
+  const vv &c_positions() const { return p; }
+};
+
+class test {
+  using vd = std::vector<double>;
+  using vv = std::vector<Vector>;
+
+public:
+  test() = default;
+  void dotestWithReference(std::ofstream &output) {
+    testData td;
+    output << "*dotestWithReference:" << std::endl;
+    output << "*Passing full input:\n";
+    inputTest(output, Input(td.masses(), td.charges(), td.positions()));
+    output << "*Passing only positions:\n";
+    inputTest(output, Input().positions(td.positions()));
+    output << "*Passing only masses:\n";
+    inputTest(output, Input().masses(td.masses()));
+    output << "*Passing only charges:\n";
+    inputTest(output, Input().charges(td.charges()));
+  }
+  void dotestWithConstReference(std::ofstream &output) {
+    testData td;
+    output << "*dotestWithConstReference:" << std::endl;
+    output << "*Passing full input:\n";
+    inputTest(output, Input(td.c_masses(), td.c_charges(), td.c_positions()));
+    output << "*Passing only positions:\n";
+    inputTest(output, Input().positions(td.c_positions()));
+    output << "*Passing only masses:\n";
+    inputTest(output, Input().masses(td.c_masses()));
+    output << "*Passing only charges:\n";
+    inputTest(output, Input().charges(td.c_charges()));
+  }
+
+  void testUsingInputAsBuffer_masses(std::ofstream &output) {
+    testData td;
+    output << "*testUsingInputAsBuffer_masses:" << std::endl;
+    output << "*Passing constant_reference:\n";
+    try {
+      workOnMass(Input(td.c_masses(), td.c_charges(), td.c_positions()));
+    } catch (std::bad_variant_access &) {
+      output << " should throw\n";
+    }
+    output << "*Passing reference:\n";
+    output << " Initial values\n Masses:";
+    pv(output, td.masses());
+    workOnMass(Input(td.masses(), td.charges(), td.positions()));
+    output << "\n";
+    // this extra line is to remember that something has changed!!!
+    output << " Values after call\n Masses:";
+    pv(output, td.masses());
+    output << std::endl;
+  }
+  void testUsingInputAsBuffer_charges(std::ofstream &output) {
+    testData td;
+    output << "*testUsingInputAsBuffer_charges:" << std::endl;
+    output << "*Passing constant_reference:\n";
+    try {
+      workOnCharges(Input(td.c_masses(), td.c_charges(), td.c_positions()));
+    } catch (std::bad_variant_access &) {
+      output << " should throw\n";
+    }
+    output << "*Passing reference:\n";
+    output << " Initial values\n Charges:";
+    pv(output, td.c_charges());
+    workOnCharges(Input(td.masses(), td.charges(), td.positions()));
+    output << "\n";
+    // this extra line is to remember that something has changed!!!
+    output << " Values after call\n Charges:";
+    pv(output, td.c_charges());
+    output << std::endl;
+  }
+  void testUsingInputAsBuffer_positions(std::ofstream &output) {
+    testData td;
+    output << "*testUsingInputAsBuffer_positions:" << std::endl;
+    output << "*Passing constant_reference:\n";
+    try {
+      workOnPositions(Input(td.c_masses(), td.c_charges(), td.c_positions()));
+    } catch (std::bad_variant_access &) {
+      output << " should throw\n";
+    }
+    output << "*Passing reference:\n";
+    output << " Initial values\n Positions:";
+    pv(output, td.positions());
+    workOnPositions(Input(td.masses(), td.charges(), td.positions()));
+    output << "\n";
+    // this extra line is to remember that something has changed!!!
+    output << " Values after call\n Positions:";
+    pv(output, td.positions());
+    output << std::endl;
+  }
+};
+
+int main() {
+  std::ofstream output("output");
+
+  test t;
+  t.dotestWithReference(output);
+  t.dotestWithConstReference(output);
+  t.testUsingInputAsBuffer_masses(output);
+  t.testUsingInputAsBuffer_charges(output);
+  t.testUsingInputAsBuffer_positions(output);
+  return 0;
+}

--- a/regtest/multicolvar/rt-input/output.reference
+++ b/regtest/multicolvar/rt-input/output.reference
@@ -1,0 +1,66 @@
+*dotestWithReference:
+*Passing full input:
+ Masses: (2) 3, 4
+ Charges: (2) -1, 1
+ Positions: (2) 0 0 0, 1 1 1
+
+*Passing only positions:
+ There are no masses
+ There are no charges
+ Positions: (2) 0 0 0, 1 1 1
+
+*Passing only masses:
+ Masses: (2) 3, 4
+ There are no charges
+ There are no positions
+
+*Passing only charges:
+ There are no masses
+ Charges: (2) -1, 1
+ There are no positions
+
+*dotestWithConstReference:
+*Passing full input:
+ Masses: (2) 3, 4
+ Charges: (2) -1, 1
+ Positions: (2) 0 0 0, 1 1 1
+
+*Passing only positions:
+ There are no masses
+ There are no charges
+ Positions: (2) 0 0 0, 1 1 1
+
+*Passing only masses:
+ Masses: (2) 3, 4
+ There are no charges
+ There are no positions
+
+*Passing only charges:
+ There are no masses
+ Charges: (2) -1, 1
+ There are no positions
+
+*testUsingInputAsBuffer_masses:
+*Passing constant_reference:
+ should throw
+*Passing reference:
+ Initial values
+ Masses:(2) 3, 4
+ Values after call
+ Masses:(2) 6, 8
+*testUsingInputAsBuffer_charges:
+*Passing constant_reference:
+ should throw
+*Passing reference:
+ Initial values
+ Charges:(2) -1, 1
+ Values after call
+ Charges:(2) -2, 2
+*testUsingInputAsBuffer_positions:
+*Passing constant_reference:
+ should throw
+*Passing reference:
+ Initial values
+ Positions:(2) 0 0 0, 1 1 1
+ Values after call
+ Positions:(2) 0 0 0, 2 2 2

--- a/src/colvar/Angle.cpp
+++ b/src/colvar/Angle.cpp
@@ -104,12 +104,11 @@ class Angle : public Colvar {
   std::vector<std::vector<Vector> > derivs;
   std::vector<Tensor> virial;
 public:
-  MULTICOLVAR_SETTINGS(multiColvars::emptyMode);
+  MULTICOLVAR_DEFAULT(multiColvars::emptyMode);
   explicit Angle(const ActionOptions&);
 // active methods:
   void calculate() override;
   static void registerKeywords( Keywords& keys );
-  static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
 
 };
 
@@ -126,7 +125,7 @@ void Angle::registerKeywords( Keywords& keys ) {
   keys.setValueDescription("the ANGLE involving these atoms");
 }
 
-void Angle::parseAtomList( const int& num, std::vector<AtomNumber>& atoms, ActionAtomistic* aa ) {
+void Angle::parseAtomList( int const num, std::vector<AtomNumber>& atoms, ActionAtomistic* aa ) {
   aa->parseAtomList("ATOMS",num,atoms);
   if(atoms.size()==3) {
     aa->log.printf("  between atoms %d %d %d\n",atoms[0].serial(),atoms[1].serial(),atoms[2].serial());

--- a/src/colvar/Angle.cpp
+++ b/src/colvar/Angle.cpp
@@ -100,7 +100,7 @@ Calculate multiple angles.
 
 class Angle : public Colvar {
   bool pbc;
-  std::vector<double> value, masses, charges;
+  std::vector<double> value;
   std::vector<std::vector<Vector> > derivs;
   std::vector<Tensor> virial;
 public:
@@ -168,19 +168,21 @@ Angle::Angle(const ActionOptions&ao):
 void Angle::calculate() {
 
   if(pbc) makeWhole();
-  calculateCV( {}, masses, charges, getPositions(), multiColvars::Ouput(value, derivs, virial), this );
+  calculateCV( {}, multiColvars::Input().positions(getPositions()), multiColvars::Ouput(value, derivs, virial), this );
   setValue( value[0] );
   for(unsigned i=0; i<derivs[0].size(); ++i)
     setAtomsDerivatives( i, derivs[0][i] );
   setBoxDerivatives( virial[0] );
 }
 
-void Angle::calculateCV( Modetype /*mode*/, const std::vector<double>& /*masses*/, const std::vector<double>& /*charges*/,
-                         const std::vector<Vector>& pos,
-                         multiColvars::Ouput out, const ActionAtomistic* aa ) {
+void Angle::calculateCV( Modetype /*mode*/,
+                         multiColvars::Input const in,
+                         multiColvars::Ouput out,
+                         const ActionAtomistic* aa ) {
   auto & vals=out.vals();
   auto & derivs=out.derivs();
   auto & virial=out.virial();
+  const auto & pos=in.positions();
   Vector dij,dik;
   dij=delta(pos[2],pos[3]);
   dik=delta(pos[1],pos[0]);

--- a/src/colvar/Angle.cpp
+++ b/src/colvar/Angle.cpp
@@ -168,7 +168,7 @@ Angle::Angle(const ActionOptions&ao):
 void Angle::calculate() {
 
   if(pbc) makeWhole();
-  calculateCV( {}, masses, charges, getPositions(), value, derivs, virial, this );
+  calculateCV( {}, masses, charges, getPositions(), multiColvars::Ouput(value, derivs, virial), this );
   setValue( value[0] );
   for(unsigned i=0; i<derivs[0].size(); ++i)
     setAtomsDerivatives( i, derivs[0][i] );
@@ -176,8 +176,11 @@ void Angle::calculate() {
 }
 
 void Angle::calculateCV( Modetype /*mode*/, const std::vector<double>& /*masses*/, const std::vector<double>& /*charges*/,
-                         const std::vector<Vector>& pos, std::vector<double>& vals, std::vector<std::vector<Vector> >& derivs,
-                         std::vector<Tensor>& virial, const ActionAtomistic* /*aa*/ ) {
+                         const std::vector<Vector>& pos,
+                         multiColvars::Ouput out, const ActionAtomistic* aa ) {
+  auto & vals=out.vals();
+  auto & derivs=out.derivs();
+  auto & virial=out.virial();
   Vector dij,dik;
   dij=delta(pos[2],pos[3]);
   dik=delta(pos[1],pos[0]);

--- a/src/colvar/DihedralCorrelation.cpp
+++ b/src/colvar/DihedralCorrelation.cpp
@@ -68,10 +68,9 @@ private:
   std::vector<std::vector<Vector> > derivs;
   std::vector<Tensor> virial;
 public:
-  MULTICOLVAR_SETTINGS(multiColvars::emptyMode);
+  MULTICOLVAR_DEFAULT(multiColvars::emptyMode);
   static void registerKeywords( Keywords& keys );
   explicit DihedralCorrelation(const ActionOptions&);
-  static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
   void calculate() override;
 };
 
@@ -107,7 +106,7 @@ DihedralCorrelation::DihedralCorrelation(const ActionOptions&ao):
   else    log.printf("  without periodic boundary conditions\n");
 }
 
-void DihedralCorrelation::parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
+void DihedralCorrelation::parseAtomList( int const num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
   aa->parseAtomList("ATOMS",num,t);
   if( num<0 && t.size()!=8 ) aa->error("Number of specified atoms should be 8");
   if( t.size()==8 ) {

--- a/src/colvar/DihedralCorrelation.cpp
+++ b/src/colvar/DihedralCorrelation.cpp
@@ -64,7 +64,7 @@ Measure the correlation between a multiple pairs of dihedral angles
 class DihedralCorrelation : public Colvar {
 private:
   bool pbc;
-  std::vector<double> value, masses, charges;
+  std::vector<double> value;
   std::vector<std::vector<Vector> > derivs;
   std::vector<Tensor> virial;
 public:
@@ -124,18 +124,19 @@ DihedralCorrelation::Modetype DihedralCorrelation::getModeAndSetupValues( Action
 void DihedralCorrelation::calculate() {
 
   if(pbc) makeWhole();
-  calculateCV( {}, masses, charges, getPositions(), multiColvars::Ouput(value, derivs, virial), this );
+  calculateCV( {}, multiColvars::Input().positions(getPositions()), multiColvars::Ouput(value, derivs, virial), this );
   setValue( value[0] );
   for(unsigned i=0; i<derivs[0].size(); ++i) setAtomsDerivatives( i, derivs[0][i] );
   setBoxDerivatives( virial[0] );
 }
 
-void DihedralCorrelation::calculateCV(Modetype  /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
-                                      const std::vector<Vector>& pos,
+void DihedralCorrelation::calculateCV(Modetype  /*mode*/,
+                                      multiColvars::Input const in,
                                       multiColvars::Ouput out, const ActionAtomistic* aa ) {
   auto & vals=out.vals();
   auto & derivs=out.derivs();
   auto & virial=out.virial();
+  const auto& pos = in.positions();
   const Vector d10=delta(pos[1],pos[0]);
   const Vector d11=delta(pos[2],pos[1]);
   const Vector d12=delta(pos[3],pos[2]);

--- a/src/colvar/DihedralCorrelation.cpp
+++ b/src/colvar/DihedralCorrelation.cpp
@@ -124,15 +124,18 @@ DihedralCorrelation::Modetype DihedralCorrelation::getModeAndSetupValues( Action
 void DihedralCorrelation::calculate() {
 
   if(pbc) makeWhole();
-  calculateCV( {}, masses, charges, getPositions(), value, derivs, virial, this );
+  calculateCV( {}, masses, charges, getPositions(), multiColvars::Ouput(value, derivs, virial), this );
   setValue( value[0] );
   for(unsigned i=0; i<derivs[0].size(); ++i) setAtomsDerivatives( i, derivs[0][i] );
   setBoxDerivatives( virial[0] );
 }
 
 void DihedralCorrelation::calculateCV(Modetype  /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
-                                      const std::vector<Vector>& pos, std::vector<double>& vals, std::vector<std::vector<Vector> >& derivs,
-                                      std::vector<Tensor>& virial, const ActionAtomistic* aa ) {
+                                      const std::vector<Vector>& pos,
+                                      multiColvars::Ouput out, const ActionAtomistic* aa ) {
+  auto & vals=out.vals();
+  auto & derivs=out.derivs();
+  auto & virial=out.virial();
   const Vector d10=delta(pos[1],pos[0]);
   const Vector d11=delta(pos[2],pos[1]);
   const Vector d12=delta(pos[3],pos[2]);

--- a/src/colvar/Dipole.cpp
+++ b/src/colvar/Dipole.cpp
@@ -90,11 +90,9 @@ class Dipole : public Colvar {
   Value* valuez=nullptr;
 public:
   explicit Dipole(const ActionOptions&);
-  static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
   void calculate() override;
   static void registerKeywords(Keywords& keys);
-  MULTICOLVAR_SETTINGS_MODE(multiColvars::components);
-  MULTICOLVAR_SETTINGS_SETUPF();
+  MULTICOLVAR_SETTINGS_BASE(multiColvars::components);
   //Declaring this playinly becasue we are using modifying the charges
   static void calculateCV( Modetype mode,
                            const std::vector<double>& masses,
@@ -149,7 +147,7 @@ Dipole::Dipole(const ActionOptions&ao):
   requestAtoms(ga_lista);
 }
 
-void Dipole::parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
+void Dipole::parseAtomList( int num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
   aa->parseAtomList("GROUP",num,t);
   if( t.size()>0 ) {
     aa->log.printf("  of %u atoms\n",static_cast<unsigned>(t.size()));

--- a/src/colvar/Distance.cpp
+++ b/src/colvar/Distance.cpp
@@ -134,10 +134,9 @@ class Distance : public Colvar {
 public:
   static void registerKeywords( Keywords& keys );
   explicit Distance(const ActionOptions&);
-  static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
 // active methods:
   void calculate() override;
-  MULTICOLVAR_SETTINGS(multiColvars::scaledComponents);
+  MULTICOLVAR_DEFAULT(multiColvars::scaledComponents);
 };
 
 typedef ColvarShortcut<Distance> DistanceShortcut;
@@ -199,7 +198,7 @@ Distance::Distance(const ActionOptions&ao):
   requestAtoms(atoms);
 }
 
-void Distance::parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
+void Distance::parseAtomList( int const num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
   aa->parseAtomList("ATOMS",num,t);
   if( t.size()==2 ) aa->log.printf("  between atoms %d %d\n",t[0].serial(),t[1].serial());
 }

--- a/src/colvar/Distance.cpp
+++ b/src/colvar/Distance.cpp
@@ -221,7 +221,7 @@ Distance::Modetype Distance::getModeAndSetupValues( ActionWithValue* av ) {
 void Distance::calculate() {
 
   if(pbc) makeWhole();
-  calculateCV( mode_, masses, charges, getPositions(), value, derivs, virial, this );
+  calculateCV( mode_, masses, charges, getPositions(), multiColvars::Ouput(value, derivs, virial), this );
 
   switch (mode_) {
   case Modetype::withCompontents: {
@@ -279,12 +279,15 @@ void Distance::calculate() {
 }
 
 void Distance::calculateCV( Modetype mode, const std::vector<double>& masses, const std::vector<double>& charges,
-                            const std::vector<Vector>& pos, std::vector<double>& vals, std::vector<std::vector<Vector> >& derivs,
-                            std::vector<Tensor>& virial, const ActionAtomistic* aa ) {
+                            const std::vector<Vector>& pos,
+                            multiColvars::Ouput out, const ActionAtomistic* aa ) {
+  auto & vals=out.vals();
+  auto & derivs=out.derivs();
+  auto & virial=out.virial();
   Vector distance=delta(pos[0],pos[1]);
   const double value=distance.modulo();
   const double invvalue=1.0/value;
-
+  //the compiler will alert me if I forgot a case :)
   switch (mode) {
   case Modetype::withCompontents: {
     derivs[0][0] = Vector(-1,0,0);

--- a/src/colvar/Distance.cpp
+++ b/src/colvar/Distance.cpp
@@ -132,8 +132,6 @@ public:
   MULTICOLVAR_DEFAULT(multiColvars::scaledComponents);
 private:
   std::vector<double> value{{0.0}};
-  std::vector<double>masses{{0.0}};
-  std::vector<double> charges{{0.0}};
   std::vector<std::vector<Vector> > derivs{std::vector<Vector>{Vector{},Vector{}}};
   std::vector<Tensor> virial{Tensor()};
   Modetype mode_;
@@ -221,7 +219,7 @@ Distance::Modetype Distance::getModeAndSetupValues( ActionWithValue* av ) {
 void Distance::calculate() {
 
   if(pbc) makeWhole();
-  calculateCV( mode_, masses, charges, getPositions(), multiColvars::Ouput(value, derivs, virial), this );
+  calculateCV( mode_, multiColvars::Input().positions(getPositions()), multiColvars::Ouput(value, derivs, virial), this );
 
   switch (mode_) {
   case Modetype::withCompontents: {
@@ -278,12 +276,13 @@ void Distance::calculate() {
   }
 }
 
-void Distance::calculateCV( Modetype mode, const std::vector<double>& masses, const std::vector<double>& charges,
-                            const std::vector<Vector>& pos,
+void Distance::calculateCV( Modetype mode,
+                            multiColvars::Input const in,
                             multiColvars::Ouput out, const ActionAtomistic* aa ) {
   auto & vals=out.vals();
   auto & derivs=out.derivs();
   auto & virial=out.virial();
+  const auto & pos = in.positions();
   Vector distance=delta(pos[0],pos[1]);
   const double value=distance.modulo();
   const double invvalue=1.0/value;

--- a/src/colvar/MultiColvarTemplate.h
+++ b/src/colvar/MultiColvarTemplate.h
@@ -43,6 +43,30 @@ enum class scaledComponents {
   noComponents
 };
 }
+/*MANUAL DRAFT
+To setup a CV compatible with multicolvartemplate you need to add
+ - A type that will be used to pass to calculateCV the calculation settings
+   - this type will be called `Modetype`
+   - using  Modetype=type;
+   - some default types are already defined in MultiColvarTemplate.h
+   - for example `using  Modetype=PLME::colvar::multiColvars::emptyMode;` when no setting inmact the calculation
+   - others predefined types are:
+     - `enum class components {withCompontents, noComponents};`
+     - `enum class plainOrScaled {scaled, plain};`
+     - `enum class scaledComponents {withCompontents, scaledComponents, noComponents};`
+ - some static function that will be called by the MultiColvarTemplate:
+   - these functions will need to match the foloowing signatures (withour the constness of the non const& arguments):
+   - `static void parseAtomList( int num, std::vector<AtomNumber>& t, ActionAtomistic* aa );`
+   - `Modetype getModeAndSetupValues( ActionWithValue* av )`
+   - `static void calculateCV( Modetype mode, const std::vector<double>& masses, const std::vector<double>& charges, const std::vector<Vector>& pos, std::vector<double>& vals, std::vector<std::vector<Vector> >& derivs, std::vector<Tensor>& virial, const ActionAtomistic* aa )
+     - this function will be called by MultiColvarTemplate to calculate the CV value on the inputs
+     - to avoid code repetitition you should change ::calculate() to call this function
+     - By default all the inputs are const ref, but the constedness can be changed, since the MulticolvarTemplate will pass the plain references
+ - By default you can decorate the public part of your CV wiht `MULTICOLVAR_DEFAULT(modetype here)` to "conver" the declaration of the CV in MultiColvarTemplate-compatible one, you will need to manually declare and implement the methods
+   - If you need to change some constness of the `calculateCV` signature use `MULTICOLVAR_SETTINGS_BASE(modetype here)` and then declare `calculateCV` with the desired constness in the signature (see Dipole.cpp)
+*/
+
+
 #define MULTICOLVAR_SETTINGS_BASE(type) using  Modetype=type; \
   static void parseAtomList( int num, std::vector<AtomNumber>& t, ActionAtomistic* aa ); \
   static Modetype getModeAndSetupValues( ActionWithValue* av )
@@ -119,7 +143,7 @@ MultiColvarTemplate<Colvar>::MultiColvarTemplate(const ActionOptions&ao):
 
       if( i==1 ) {
         ablocks.resize(t.size());
-      }
+        }
       if( t.size()!=ablocks.size() ) {
         std::string ss;
         Tools::convert(i,ss);
@@ -132,7 +156,7 @@ MultiColvarTemplate<Colvar>::MultiColvarTemplate(const ActionOptions&ao):
       t.resize(0);
     }
   }
-  if( all_atoms.size()==0 ) {
+  if( all_atoms.size()==0 ){
     error("No atoms have been specified");
   }
   requestAtoms(all_atoms);
@@ -143,7 +167,7 @@ MultiColvarTemplate<Colvar>::MultiColvarTemplate(const ActionOptions&ao):
   }
   if( keywords.exists("WHOLEMOLECULES") ) {
     parseFlag("WHOLEMOLECULES",wholemolecules);
-    if( wholemolecules ) {
+    if( wholemolecules ){
       usepbc=false;
     }
   }

--- a/src/colvar/MultiColvarTemplate.h
+++ b/src/colvar/MultiColvarTemplate.h
@@ -143,7 +143,7 @@ MultiColvarTemplate<Colvar>::MultiColvarTemplate(const ActionOptions&ao):
 
       if( i==1 ) {
         ablocks.resize(t.size());
-        }
+      }
       if( t.size()!=ablocks.size() ) {
         std::string ss;
         Tools::convert(i,ss);
@@ -156,7 +156,7 @@ MultiColvarTemplate<Colvar>::MultiColvarTemplate(const ActionOptions&ao):
       t.resize(0);
     }
   }
-  if( all_atoms.size()==0 ){
+  if( all_atoms.size()==0 ) {
     error("No atoms have been specified");
   }
   requestAtoms(all_atoms);
@@ -167,7 +167,7 @@ MultiColvarTemplate<Colvar>::MultiColvarTemplate(const ActionOptions&ao):
   }
   if( keywords.exists("WHOLEMOLECULES") ) {
     parseFlag("WHOLEMOLECULES",wholemolecules);
-    if( wholemolecules ){
+    if( wholemolecules ) {
       usepbc=false;
     }
   }

--- a/src/colvar/Plane.cpp
+++ b/src/colvar/Plane.cpp
@@ -68,11 +68,9 @@ private:
 public:
   static void registerKeywords( Keywords& keys );
   explicit Plane(const ActionOptions&);
-  static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
-
 // active methods:
   void calculate() override;
-  MULTICOLVAR_SETTINGS(multiColvars::emptyMode);
+  MULTICOLVAR_DEFAULT(multiColvars::emptyMode);
 };
 
 typedef ColvarShortcut<Plane> PlaneShortcut;
@@ -90,7 +88,7 @@ void Plane::registerKeywords( Keywords& keys ) {
   keys.add("hidden","NO_ACTION_LOG","suppresses printing from action on the log");
 }
 
-void Plane::parseAtomList( const int& num, std::vector<AtomNumber>& atoms, ActionAtomistic* aa ) {
+void Plane::parseAtomList( int const num, std::vector<AtomNumber>& atoms, ActionAtomistic* aa ) {
   aa->parseAtomList("ATOMS",num,atoms);
   if(atoms.size()==3) {
     aa->log.printf("  containing atoms %d %d %d\n",atoms[0].serial(),atoms[1].serial(),atoms[2].serial());

--- a/src/colvar/Plane.cpp
+++ b/src/colvar/Plane.cpp
@@ -131,15 +131,17 @@ Plane::Plane(const ActionOptions&ao):
 void Plane::calculate() {
 
   if(pbc) makeWhole();
-  calculateCV( {}, masses, charges, getPositions(), value, derivs, virial, this );
+  calculateCV( {}, masses, charges, getPositions(), multiColvars::Ouput(value, derivs, virial), this );
   setValue( value[0] );
   for(unsigned i=0; i<derivs[0].size(); ++i) setAtomsDerivatives( i, derivs[0][i] );
   setBoxDerivatives( virial[0] );
 }
 
 void Plane::calculateCV( Modetype /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
-                         const std::vector<Vector>& pos, std::vector<double>& vals, std::vector<std::vector<Vector> >& derivs,
-                         std::vector<Tensor>& virial, const ActionAtomistic* aa ) {
+                         const std::vector<Vector>& pos,multiColvars::Ouput out, const ActionAtomistic* aa ) {
+  auto & vals=out.vals();
+  auto & derivs=out.derivs();
+  auto & virial=out.virial();
   Vector d1=delta( pos[1], pos[0] );
   Vector d2=delta( pos[2], pos[3] );
   Vector cp = crossProduct( d1, d2 );

--- a/src/colvar/Plane.cpp
+++ b/src/colvar/Plane.cpp
@@ -62,7 +62,7 @@ namespace colvar {
 class Plane : public Colvar {
 private:
   bool pbc;
-  std::vector<double> value, masses, charges;
+  std::vector<double> value;
   std::vector<std::vector<Vector> > derivs;
   std::vector<Tensor> virial;
 public:
@@ -131,17 +131,19 @@ Plane::Plane(const ActionOptions&ao):
 void Plane::calculate() {
 
   if(pbc) makeWhole();
-  calculateCV( {}, masses, charges, getPositions(), multiColvars::Ouput(value, derivs, virial), this );
+  calculateCV( {}, multiColvars::Input().positions(getPositions()), multiColvars::Ouput(value, derivs, virial), this );
   setValue( value[0] );
   for(unsigned i=0; i<derivs[0].size(); ++i) setAtomsDerivatives( i, derivs[0][i] );
   setBoxDerivatives( virial[0] );
 }
 
-void Plane::calculateCV( Modetype /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
-                         const std::vector<Vector>& pos,multiColvars::Ouput out, const ActionAtomistic* aa ) {
+void Plane::calculateCV( Modetype /*mode*/,
+                         multiColvars::Input const in,
+                         multiColvars::Ouput out, const ActionAtomistic* aa ) {
   auto & vals=out.vals();
   auto & derivs=out.derivs();
   auto & virial=out.virial();
+  const auto & pos = in.positions();
   Vector d1=delta( pos[1], pos[0] );
   Vector d2=delta( pos[2], pos[3] );
   Vector cp = crossProduct( d1, d2 );

--- a/src/colvar/Position.cpp
+++ b/src/colvar/Position.cpp
@@ -99,10 +99,9 @@ class Position : public Colvar {
 public:
   static void registerKeywords( Keywords& keys );
   explicit Position(const ActionOptions&);
-  static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
 // active methods:
   void calculate() override;
-  MULTICOLVAR_SETTINGS(multiColvars::plainOrScaled);
+  MULTICOLVAR_DEFAULT(multiColvars::plainOrScaled);
 };
 
 typedef ColvarShortcut<Position> PositionShortcut;
@@ -152,7 +151,7 @@ Position::Position(const ActionOptions&ao):
   requestAtoms(atoms);
 }
 
-void Position::parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
+void Position::parseAtomList(int const num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
   aa->parseAtomList("ATOM",num,t);
   if( t.size()==1 ) aa->log.printf("  for atom %d\n",t[0].serial());
   else if( num<0 || t.size()!=0 ) aa->error("Number of specified atoms should be 1");

--- a/src/colvar/Position.cpp
+++ b/src/colvar/Position.cpp
@@ -101,8 +101,6 @@ private:
   Modetype components;
   bool pbc;
   std::vector<double> value;
-  std::vector<double> masses;
-  std::vector<double> charges;
   std::vector<std::vector<Vector> > derivs;
   std::vector<Tensor> virial;
 };
@@ -181,7 +179,7 @@ void Position::calculate() {
   } else {
     distance[0]=delta(Vector(0.0,0.0,0.0),getPosition(0));
   }
-  calculateCV( components, masses, charges, distance, multiColvars::Ouput(value, derivs, virial), this );
+  calculateCV( components, multiColvars::Input().positions(distance), multiColvars::Ouput(value, derivs, virial), this );
   switch (components) {
   case Modetype::scaled: {
     Value* valuea=getPntrToComponent("a");
@@ -216,12 +214,16 @@ void Position::calculate() {
   }
 }
 
-void Position::calculateCV( Modetype mode, const std::vector<double>& masses, const std::vector<double>& charges,
-                            const std::vector<Vector>& pos,
+void Position::calculateCV( Modetype mode,
+                            multiColvars::Input const in,
                             multiColvars::Ouput out, const ActionAtomistic* aa ) {
   auto & vals=out.vals();
   auto & derivs=out.derivs();
   auto & virial=out.virial();
+  const auto &pos = in.positions();
+  ////////////////////////////////////////////////////////////////////////////
+  //why here there is not the distance from 000 treatment??????
+  ///////////////////////////////////////////////////////////////////////////
   switch (mode)
   {
   case Modetype::scaled: {

--- a/src/colvar/SelectMassCharge.cpp
+++ b/src/colvar/SelectMassCharge.cpp
@@ -139,14 +139,14 @@ SelectMassCharge::Modetype SelectMassCharge::getModeAndSetupValues( ActionWithVa
 
 // calculator
 void SelectMassCharge::calculate() {
-  std::vector<double> masses(1), charges(1), vals(1);
+  std::vector<double> masses(1), charges(1), value(1);
   std::vector<Vector> pos; std::vector<std::vector<Vector> > derivs; std::vector<Tensor> virial;
-  calculateCV( {}, masses, charges, pos, vals, derivs, virial, this ); setValue( vals[0] );
+  calculateCV( {}, masses, charges, pos, multiColvars::Ouput(value, derivs, virial), this ); setValue( value[0] );
 }
 
 void SelectMassCharge::calculateCV( Modetype /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
-                                    const std::vector<Vector>& pos, std::vector<double>& vals, std::vector<std::vector<Vector> >& derivs,
-                                    std::vector<Tensor>& virial, const ActionAtomistic* aa ) {
+                                    const std::vector<Vector>& pos,multiColvars::Ouput out, const ActionAtomistic* aa ) {
+  auto & vals=out.vals();
   if( aa->getName().find("MASSES")!=std::string::npos ) {
     vals[0]=masses[0];
   } else if( aa->chargesWereSet ) {

--- a/src/colvar/SelectMassCharge.cpp
+++ b/src/colvar/SelectMassCharge.cpp
@@ -86,10 +86,9 @@ class SelectMassCharge : public Colvar {
 public:
   static void registerKeywords( Keywords& keys );
   explicit SelectMassCharge(const ActionOptions&);
-  static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
 // active methods:
   void calculate() override;
-  MULTICOLVAR_SETTINGS(multiColvars::emptyMode);
+  MULTICOLVAR_DEFAULT(multiColvars::emptyMode);
 };
 
 typedef ColvarShortcut<SelectMassCharge> MQShortcut;
@@ -119,7 +118,7 @@ SelectMassCharge::SelectMassCharge(const ActionOptions&ao):
   requestAtoms(atoms);
 }
 
-void SelectMassCharge::parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
+void SelectMassCharge::parseAtomList(  int const num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
   aa->parseAtomList("ATOM",num,t);
   if( t.size()==1 ) aa->log.printf("  for atom %d\n",t[0].serial());
   else if( num<0 || t.size()!=0 ) aa->error("Number of specified atoms should be 1");

--- a/src/colvar/SelectMassCharge.cpp
+++ b/src/colvar/SelectMassCharge.cpp
@@ -82,6 +82,12 @@ Get the mass of one or multiple atoms
 namespace PLMD {
 namespace colvar {
 
+namespace
+{
+enum class MC {Mass,Charge};
+} // namespace unnamed
+
+template <MC mq>
 class SelectMassCharge : public Colvar {
 public:
   static void registerKeywords( Keywords& keys );
@@ -89,18 +95,27 @@ public:
 // active methods:
   void calculate() override;
   MULTICOLVAR_DEFAULT(multiColvars::emptyMode);
+private:
+  AtomNumber theAtom;
 };
 
-typedef ColvarShortcut<SelectMassCharge> MQShortcut;
-PLUMED_REGISTER_ACTION(MQShortcut,"MASS")
-PLUMED_REGISTER_ACTION(MQShortcut,"CHARGE")
-PLUMED_REGISTER_ACTION(SelectMassCharge,"MASS_SCALAR")
-PLUMED_REGISTER_ACTION(SelectMassCharge,"CHARGE_SCALAR")
-typedef MultiColvarTemplate<SelectMassCharge> MQMulti;
-PLUMED_REGISTER_ACTION(MQMulti,"MASS_VECTOR")
-PLUMED_REGISTER_ACTION(MQMulti,"CHARGE_VECTOR")
+typedef SelectMassCharge<MC::Mass> SelectMass;
+typedef SelectMassCharge<MC::Charge> SelectCharge;
+PLUMED_REGISTER_ACTION(SelectMass,"MASS_SCALAR")
+PLUMED_REGISTER_ACTION(SelectCharge,"CHARGE_SCALAR")
 
-void SelectMassCharge::registerKeywords( Keywords& keys ) {
+typedef ColvarShortcut<SelectMass> MassShortcut;
+typedef ColvarShortcut<SelectCharge> ChargeShortcut;
+PLUMED_REGISTER_ACTION(MassShortcut,"MASS")
+PLUMED_REGISTER_ACTION(ChargeShortcut,"CHARGE")
+
+typedef MultiColvarTemplate<SelectMass> MassMulti;
+typedef MultiColvarTemplate<SelectCharge> ChargeMulti;
+PLUMED_REGISTER_ACTION(MassMulti,"MASS_VECTOR")
+PLUMED_REGISTER_ACTION(ChargeMulti,"CHARGE_VECTOR")
+
+template <MC mq>
+void SelectMassCharge<mq>::registerKeywords( Keywords& keys ) {
   Colvar::registerKeywords( keys );
   keys.add("atoms","ATOM","the atom number");
   keys.add("atoms","ATOMS","the atom numbers that you would like to store the masses and charges of");
@@ -110,52 +125,89 @@ void SelectMassCharge::registerKeywords( Keywords& keys ) {
   keys.setDisplayName( acname.substr(0,und) ); keys.setValueDescription("the " + keys.getDisplayName() + " of the atom");
 }
 
-SelectMassCharge::SelectMassCharge(const ActionOptions&ao):
+template <MC mq>
+SelectMassCharge<mq>::SelectMassCharge(const ActionOptions&ao):
   PLUMED_COLVAR_INIT(ao)
 {
-  std::vector<AtomNumber> atoms; parseAtomList(-1,atoms,this);
+  std::vector<AtomNumber> atoms;
+  parseAtomList(-1,atoms,this);
+  theAtom=atoms[0];
   /*Modetype mode=*/getModeAndSetupValues(this);
   requestAtoms(atoms);
 }
 
-void SelectMassCharge::parseAtomList(  int const num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
+template <MC mq>
+void SelectMassCharge<mq>::parseAtomList(  int const num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
   aa->parseAtomList("ATOM",num,t);
-  if( t.size()==1 ) aa->log.printf("  for atom %d\n",t[0].serial());
-  else if( num<0 || t.size()!=0 ) aa->error("Number of specified atoms should be 1");
+  if( t.size()==1 ) {
+    aa->log.printf("  for atom %d\n",t[0].serial());
+  } else if( num<0 || t.size()!=0 ) {
+    aa->error("Number of specified atoms should be 1");
+  }
 }
 
-SelectMassCharge::Modetype SelectMassCharge::getModeAndSetupValues( ActionWithValue* av ) {
-  av->addValueWithDerivatives(); av->setNotPeriodic(); bool constant=true;
-  ActionAtomistic* aa=dynamic_cast<ActionAtomistic*>( av ); plumed_assert( aa );
+template <MC mq>
+typename SelectMassCharge<mq>::Modetype SelectMassCharge<mq>::getModeAndSetupValues( ActionWithValue* av ) {
+  av->addValueWithDerivatives();
+  av->setNotPeriodic();
+  bool constant=true;
+  ActionAtomistic* aa=dynamic_cast<ActionAtomistic*>( av );
+  plumed_assert( aa );
   for(unsigned i=0; i<aa->getNumberOfAtoms(); ++i) {
     std::pair<std::size_t,std::size_t> p = aa->getValueIndices( aa->getAbsoluteIndex(i) );
-    if( av->getName().find("MASS")!=std::string::npos && !aa->masv[p.first]->isConstant() ) constant=false;
-    if( av->getName().find("CHARGE")!=std::string::npos && !aa->chargev[p.first]->isConstant() ) constant=false;
+    if constexpr( mq == MC::Mass ) {
+      constant = aa->isMassConstant(p.first);
+    } else {
+      constant = aa->isChargeConstant(p.first);
+    }
   }
-  if( !constant ) av->error("cannot deal with non-constant " + av->getName() + " values");
+  if( !constant ) {
+    av->error("cannot deal with non-constant " + av->getName() + " values");
+  }
   (av->copyOutput(0))->setConstant();
   return {};
 }
 
 // calculator
-void SelectMassCharge::calculate() {
-  std::vector<double> masses(1), charges(1), value(1);
-  std::vector<Vector> pos; std::vector<std::vector<Vector> > derivs; std::vector<Tensor> virial;
-  calculateCV( {}, masses, charges, pos, multiColvars::Ouput(value, derivs, virial), this ); setValue( value[0] );
+
+template <MC mq>
+void SelectMassCharge<mq>::calculate() {
+  std::vector<Vector> posdummy;
+  std::vector<std::vector<Vector> > derivsdummy;
+  std::vector<Tensor> virialdummy;
+
+  std::vector<double> massesOrCharges(1);
+  if constexpr( mq == MC::Mass ) {
+    massesOrCharges[0]=getMass(theAtom.index());
+  } else {
+    massesOrCharges[0]=getCharge(theAtom.index());
+  }
+  std::vector<double> vals(1);
+
+  calculateCV( {}, massesOrCharges, massesOrCharges, posdummy, multiColvars::Ouput(vals, derivsdummy, virialdummy), this );
+
+  setValue( vals[0] );
+  // does the code above give the same result as doing:
+  // if constexpr( mq == MC::Mass ) {
+  //   setValue( getMass(theAtom.index) );
+  // } else {
+  //   setValue( getCharge(theAtom.index) );
+  // }
+  // ???
+  //calculateCV copies the first element from masses or charges into vals[0]
 }
 
-void SelectMassCharge::calculateCV( Modetype /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
-                                    const std::vector<Vector>& pos,multiColvars::Ouput out, const ActionAtomistic* aa ) {
+template <MC mq>
+void SelectMassCharge<mq>::calculateCV( Modetype /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
+                                        const std::vector<Vector>& pos,multiColvars::Ouput out, const ActionAtomistic* aa ) {
   auto & vals=out.vals();
-  if( aa->getName().find("MASSES")!=std::string::npos ) {
+  if constexpr(mq == MC::Mass)  {
     vals[0]=masses[0];
-  } else if( aa->chargesWereSet ) {
+    // } else if( aa->chargesWereSet ) { this is done in the getModeAndSetupValues by isChargeConstant
+  } else {
     vals[0]=charges[0];
   }
 }
 
-}
-}
-
-
-
+} // namespace colvar
+} // namespace PLMD

--- a/src/colvar/SelectMassCharge.cpp
+++ b/src/colvar/SelectMassCharge.cpp
@@ -172,19 +172,18 @@ typename SelectMassCharge<mq>::Modetype SelectMassCharge<mq>::getModeAndSetupVal
 
 template <MC mq>
 void SelectMassCharge<mq>::calculate() {
-  std::vector<Vector> posdummy;
+
   std::vector<std::vector<Vector> > derivsdummy;
   std::vector<Tensor> virialdummy;
-
-  std::vector<double> massesOrCharges(1);
-  if constexpr( mq == MC::Mass ) {
-    massesOrCharges[0]=getMass(theAtom.index());
-  } else {
-    massesOrCharges[0]=getCharge(theAtom.index());
-  }
   std::vector<double> vals(1);
 
-  calculateCV( {}, massesOrCharges, massesOrCharges, posdummy, multiColvars::Ouput(vals, derivsdummy, virialdummy), this );
+  if constexpr( mq == MC::Mass ) {
+    std::vector<double> mass{getMass(theAtom.index())};
+    calculateCV( {}, multiColvars::Input().masses(mass), multiColvars::Ouput(vals, derivsdummy, virialdummy), this );
+  } else {
+    std::vector<double> charge{getCharge(theAtom.index())};
+    calculateCV( {}, multiColvars::Input().charges(charge), multiColvars::Ouput(vals, derivsdummy, virialdummy), this );
+  }
 
   setValue( vals[0] );
   // does the code above give the same result as doing:
@@ -198,14 +197,15 @@ void SelectMassCharge<mq>::calculate() {
 }
 
 template <MC mq>
-void SelectMassCharge<mq>::calculateCV( Modetype /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
-                                        const std::vector<Vector>& pos,multiColvars::Ouput out, const ActionAtomistic* aa ) {
+void SelectMassCharge<mq>::calculateCV( Modetype /*mode*/,
+                                        multiColvars::Input const in,
+                                        multiColvars::Ouput out, const ActionAtomistic* aa ) {
   auto & vals=out.vals();
   if constexpr(mq == MC::Mass)  {
-    vals[0]=masses[0];
+    vals[0]= in.masses()[0];
     // } else if( aa->chargesWereSet ) { this is done in the getModeAndSetupValues by isChargeConstant
   } else {
-    vals[0]=charges[0];
+    vals[0]=in.charges()[0];
   }
 }
 

--- a/src/colvar/Torsion.cpp
+++ b/src/colvar/Torsion.cpp
@@ -115,14 +115,13 @@ class Torsion : public Colvar {
   std::vector<Tensor> virial;
 public:
   explicit Torsion(const ActionOptions&);
-  static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
 // active methods:
   void calculate() override;
   static void registerKeywords(Keywords& keys);
   enum class torsionModes {
     torsion,cosine
   };
-  MULTICOLVAR_SETTINGS(torsionModes);
+  MULTICOLVAR_DEFAULT(torsionModes);
 };
 
 typedef ColvarShortcut<Torsion> TorsionShortcut;
@@ -183,7 +182,7 @@ Torsion::Torsion(const ActionOptions&ao):
   requestAtoms(atoms);
 }
 
-void Torsion::parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
+void Torsion::parseAtomList( int const num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
   std::vector<AtomNumber> v1,v2,axis;
   aa->parseAtomList("ATOMS",num,t);
   aa->parseAtomList("VECTORA",num,v1);

--- a/src/colvar/Torsion.cpp
+++ b/src/colvar/Torsion.cpp
@@ -145,10 +145,10 @@ void Torsion::registerKeywords(Keywords& keys) {
 
 Torsion::Torsion(const ActionOptions&ao):
   PLUMED_COLVAR_INIT(ao),
-  pbc(true),
   value(1),
   derivs(1),
-  virial(1)
+  virial(1),
+  pbc(true)
 {
   derivs[0].resize(6); std::vector<AtomNumber> atoms;
   std::vector<AtomNumber> v1; ActionAtomistic::parseAtomList("VECTOR1",v1);

--- a/src/colvar/Torsion.cpp
+++ b/src/colvar/Torsion.cpp
@@ -117,7 +117,7 @@ public:
   };
   MULTICOLVAR_DEFAULT(torsionModes);
 private:
-  std::vector<double> value, masses, charges;
+  std::vector<double> value;
   std::vector<std::vector<Vector> > derivs;
   std::vector<Tensor> virial;
   bool pbc;
@@ -228,7 +228,7 @@ void Torsion::calculate() {
   if(pbc) {
     makeWhole();
   }
-  calculateCV( mode, masses, charges, getPositions(), multiColvars::Ouput(value, derivs, virial), this );
+  calculateCV( mode, multiColvars::Input().positions(getPositions()), multiColvars::Ouput(value, derivs, virial), this );
   for(unsigned i=0; i<6; ++i) {
     setAtomsDerivatives(i,derivs[0][i] );
   }
@@ -236,13 +236,13 @@ void Torsion::calculate() {
   setBoxDerivatives( virial[0] );
 }
 
-void Torsion::calculateCV( Modetype mode, const std::vector<double>& masses, const std::vector<double>& charges,
-                           const std::vector<Vector>& pos,
+void Torsion::calculateCV( Modetype mode,
+                           multiColvars::Input const in,
                            multiColvars::Ouput out, const ActionAtomistic* aa ) {
   auto & vals=out.vals();
   auto & derivs=out.derivs();
   auto & virial=out.virial();
-
+  const auto & pos = in.positions();
   Vector d0=delta(pos[1],pos[0]);
   Vector d1=delta(pos[3],pos[2]);
   Vector d2=delta(pos[5],pos[4]);

--- a/src/core/ActionAtomistic.h
+++ b/src/core/ActionAtomistic.h
@@ -35,10 +35,6 @@ namespace PLMD {
 class Pbc;
 class PDB;
 
-namespace colvar {
-class SelectMassCharge;
-}
-
 /// \ingroup MULTIINHERIT
 /// Action used to create objects that access the positions of the atoms from the MD code
 class ActionAtomistic :
@@ -46,7 +42,6 @@ class ActionAtomistic :
 {
   friend class Group;
   friend class DomainDecomposition;
-  friend class colvar::SelectMassCharge;
   friend class ActionWithVirtualAtom;
 
   std::vector<AtomNumber> indexes;         // the set of needed atoms
@@ -82,9 +77,9 @@ class ActionAtomistic :
 protected:
   bool                  chargesWereSet;
   void setExtraCV(const std::string &name);
+public:
 /// Used to interpret whether this index is a virtual atom or a real atom
   std::pair<std::size_t, std::size_t> getValueIndices( const AtomNumber& i ) const ;
-public:
 /// Request an array of atoms.
 /// This method is used to ask for a list of atoms. Atoms
 /// should be asked for by number. If this routine is called
@@ -116,8 +111,12 @@ public:
   const double & getEnergy()const;
 /// Get mass of i-th atom
   double getMass(int i)const;
+/// Check if the mass of the i-th atom is constant
+  bool isMassConstant(int i) const;
 /// Get charge of i-th atom
   double getCharge(int i)const;
+/// Check if the charge of the i-th atom is constant
+  bool isChargeConstant(int i) const;
 /// Get the force acting on a particular atom
   Vector getForce( const std::pair<std::size_t, std::size_t>& a ) const ;
 /// Add force to an atom
@@ -206,9 +205,20 @@ double ActionAtomistic::getMass(int i)const {
 }
 
 inline
+bool ActionAtomistic::isMassConstant(int i)const {
+  return masv[i]->isConstant();
+}
+
+inline
 double ActionAtomistic::getCharge(int i) const {
   if( !chargesWereSet ) error("charges were not passed to plumed");
   return charges[i];
+}
+
+inline
+bool ActionAtomistic::isChargeConstant(int i) const {
+  if( !chargesWereSet ) error("charges were not passed to plumed");
+  return chargev[i]->isConstant();
 }
 
 inline

--- a/src/core/ActionWithVector.cpp
+++ b/src/core/ActionWithVector.cpp
@@ -277,12 +277,16 @@ void ActionWithVector::getNumberOfTasks( unsigned& ntasks ) {
 
 void ActionWithVector::runTask( const unsigned& current, MultiValue& myvals ) const {
   const ActionWithMatrix* am = dynamic_cast<const ActionWithMatrix*>(this);
-  myvals.setTaskIndex(current); myvals.vector_call=true; performTask( current, myvals );
+  myvals.setTaskIndex(current);
+  myvals.vector_call=true;
+  performTask( current, myvals );
   for(unsigned i=0; i<getNumberOfComponents(); ++i) {
     const Value* myval = getConstPntrToComponent(i);
-    if( am || myval->hasDerivatives() ) continue;
+    if( am || myval->hasDerivatives() )
+      continue;
     Value* myv = const_cast<Value*>( myval );
-    if( getName()=="RMSD_VECTOR" && myv->getRank()==2 ) continue;
+    if( getName()=="RMSD_VECTOR" && myv->getRank()==2 )
+      continue;
     myv->set( current, myvals.get( i ) );
   }
 }

--- a/src/core/Value.cpp
+++ b/src/core/Value.cpp
@@ -361,7 +361,7 @@ void Value::print( OFile& ofile ) const {
 
 void Value::printForce( OFile& ofile ) const {
   if( shape.size()==0 || getNumberOfValues()==1 ) {
-    ofile.printField( name, getForce(0) ); 
+    ofile.printField( name, getForce(0) );
   } else {
     std::vector<unsigned> indices( shape.size() );
     for(unsigned i=0; i<getNumberOfValues(); ++i) {
@@ -371,7 +371,7 @@ void Value::printForce( OFile& ofile ) const {
       ofile.printField( fname,  getForce(i) );
     }
   }
-} 
+}
 
 unsigned Value::getGoodNumThreads( const unsigned& j, const unsigned& k ) const {
   return OpenMP::getGoodNumThreads( &data[j], (k-j) );

--- a/src/crystdistrib/Quaternion.cpp
+++ b/src/crystdistrib/Quaternion.cpp
@@ -107,7 +107,7 @@ public:
 
 // active methods:
   void calculate() override;
-  MULTICOLVAR_SETTINGS(::PLMD::colvar::multiColvars::emptyMode);
+  MULTICOLVAR_DEFAULT(::PLMD::colvar::multiColvars::emptyMode);
 };
 
 typedef colvar::ColvarShortcut<Quaternion> QuaternionShortcut;

--- a/src/crystdistrib/Quaternion.cpp
+++ b/src/crystdistrib/Quaternion.cpp
@@ -164,7 +164,7 @@ Quaternion::Modetype Quaternion::getModeAndSetupValues( ActionWithValue* av ) {
 void Quaternion::calculate() {
   if(pbc) makeWhole();
 
-  calculateCV( {}, masses, charges, getPositions(), value, derivs, virial, this );
+  calculateCV( {}, masses, charges, getPositions(), PLMD::colvar::multiColvars::Ouput(value, derivs, virial), this );
   for(unsigned j=0; j<4; ++j) {
     Value* valuej=getPntrToComponent(j);
     for(unsigned i=0; i<3; ++i) setAtomsDerivatives(valuej,i,derivs[j][i] );
@@ -175,8 +175,11 @@ void Quaternion::calculate() {
 
 // calculator
 void Quaternion::calculateCV( Modetype /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
-                              const std::vector<Vector>& pos, std::vector<double>& vals, std::vector<std::vector<Vector> >& derivs,
-                              std::vector<Tensor>& virial, const ActionAtomistic* aa ) {
+                              const std::vector<Vector>& pos,
+                              PLMD::colvar::multiColvars::Ouput out, const ActionAtomistic* aa ) {
+  auto & vals=out.vals();
+  auto & derivs=out.derivs();
+  auto & virial=out.virial();
   //declarations
   Vector vec1_comp = delta( pos[0], pos[1] ); //components between atom 1 and 2
   Vector vec2_comp = delta( pos[0], pos[2] ); //components between atom 1 and 3

--- a/src/crystdistrib/Quaternion.cpp
+++ b/src/crystdistrib/Quaternion.cpp
@@ -145,7 +145,7 @@ Quaternion::Quaternion(const ActionOptions&ao):
   requestAtoms(atoms);
 }
 
-void Quaternion::parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
+void Quaternion::parseAtomList(int num, std::vector<AtomNumber>& t, ActionAtomistic* aa ) {
   aa->parseAtomList("ATOMS",num,t);
   if( t.size()==3 ) aa->log.printf("  involving atoms %d %d %d\n",t[0].serial(),t[1].serial(),t[0].serial());
 }

--- a/src/crystdistrib/Quaternion.cpp
+++ b/src/crystdistrib/Quaternion.cpp
@@ -104,12 +104,10 @@ public:
   static void registerKeywords( Keywords& keys );
   explicit Quaternion(const ActionOptions&);
   static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
-  static unsigned getModeAndSetupValues( ActionWithValue* av );
+
 // active methods:
   void calculate() override;
-  static void calculateCV( const unsigned& mode, const std::vector<double>& masses, const std::vector<double>& charges,
-                           const std::vector<Vector>& pos, std::vector<double>& vals, std::vector<std::vector<Vector> >& derivs,
-                           std::vector<Tensor>& virial, const ActionAtomistic* aa );
+  MULTICOLVAR_SETTINGS(::PLMD::colvar::multiColvars::emptyMode);
 };
 
 typedef colvar::ColvarShortcut<Quaternion> QuaternionShortcut;
@@ -145,7 +143,7 @@ Quaternion::Quaternion(const ActionOptions&ao):
   parseFlag("NOPBC",nopbc);
   pbc=!nopbc;
 
-  unsigned mode = getModeAndSetupValues( this );
+  /*Modetype mode =*/ getModeAndSetupValues( this );
   requestAtoms(atoms);
 }
 
@@ -154,19 +152,19 @@ void Quaternion::parseAtomList( const int& num, std::vector<AtomNumber>& t, Acti
   if( t.size()==3 ) aa->log.printf("  involving atoms %d %d %d\n",t[0].serial(),t[1].serial(),t[0].serial());
 }
 
-unsigned Quaternion::getModeAndSetupValues( ActionWithValue* av ) {
+Quaternion::Modetype Quaternion::getModeAndSetupValues( ActionWithValue* av ) {
   // This sets up values that we can pass around in PLUMED
   av->addComponentWithDerivatives("w"); av->componentIsNotPeriodic("w");
   av->addComponentWithDerivatives("i"); av->componentIsNotPeriodic("i");
   av->addComponentWithDerivatives("j"); av->componentIsNotPeriodic("j");
   av->addComponentWithDerivatives("k"); av->componentIsNotPeriodic("k");
-  return 0;
+  return {};
 }
 
 void Quaternion::calculate() {
   if(pbc) makeWhole();
 
-  calculateCV( 0, masses, charges, getPositions(), value, derivs, virial, this );
+  calculateCV( {}, masses, charges, getPositions(), value, derivs, virial, this );
   for(unsigned j=0; j<4; ++j) {
     Value* valuej=getPntrToComponent(j);
     for(unsigned i=0; i<3; ++i) setAtomsDerivatives(valuej,i,derivs[j][i] );
@@ -176,7 +174,7 @@ void Quaternion::calculate() {
 }
 
 // calculator
-void Quaternion::calculateCV( const unsigned& mode, const std::vector<double>& masses, const std::vector<double>& charges,
+void Quaternion::calculateCV( Modetype /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
                               const std::vector<Vector>& pos, std::vector<double>& vals, std::vector<std::vector<Vector> >& derivs,
                               std::vector<Tensor>& virial, const ActionAtomistic* aa ) {
   //declarations

--- a/src/crystdistrib/Quaternion.cpp
+++ b/src/crystdistrib/Quaternion.cpp
@@ -97,7 +97,7 @@ See \ref QUATERNION for more details
 class Quaternion : public Colvar {
 private:
   bool pbc;
-  std::vector<double> value, masses, charges;
+  std::vector<double> value;
   std::vector<std::vector<Vector> > derivs;
   std::vector<Tensor> virial;
 public:
@@ -162,7 +162,7 @@ Quaternion::Modetype Quaternion::getModeAndSetupValues( ActionWithValue* av ) {
 void Quaternion::calculate() {
   if(pbc) makeWhole();
 
-  calculateCV( {}, masses, charges, getPositions(), PLMD::colvar::multiColvars::Ouput(value, derivs, virial), this );
+  calculateCV( {}, PLMD::colvar::multiColvars::Input().positions(getPositions()), PLMD::colvar::multiColvars::Ouput(value, derivs, virial), this );
   for(unsigned j=0; j<4; ++j) {
     Value* valuej=getPntrToComponent(j);
     for(unsigned i=0; i<3; ++i) setAtomsDerivatives(valuej,i,derivs[j][i] );
@@ -172,12 +172,13 @@ void Quaternion::calculate() {
 }
 
 // calculator
-void Quaternion::calculateCV( Modetype /*mode*/, const std::vector<double>& masses, const std::vector<double>& charges,
-                              const std::vector<Vector>& pos,
+void Quaternion::calculateCV( Modetype /*mode*/,
+                              PLMD::colvar::multiColvars::Input const in,
                               PLMD::colvar::multiColvars::Ouput out, const ActionAtomistic* aa ) {
   auto & vals=out.vals();
   auto & derivs=out.derivs();
   auto & virial=out.virial();
+  const auto & pos = in.positions();
   //declarations
   Vector vec1_comp = delta( pos[0], pos[1] ); //components between atom 1 and 2
   Vector vec2_comp = delta( pos[0], pos[2] ); //components between atom 1 and 3

--- a/src/crystdistrib/Quaternion.cpp
+++ b/src/crystdistrib/Quaternion.cpp
@@ -103,8 +103,6 @@ private:
 public:
   static void registerKeywords( Keywords& keys );
   explicit Quaternion(const ActionOptions&);
-  static void parseAtomList( const int& num, std::vector<AtomNumber>& t, ActionAtomistic* aa );
-
 // active methods:
   void calculate() override;
   MULTICOLVAR_DEFAULT(::PLMD::colvar::multiColvars::emptyMode);


### PR DESCRIPTION
@gtribello 
I am starting to do some work to bring `Multicolvar.h` to be more compatible with the GPU

This first commit just aims to clearer the "mode" variable, and add a small layer of automatism to setting up a colvar to be compatible with a Multicolvar with a few macros. I think this could make it easier to change the function signatures faster. 


For running on a GPU I may need to restart implementing #1092