### PR TITLE
adding the "nobadge" badge to gen_example

### DIFF
--- a/src/cltools/GenExample.cpp
+++ b/src/cltools/GenExample.cpp
@@ -174,6 +174,8 @@ int GenExample::main(FILE* in, FILE*out,Communicator& pc) {
     ofile<<"with-LOAD-yellow";
   } else if(status=="incomplete") {
     ofile<<version<<"-incomplete-yellow";
+  } else if ( status=="nobadge" ) {
+    ofile<<"nobadge-36454F";
   } else {
     error("unknown status");
   }

--- a/src/cltools/GenExample.cpp
+++ b/src/cltools/GenExample.cpp
@@ -177,7 +177,7 @@ int GenExample::main(FILE* in, FILE*out,Communicator& pc) {
   } else if ( status=="nobadge" ) {
     ofile<<"nobadge-36454F";
   } else {
-    error("unknown status");
+    error("unknown status: "+status);
   }
   ofile<<".svg\" alt=\"tested on "<<version<<"\" /></div>";
   ofile.flush();


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

>afterthought:
>The aim of this was to cover some segmentation fault.
> This does not solve those segmentation faults
> But I think that that is due some problems that cam from what happen after `error` is used. I just solved the no badge problem in some part of the manual, but some pages like the one about the `...` now it should render correcly, or at leas running an example with standalone things when you do not care about the status badge

 In #1183 I randomly discovered a sigsegv when running gen_example on plumed tools.

It looked like the "nobadge" status was missing from the options when creating a badge, now it displays a ![](https://img.shields.io/badge/-nobadge-36454F.svg) in that case.

`"nobadge"` looks like it is the default status when `gen_example` is called with no arguments, so I do not know it this is the correct solution (but

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release v2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
