### PR TITLE
Removed creation of vatoms when using DISTANCES GROUPA/GROUPB syntax …

### DIFF
--- a/CHANGES/v2.10.md
+++ b/CHANGES/v2.10.md
@@ -41,6 +41,7 @@ Before switching to version 2.10, users are invited to carefully read the follow
   - Action NBONDS no longer exists.  The same effect can be achieved through a more transparent implementation that you can read about here: https://plumed-school.github.io/lessons/23/001/data/Steinhardt.html
   - Action CENTER_OF_MULTICOLVAR no longer exists.  You now simply use \ref CENTER with the PHASES option and a vector as input for the weights.
   - Dimensionality reduction methods and landmark selection actions have a new syntax. A good introduction that explains how to use these actions can be found in [this tutorial](https://plumed-school.github.io/lessons/21/006/data/DIMENSIONALITY.html)
+  - if you use \ref DISTANCES with the GROUP or GROUPA/GROUPB syntax each distance is no longer allocated to a position in space.  You thus cannot use the GROUP or GROUPA/GROUPB variants of action with methods such as \ref DUMPMULTICOLVAR, \ref MULTICOLVARDENS or \ref SMAC.  To be clear if you use \DISTANCES with the ATOMS1/ATOMS2/ATOMS3/... syntax you can still use it with \ref DUMPMULTICOLVAR, \ref MULTICOLVARDENS or \ref SMAC.  We believe this second use case was the variant of the old version that was widely used.
 
 - Places where we strongly recommend using the new sytax:
   - If you are using \ref DFSCLUSTERING and the \ref CLUSTER_PROPERTIES or \ref CLUSTER_DISTRIBUTION actions you are strongly encouraged to read: https://plumed-school.github.io/lessons/23/001/data/Clusters.html

--- a/src/multicolvar/Distances.cpp
+++ b/src/multicolvar/Distances.cpp
@@ -279,32 +279,13 @@ Distances::Distances(const ActionOptions& ao):
       if( grpb.size()==0 ) {
         error("found GROUPA but no corresponding GROUPB");
       }
-      std::string grpstr = getShortcutLabel() + "_grp: GROUP ATOMS=";
       bool printcomment=false;
       for(unsigned i=0; i<grpa.size(); ++i) {
         for(unsigned j=0; j<grpb.size(); ++j) {
-          std::string num;
           Tools::convert( i*grpb.size() + j + 1, num );
           dline += " ATOMS" + num + "=" + grpa[i] + "," + grpb[j];
-          if( i*grpb.size() + j<6 ) {
-            readInputLine( getShortcutLabel() + "_vatom" + num + ": CENTER ATOMS=" + grpa[i] + "," + grpb[j], true );
-          } else {
-            readInputLine( getShortcutLabel() + "_vatom" + num + ": CENTER ATOMS=" + grpa[i] + "," + grpb[j], false );
-            printcomment=true;
-          }
-          if( i+j==0 ) {
-            grpstr += getShortcutLabel() + "_vatom" + num;
-          } else {
-            grpstr += "," + getShortcutLabel() + "_vatom" + num;
-          }
         }
       }
-      std::string num;
-      Tools::convert( grpa.size()*grpb.size(), num );
-      if( printcomment ) {
-        addCommentToShortcutOutput("# A further " + num + " CENTER like the ones above were also created but are not shown");
-      }
-      readInputLine( grpstr );
     } else {
       std::string grpstr = getShortcutLabel() + "_grp: GROUP ATOMS=";
       for(unsigned i=1;; ++i) {


### PR DESCRIPTION
…(#1193)

* Removed creation of vatoms when using DISTANCES GROUPA/GROUPB syntax

* Added details of changes made yesterday to change log

---------

<!--
  Feel free to delete not relevant sections below
-->

##### Description

<!-- describe here your pull request -->

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __XXXXX__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
