### PR TITLE
now the div are span for the kw in the listings

### DIFF
--- a/src/cltools/GenExample.cpp
+++ b/src/cltools/GenExample.cpp
@@ -404,7 +404,7 @@ void GenExample::printExampleInput( const std::vector<std::vector<std::string> >
           std::size_t eq=interpreted[i].find_first_of("=");
           if( eq!=std::string::npos ) {
             std::string keyword=interpreted[i].substr(0,eq), rest=interpreted[i].substr(eq+1);
-            ofile<<"<div class=\"tooltip\">"<<keyword<<"<div class=\"right\">"<<keys.getTooltip(keyword)<<"<i></i></div></div>";
+            ofile<<"<span class=\"tooltip\">"<<keyword<<"<span class=\"right\">"<<keys.getTooltip(keyword)<<"<i></i></span></span>";
             if( rest=="__FILL__" ) {
               if( status!="incomplete" ) {
                 error("found __FILL__ statement but status is " + status);
@@ -447,7 +447,7 @@ void GenExample::printExampleInput( const std::vector<std::vector<std::string> >
             ofile<<" ";
           } else if( interpreted[i]!="@newline" && interpreted[i]!="..." ) {
             myinputline += interpreted[i] + " ";
-            ofile<<"<div class=\"tooltip\">"<<interpreted[i]<<"<div class=\"right\">"<<keys.getTooltip(interpreted[i])<<"<i></i></div></div> ";
+            ofile<<"<span class=\"tooltip\">"<<interpreted[i]<<"<span class=\"right\">"<<keys.getTooltip(interpreted[i])<<"<i></i></span></span> ";
           } else if( interpreted[i]=="..." ) {
             ofile<<"...";
           }


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

This is the same tiny bit I have set up in a PR for Plumed2HTML.

The problem is that the `div` elements in the listing of the plumed examples in the manual causes extra new lines when copy-pasting the plumed examples.

for example 
```
dist: DISTANCES ATOMS1=1,300 ATOMS2=1,400 ATOMS3=1,500
```
gets pasted as:
```
dist: DISTANCES ATOMS1
=1,300 ATOMS2
=1,400 ATOMS3
=1,500
```

I do not know if is the keyword element or the tooltip that pops up, but using to `span` will solve that problem (at least on Firefox).


##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release v2.9

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
