### PR TITLE
Added option in keywords to set an action as depracated and then to p…

### DIFF
--- a/src/cltools/GenJson.cpp
+++ b/src/cltools/GenJson.cpp
@@ -156,6 +156,16 @@ int GenJson::main(FILE* in, FILE*out,Communicator& pc) {
     Keywords keys;
     actionRegister().getKeywords( action_names[i], keys );
     std::cout<<"    \"displayname\" : \""<<keys.getDisplayName()<<"\",\n";
+// This is used for noting actions that have been deprecated
+    std::string replacement = keys.getReplacementAction();
+    if( replacement!="none" ) {
+      bool found_replacement=false;
+      for(unsigned j=0; j<action_names.size(); ++j) {
+        if( action_names[j]==replacement ) { found_replacement=true; break; }
+      }
+      if( !found_replacement ) error("could not find action named " + replacement + " that is supposed to be used to replace " + action_names[i] );
+      std::cout<<"    \"replacement\" : \""<<replacement<<"\",\n"; 
+    }
     std::cout<<"    \"syntax\" : {"<<std::endl;
     for(unsigned j=0; j<keys.size(); ++j) {
       std::string defa = "", desc = keys.getKeywordDescription( keys.getKeyword(j) );

--- a/src/cltools/GenJson.cpp
+++ b/src/cltools/GenJson.cpp
@@ -161,10 +161,15 @@ int GenJson::main(FILE* in, FILE*out,Communicator& pc) {
     if( replacement!="none" ) {
       bool found_replacement=false;
       for(unsigned j=0; j<action_names.size(); ++j) {
-        if( action_names[j]==replacement ) { found_replacement=true; break; }
+        if( action_names[j]==replacement ) {
+          found_replacement=true;
+          break;
+        }
       }
-      if( !found_replacement ) error("could not find action named " + replacement + " that is supposed to be used to replace " + action_names[i] );
-      std::cout<<"    \"replacement\" : \""<<replacement<<"\",\n"; 
+      if( !found_replacement ) {
+        error("could not find action named " + replacement + " that is supposed to be used to replace " + action_names[i] );
+      }
+      std::cout<<"    \"replacement\" : \""<<replacement<<"\",\n";
     }
     std::cout<<"    \"syntax\" : {"<<std::endl;
     for(unsigned j=0; j<keys.size(); ++j) {

--- a/src/multicolvar/DumpMultiColvar.cpp
+++ b/src/multicolvar/DumpMultiColvar.cpp
@@ -47,6 +47,7 @@ PLUMED_REGISTER_ACTION(DumpMultiColvar,"DUMPMULTICOLVAR")
 
 void DumpMultiColvar::registerKeywords(Keywords& keys) {
   ActionShortcut::registerKeywords( keys );
+  keys.setDeprecated("DUMPATOMS");
   keys.add("compulsory","DATA","the vector you wish to transform");
   keys.add("compulsory","FILE","the file that you would like to output the data to");
   keys.remove("HAS_VALUES");

--- a/src/multicolvar/MFilterLess.cpp
+++ b/src/multicolvar/MFilterLess.cpp
@@ -47,6 +47,7 @@ PLUMED_REGISTER_ACTION(MFilterLess,"MFILTER_LESS")
 
 void MFilterLess::registerKeywords(Keywords& keys) {
   ActionShortcut::registerKeywords( keys );
+  keys.setDeprecated("LESS_THAN");
   keys.add("compulsory","DATA","the vector you wish to transform");
   keys.add("compulsory","SWITCH","the switching function that transform");
   keys.setValueDescription("vector","a vector that has the same dimension as the input vector with elements equal to one if the corresponding component of the vector is less than a tolerance and zero otherwise");

--- a/src/multicolvar/MFilterMore.cpp
+++ b/src/multicolvar/MFilterMore.cpp
@@ -47,6 +47,7 @@ PLUMED_REGISTER_ACTION(MFilterMore,"MFILTER_MORE")
 
 void MFilterMore::registerKeywords(Keywords& keys) {
   ActionShortcut::registerKeywords( keys );
+  keys.setDeprecated("MORE_THAN");
   keys.add("compulsory","DATA","the vector you wish to transform");
   keys.add("compulsory","SWITCH","the switching function that transform");
   keys.addFlag("LOWMEM",false,"this flag does nothing and is present only to ensure back-compatibility");

--- a/src/multicolvar/UWalls.cpp
+++ b/src/multicolvar/UWalls.cpp
@@ -48,6 +48,7 @@ PLUMED_REGISTER_ACTION(UWalls,"UWALLS")
 
 void UWalls::registerKeywords(Keywords& keys) {
   ActionShortcut::registerKeywords( keys );
+  keys.setDeprecated("UPPER_WALLS");
   keys.add("compulsory","DATA","the values you want to restrain");
   keys.add("compulsory","AT","the radius of the sphere");
   keys.add("compulsory","KAPPA","the force constant for the wall.  The k_i in the expression for a wall.");

--- a/src/tools/Keywords.cpp
+++ b/src/tools/Keywords.cpp
@@ -1165,4 +1165,12 @@ std::string Keywords::getDisplayName() const {
   return thisactname;
 }
 
+void Keywords::setDeprecated( const std::string& name ) {
+  replaceaction = name;
+}
+
+std::string Keywords::getReplacementAction() const {
+  return replaceaction;
+}
+
 }// namespace PLMD

--- a/src/tools/Keywords.h
+++ b/src/tools/Keywords.h
@@ -94,6 +94,8 @@ private:
   bool isatoms=true;
 /// The name of the action that has this set of keywords
   std::string thisactname;
+/// The action to use in place of this deprecated action
+  std::string replaceaction="none";
 
   struct keyInfo {
     /// Whether the keyword is compulsory, optional...
@@ -308,6 +310,10 @@ public:
   std::string getDisplayName() const ;
 /// Set the display name
   void setDisplayName( const std::string& name );
+/// Get the action that should be used to replace this one if action has been deprecated
+  std::string getReplacementAction() const ;
+/// Note that this action has been deprecated
+  void setDeprecated( const std::string& name );
 };
 
 //the following templates specializations make the bitmask enum work with the

--- a/src/volumes/Density.cpp
+++ b/src/volumes/Density.cpp
@@ -47,6 +47,7 @@ PLUMED_REGISTER_ACTION(Density,"DENSITY")
 
 void Density::registerKeywords(Keywords& keys) {
   ActionShortcut::registerKeywords( keys );
+  keys.setDeprecated("GROUP");
   keys.add("compulsory","SPECIES","the atoms in the group");
   keys.setValueDescription("atoms","indices for the specified group of atoms");
   keys.needsAction("ONES");
@@ -58,6 +59,7 @@ Density::Density(const ActionOptions& ao):
   ActionShortcut(ao) {
   std::string atoms;
   parse("SPECIES",atoms);
+  warning("This action has been depracated.  Look at the log to see how the same result is achieved with the new syntax"); 
   readInputLine( getShortcutLabel() + ": GROUP ATOMS=" + atoms);
 }
 

--- a/src/volumes/Density.cpp
+++ b/src/volumes/Density.cpp
@@ -59,7 +59,7 @@ Density::Density(const ActionOptions& ao):
   ActionShortcut(ao) {
   std::string atoms;
   parse("SPECIES",atoms);
-  warning("This action has been depracated.  Look at the log to see how the same result is achieved with the new syntax"); 
+  warning("This action has been depracated.  Look at the log to see how the same result is achieved with the new syntax");
   readInputLine( getShortcutLabel() + ": GROUP ATOMS=" + atoms);
 }
 


### PR DESCRIPTION
##### Description

This PR adds a facility where you can note that an action should no longer be used by adding the command:

```c++
setDeprecated("LESS_THAN");
```

In the registerKeywords method of an action. The deprecated actions are then tracked in the syntax.json file. By putting this information in that file this way we can note eggs and lessons that are using actions that we have moved on from at some stage in the future.

This does the same as PR #1160 but it is rebased on master.  I will thus close #1160 and replace it with this one.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.11

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
