### PR TITLE
[FIX] Moving the checkArgumentType error to its caller

### DIFF
--- a/src/core/ActionWithArguments.cpp
+++ b/src/core/ActionWithArguments.cpp
@@ -243,7 +243,7 @@ void ActionWithArguments::interpretArgumentList(const std::vector<std::string>& 
   }
   for(unsigned i=0; i<arg.size(); ++i) {
     if( !readact->keywords.checkArgumentType( arg[i]->getRank(), arg[i]->hasDerivatives() ) ) {
-      readact->warning("documentation for input type is not provided in " + readact->getName() );
+      readact->error("documentation for input type is not provided in " + readact->getName() );
     }
   }
 }

--- a/src/tools/Keywords.cpp
+++ b/src/tools/Keywords.cpp
@@ -1054,43 +1054,25 @@ std::vector<std::string> Keywords::getArgumentKeys() const {
 }
 
 bool Keywords::checkArgumentType( const std::size_t& rank, const bool& hasderiv ) const {
-  std::map <std::string,bool> arguments;
+  bool allArgumentsAreCorrect = true;
   for(auto const& kw : getArgumentKeys() ) {
     const auto & at = std::get<argType>(keywords.at(kw).argument_type);
-    arguments[kw] = false;
+    bool kwIsCorrect = false;
     if( rank==0  && valid(at | argType::scalar)) {
-      arguments[kw] = true;
+      kwIsCorrect = true;
     }
     if( hasderiv && valid(at | argType::grid)) {
-      arguments[kw] = true;
+      kwIsCorrect = true;
     }
     if( rank==1  && valid(at | argType::vector)) {
-      arguments[kw] = true;
+      kwIsCorrect = true;
     }
     if( rank==2  && valid(at | argType::matrix)) {
-      arguments[kw] = true;
+      kwIsCorrect = true;
     }
+    allArgumentsAreCorrect &= kwIsCorrect;
   }
-  if(std::all_of(arguments.begin(), arguments.end(),
-  [](auto const& arg) {
-  return arg.second;
-})) {
-    return true;
-  }
-  ///@todo this plumed_merror breaks the check that is in the only place that
-  ///calls this function (at the end of ActionWithArguments::interpretArgumentList)
-  std::string errorMessage = "WARNING: type for the following arguments has not been specified\n"
-                             "or dimensions are not compatible with rank "+std::to_string(rank)
-                             +" and the "+ ((hasderiv)?"presence":"absence") +" of the derivative \n";
-  for (auto const& arg : arguments) {
-    if (!arg.second) {
-      errorMessage += arg.first +
-                      " ("+toString(std::get<argType>(keywords.at(arg.first).argument_type))+")" +"\n";
-    }
-  }
-  //the merror makes the return never executed!!!
-  plumed_merror(errorMessage);
-  return false;
+  return allArgumentsAreCorrect;
 }
 
 std::string Keywords::getArgumentType( const std::string& name ) const {


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

This is the PR about the problem I saw in #1167 and #1166

I think that the intended use of the original change I am fixing was to change the warning into an error, since I saw that it generates SEGFAULTs in case of keeping it as 
 a warning.

But the `plumed_merror` in the `Keywords` scope lose the information of having the information of the "culprit action" (and I think that `plumed_merror` is deprecated in favour of `plumed_error`, right?). So I simply changed the `->warning` into an `->error` to have the name of the action that arises the problem

I think this is more a "dev-side" problem than a "user-input" one, but  it is still better to state to the user what is the action that may cause the error, since it can be "workarounded" as I did in #1166

`checkArgumentType` is only used in a single instance, so I think the modification is safe:
```
>git grep -n checkArgumentType
src/core/ActionWithArguments.cpp:195:    if( !readact->keywords.checkArgumentType( arg[i]->getRank(), arg[i]->hasDerivatives() ) ) {
src/tools/Keywords.cpp:693:bool Keywords::checkArgumentType( const std::size_t& rank, const bool& hasderiv ) const {
src/tools/Keywords.h:191:  bool checkArgumentType( const std::size_t& rank, const bool& hasderiv ) const ;
```
##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release I ma targetting master but maybe v2.10 may be better?

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
