### PR TITLE
Citation management with DOI stuff

### DIFF
--- a/json/doi_manager.py
+++ b/json/doi_manager.py
@@ -1,0 +1,51 @@
+import subprocess
+import json
+
+def get_dois_from_syntax() :
+  with open("syntax.json") as f :
+    try:
+       plumed_syntax = json.load(f)
+    except ValueError as ve:
+       raise InvalidJSONError(ve)
+
+  doilist = []
+  for key, value in plumed_syntax.items() :
+      if not isinstance(value,dict) or "dois" not in value.keys() : continue
+      for doi in value["dois"] : 
+          if doi not in doilist : doilist.append(doi)
+  return doilist
+
+def get_reference(doi):
+    # initialize strings
+    ref=""; ref_url=""
+    # retrieve citation from doi
+    if(len(doi)>0):
+      # check if unpublished/submitted
+      if(doi.lower()=="unpublished" or doi.lower()=="submitted"):
+        ref=doi.lower()
+      # get info from doi
+      else:
+        try:
+          # get citation
+          cit = subprocess.check_output('curl -LH "Accept: text/bibliography; style=science" \'http://dx.doi.org/'+doi+'\'', shell=True).decode('utf-8').strip()
+          if("DOI Not Found" in cit):
+           ref="DOI not found"
+          else:
+           # get citation
+           ref=cit[3:cit.find(", doi")]
+           # and url
+           ref_url="http://dx.doi.org/"+doi 
+        except:
+          ref="DOI not found"
+    return ref
+
+if __name__ == "__main__" :
+   # Get all the dois that are listed in the syntax file
+   doilist = get_dois_from_syntax()
+   # Now get all the references using Max's magic script and create the map
+   of = open("../src/tools/CitationMap.inc","w+")
+   for doi in doilist : 
+       reference = get_reference(doi)
+       if doi==doilist[-1] : of.write("{\"" + doi + "\",\"" + get_reference(doi) + "\"}") 
+       else : of.write("{\"" + doi + "\",\"" + get_reference(doi) + "\"}")
+   of.close()

--- a/src/adjmat/AdjacencyMatrixBase.cpp
+++ b/src/adjmat/AdjacencyMatrixBase.cpp
@@ -43,6 +43,7 @@ void AdjacencyMatrixBase::registerKeywords( Keywords& keys ) {
   keys.addOutputComponent("y","COMPONENTS","matrix","the projection of the bond on the y axis");
   keys.addOutputComponent("z","COMPONENTS","matrix","the projection of the bond on the z axis");
   keys.setValueDescription("matrix","a matrix containing the weights for the bonds between each pair of atoms");
+  keys.addDOI("10.1021/acs.jctc.6b01073");
 }
 
 AdjacencyMatrixBase::AdjacencyMatrixBase(const ActionOptions& ao):
@@ -174,7 +175,7 @@ AdjacencyMatrixBase::AdjacencyMatrixBase(const ActionOptions& ao):
     addComponent( "z", shape );
     componentIsNotPeriodic("z");
   }
-  log<<"  Bibliography "<<plumed.cite("Tribello, Giberti, Sosso, Salvalaglio and Parrinello, J. Chem. Theory Comput. 13, 1317 (2017)")<<"\n";
+  log<<"  Bibliography "<<plumed.cite("10.1021/acs.jctc.6b01073")<<"\n";
 }
 
 unsigned AdjacencyMatrixBase::getNumberOfDerivatives() {

--- a/src/bias/Bias.cpp
+++ b/src/bias/Bias.cpp
@@ -20,6 +20,7 @@
    along with plumed.  If not, see <http://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 #include "Bias.h"
+#include "core/PlumedMain.h"
 
 
 namespace PLMD {
@@ -37,7 +38,7 @@ Bias::Bias(const ActionOptions&ao):
 
   if(getStride()>1) {
     log<<"  multiple time step "<<getStride()<<" ";
-    log<<cite("Ferrarotti, Bottaro, Perez-Villa, and Bussi, J. Chem. Theory Comput. 11, 139 (2015)")<<"\n";
+    log<<plumed.cite("Ferrarotti, Bottaro, Perez-Villa, and Bussi, J. Chem. Theory Comput. 11, 139 (2015)")<<"\n";
   }
   for(unsigned i=0; i<getNumberOfArguments(); ++i) {
     (getPntrToArgument(i)->getPntrToAction())->turnOnDerivatives();

--- a/src/bias/MovingRestraint.cpp
+++ b/src/bias/MovingRestraint.cpp
@@ -20,6 +20,7 @@
    along with plumed.  If not, see <http://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 #include "Bias.h"
+#include "core/PlumedMain.h"
 #include "core/ActionRegister.h"
 
 namespace PLMD {
@@ -231,7 +232,7 @@ MovingRestraint::MovingRestraint(const ActionOptions&ao):
   tot_work=0.0;
 
   log<<"  Bibliography ";
-  log<<cite("Grubmuller, Heymann, and Tavan, Science 271, 997 (1996)")<<"\n";
+  log<<plumed.cite("Grubmuller, Heymann, and Tavan, Science 271, 997 (1996)")<<"\n";
 
 }
 

--- a/src/cltools/GenJson.cpp
+++ b/src/cltools/GenJson.cpp
@@ -171,6 +171,14 @@ int GenJson::main(FILE* in, FILE*out,Communicator& pc) {
       }
       std::cout<<"    \"replacement\" : \""<<replacement<<"\",\n";
     }
+    // This outputs all the DOI information from the registerKeyword method in the json file
+    std::cout<<"     \"dois\" : [";
+    unsigned ndoi = keys.getDOIList().size();
+    if( ndoi>0 ) {
+      std::cout<<"\"" + keys.getDOIList()[0] + "\"";
+      for(unsigned j=1; j<ndoi; ++j) std::cout<<", \"" + keys.getDOIList()[j] + "\"";
+    }
+    std::cout<<"],\n";
     std::cout<<"    \"syntax\" : {"<<std::endl;
     for(unsigned j=0; j<keys.size(); ++j) {
       std::string defa = "", desc = keys.getKeywordDescription( keys.getKeyword(j) );

--- a/src/cltools/GenJson.cpp
+++ b/src/cltools/GenJson.cpp
@@ -176,7 +176,9 @@ int GenJson::main(FILE* in, FILE*out,Communicator& pc) {
     unsigned ndoi = keys.getDOIList().size();
     if( ndoi>0 ) {
       std::cout<<"\"" + keys.getDOIList()[0] + "\"";
-      for(unsigned j=1; j<ndoi; ++j) std::cout<<", \"" + keys.getDOIList()[j] + "\"";
+      for(unsigned j=1; j<ndoi; ++j) {
+        std::cout<<", \"" + keys.getDOIList()[j] + "\"";
+      }
     }
     std::cout<<"],\n";
     std::cout<<"    \"syntax\" : {"<<std::endl;

--- a/src/clusters/ClusteringBase.cpp
+++ b/src/clusters/ClusteringBase.cpp
@@ -50,6 +50,7 @@ ClusteringBase::ClusteringBase(const ActionOptions&ao):
   // Resize local variables
   which_cluster.resize( getPntrToArgument(0)->getShape()[0] );
   cluster_sizes.resize( getPntrToArgument(0)->getShape()[0] );
+  log<<"  Bibliography "<<plumed.cite("10.1021/acs.jctc.6b01073")<<"\n";
 }
 
 void ClusteringBase::retrieveAdjacencyLists( std::vector<unsigned>& nneigh, Matrix<unsigned>& adj_list ) {

--- a/src/clusters/ClusteringBase.cpp
+++ b/src/clusters/ClusteringBase.cpp
@@ -28,6 +28,7 @@ namespace clusters {
 void ClusteringBase::registerKeywords( Keywords& keys ) {
   matrixtools::MatrixOperationBase::registerKeywords( keys );
   keys.setValueDescription("vector","vector with length that is equal to the number of rows in the input matrix.  Elements of this vector are equal to the cluster that each node is a part of");
+  keys.addDOI("10.1021/acs.jctc.6b01073");
 }
 
 ClusteringBase::ClusteringBase(const ActionOptions&ao):

--- a/src/core/ActionShortcut.cpp
+++ b/src/core/ActionShortcut.cpp
@@ -88,19 +88,18 @@ void ActionShortcut::readInputLine( const std::string& input, bool saveline ) {
     founds=true;
   }
   if( found ) {
-    std::string f_input = input;
     if( !founds && saveline ) {
       addToSavedInputLines( input );
     }
     if( keywords.exists("RESTART") ) {
       if( restart ) {
-        f_input += " RESTART=YES";
+        words.push_back("RESTART=YES");
       }
       if( !restart ) {
-        f_input += " RESTART=NO";
+        words.push_back("RESTART=NO");
       }
     }
-    plumed.readInputLine( f_input );
+    plumed.readInputWords( words, false );
     if( !founds ) {
       ActionWithValue* av=NULL;
       for(auto pp=plumed.getActionSet().rbegin(); pp!=plumed.getActionSet().rend(); ++pp) {

--- a/src/core/GenericMolInfo.cpp
+++ b/src/core/GenericMolInfo.cpp
@@ -368,16 +368,16 @@ void GenericMolInfo::interpretSymbol( const std::string& symbol, std::vector<Ato
     }
     log<<"  selection interpreted using ";
     if(Tools::startWith(symbol,"mdt:")) {
-      log<<"mdtraj "<<cite("McGibbon et al, Biophys. J., 109, 1528 (2015)")<<"\n";
+      log<<"mdtraj "<<plumed.cite("McGibbon et al, Biophys. J., 109, 1528 (2015)")<<"\n";
     }
     if(Tools::startWith(symbol,"mda:")) {
-      log<<"MDAnalysis "<<cite("Gowers et al, Proceedings of the 15th Python in Science Conference, doi:10.25080/majora-629e541a-00e (2016)")<<"\n";
+      log<<"MDAnalysis "<<plumed.cite("Gowers et al, Proceedings of the 15th Python in Science Conference, doi:10.25080/majora-629e541a-00e (2016)")<<"\n";
     }
     if(Tools::startWith(symbol,"vmdexec:")) {
-      log<<"VMD "<<cite("Humphrey, Dalke, and Schulten, K., J. Molec. Graphics, 14, 33 (1996)")<<"\n";
+      log<<"VMD "<<plumed.cite("Humphrey, Dalke, and Schulten, K., J. Molec. Graphics, 14, 33 (1996)")<<"\n";
     }
     if(Tools::startWith(symbol,"vmd:")) {
-      log<<"VMD (github.com/Eigenstate/vmd-python) "<<cite("Humphrey, Dalke, and Schulten, K., J. Molec. Graphics, 14, 33 (1996)")<<"\n";
+      log<<"VMD (github.com/Eigenstate/vmd-python) "<<plumed.cite("Humphrey, Dalke, and Schulten, K., J. Molec. Graphics, 14, 33 (1996)")<<"\n";
     }
     return;
   }

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -1067,7 +1067,11 @@ void PlumedMain::readInputLine(const std::string & str, const bool& before_init)
     return;
   }
   std::vector<std::string> words=Tools::getWords(str);
-  citations.clear();
+  if( before_init ) {
+    plumed_assert( citations.empty() );
+  } else {
+    citations.clear();
+  }
   readInputWords(words,before_init);
   if(!citations.empty()) {
     log<<"Relevant bibliography:\n";
@@ -1729,7 +1733,7 @@ bool PlumedMain::DeprecatedAtoms::usingNaturalUnits() const {
 }
 
 void PlumedMain::DeprecatedAtoms::setCollectEnergy(bool b) const {
-  plumed.readInputLine( plumed.MDEngine + "_energy: ENERGY" );
+  plumed.readInputWords( Tools::getWords(plumed.MDEngine + "_energy: ENERGY"), false );
   plumed.setEnergyValue( plumed.MDEngine + "_energy" );
 }
 

--- a/src/generic/EffectiveEnergyDrift.cpp
+++ b/src/generic/EffectiveEnergyDrift.cpp
@@ -190,7 +190,7 @@ EffectiveEnergyDrift::EffectiveEnergyDrift(const ActionOptions&ao):
     }
   }
 
-  log<<"Bibliography "<<cite("Ferrarotti, Bottaro, Perez-Villa, and Bussi, J. Chem. Theory Comput. 11, 139 (2015)")<<"\n";
+  log<<"Bibliography "<<plumed.cite("Ferrarotti, Bottaro, Perez-Villa, and Bussi, J. Chem. Theory Comput. 11, 139 (2015)")<<"\n";
 
   //construct biases from ActionWithValue with a component named bias
   std::vector<ActionWithValue*> tmpActions=plumed.getActionSet().select<ActionWithValue*>();

--- a/src/gridtools/KDE.cpp
+++ b/src/gridtools/KDE.cpp
@@ -157,20 +157,20 @@ KDE::KDE(const ActionOptions&ao):
             band += "," + bwidths[i];
           }
         }
-        plumed.readInputLine( getLabel() + "_sigma: CONSTANT " + band );
-        plumed.readInputLine( getLabel() + "_cov: CUSTOM ARG=" + getLabel() + "_sigma FUNC=x*x PERIODIC=NO" );
-        plumed.readInputLine( getLabel() + "_icov: CUSTOM ARG=" + getLabel() + "_cov FUNC=1/x PERIODIC=NO" );
+        plumed.readInputWords( Tools::getWords( getLabel() + "_sigma: CONSTANT " + band ), false );
+        plumed.readInputWords( Tools::getWords( getLabel() + "_cov: CUSTOM ARG=" + getLabel() + "_sigma FUNC=x*x PERIODIC=NO"), false );
+        plumed.readInputWords( Tools::getWords( getLabel() + "_icov: CUSTOM ARG=" + getLabel() + "_cov FUNC=1/x PERIODIC=NO"), false );
         bandwidth = getLabel() + "_icov";
 
         if( (kerneltype=="gaussian" || kerneltype=="GAUSSIAN") && weights_are_volumes ) {
           std::string pstr;
           Tools::convert( sqrt(pow(2*pi,bwidths.size())), pstr );
-          plumed.readInputLine( getLabel() + "_bwprod: PRODUCT ARG=" + getLabel() + "_cov");
-          plumed.readInputLine( getLabel() + "_vol: CUSTOM ARG=" + getLabel() + "_bwprod FUNC=(sqrt(x)*" + pstr + ") PERIODIC=NO");
+          plumed.readInputWords( Tools::getWords( getLabel() + "_bwprod: PRODUCT ARG=" + getLabel() + "_cov"), false );
+          plumed.readInputWords( Tools::getWords( getLabel() + "_vol: CUSTOM ARG=" + getLabel() + "_bwprod FUNC=(sqrt(x)*" + pstr + ") PERIODIC=NO"), false );
           if( hasheight ) {
-            plumed.readInputLine( getLabel() + "_height: CUSTOM ARG=" + weight_str[0] + "," + getLabel() + "_vol FUNC=x/y PERIODIC=NO");
+            plumed.readInputWords( Tools::getWords( getLabel() + "_height: CUSTOM ARG=" + weight_str[0] + "," + getLabel() + "_vol FUNC=x/y PERIODIC=NO"), false );
           } else {
-            plumed.readInputLine( getLabel() + "_height: CUSTOM ARG=" + getLabel() + "_vol FUNC=1/x PERIODIC=NO");
+            plumed.readInputWords( Tools::getWords( getLabel() + "_height: CUSTOM ARG=" + getLabel() + "_vol FUNC=1/x PERIODIC=NO"), false );
           }
           hasheight=true;
           weight_str.resize(1);

--- a/src/tools/.gitignore
+++ b/src/tools/.gitignore
@@ -7,3 +7,4 @@
 !/Makefile
 !/README
 !/module.type
+!/CitationMap.inc

--- a/src/tools/CitationMap.inc
+++ b/src/tools/CitationMap.inc
@@ -1,0 +1,1 @@
+{"10.1021/acs.jctc.6b01073","G. A. Tribello, F. Giberti, G. C. Sosso, M. Salvalaglio, M. Parrinello, Analyzing and Driving Cluster Formation in Atomistic Simulations. Journal of Chemical Theory and Computation. 13, 1317–1327 (2017)"}

--- a/src/tools/Citations.cpp
+++ b/src/tools/Citations.cpp
@@ -26,14 +26,23 @@
 
 namespace PLMD {
 
+const static Tools::FastStringUnorderedMap<std::string> doi_map = {
+#include "CitationMap.inc"
+};
+
 std::string Citations::cite(const std::string & item) {
+  std::string myref=item;
+  if( doi_map.find(item)!=doi_map.end() ) {
+    myref=doi_map.find(item)->second;
+  }
+
   unsigned i;
   for(i=0; i<items.size(); ++i)
-    if(items[i]==item) {
+    if(items[i]==myref) {
       break;
     }
   if(i==items.size()) {
-    items.push_back(item);
+    items.push_back(myref);
   }
   plumed_assert(i<items.size());
   std::string ret;

--- a/src/tools/Keywords.cpp
+++ b/src/tools/Keywords.cpp
@@ -1173,4 +1173,12 @@ std::string Keywords::getReplacementAction() const {
   return replaceaction;
 }
 
+void Keywords::addDOI( const std::string& doi ) {
+  doilist.push_back( doi );
+}
+
+const std::vector<std::string>& Keywords::getDOIList() const {
+  return doilist;
+}
+
 }// namespace PLMD

--- a/src/tools/Keywords.h
+++ b/src/tools/Keywords.h
@@ -152,6 +152,8 @@ private:
   std::vector<std::string> neededActions;
 /// List of suffixes that can be used with this action
   std::vector<std::string> actionNameSuffixes;
+/// List of doi's that should appear in the manual
+  std::vector<std::string> doilist;
 /// Print the documentation for the named keyword in html
   void print_html_item( const std::string& ) const;
 public:
@@ -314,6 +316,10 @@ public:
   std::string getReplacementAction() const ;
 /// Note that this action has been deprecated
   void setDeprecated( const std::string& name );
+/// Add a DOI to the list in the manual page for this action
+  void addDOI( const std::string& doi );
+/// Get the list of DOI
+  const std::vector<std::string>& getDOIList() const ;
 };
 
 //the following templates specializations make the bitmask enum work with the

--- a/src/valtools/SelectWithMask.cpp
+++ b/src/valtools/SelectWithMask.cpp
@@ -110,7 +110,7 @@ SelectWithMask::SelectWithMask(const ActionOptions& ao):
       for(unsigned i=1; i<getPntrToArgument(0)->getShape()[1]; ++i) {
         con += ",0";
       }
-      plumed.readInputLine( getLabel() + "_colmask: CONSTANT VALUES=" + con );
+      plumed.readInputWords( Tools::getWords(getLabel() + "_colmask: CONSTANT VALUES=" + con), false );
       std::vector<std::string> labs(1, getLabel() + "_colmask");
       ActionWithArguments::interpretArgumentList( labs, plumed.getActionSet(), this, cmask );
     } else if( rmask.size()==0 ) {
@@ -118,7 +118,7 @@ SelectWithMask::SelectWithMask(const ActionOptions& ao):
       for(unsigned i=1; i<getPntrToArgument(0)->getShape()[0]; ++i) {
         con += ",0";
       }
-      plumed.readInputLine( getLabel() + "_rowmask: CONSTANT VALUES=" + con );
+      plumed.readInputWords( Tools::getWords(getLabel() + "_rowmask: CONSTANT VALUES=" + con), false );
       std::vector<std::string> labs(1, getLabel() + "_rowmask");
       ActionWithArguments::interpretArgumentList( labs, plumed.getActionSet(), this, rmask );
     }


### PR DESCRIPTION
##### Description

This is a rework of PR #1115.  It allows you to put the DOIs of papers that describe the functionality in an action in the syntax.json file. To add a DOI to your paper, you simply use the command:

```c++
keys.addDOI("<DOI>");
```

in the registerKeywords method of your action. Hopefully, this will help users quickly build documentation for their methods when we get the new manual working.

Now, however, you can also cite a DOI in the PLUMED log file as well using:

```c++
log<<plumed.cite("<DOI>")<<"\n";
```

This works because I reuse Max's magic python script to create a std::map from all the DOIs that have been included in the json file.  I then read the map in the Citation Manager object.  A few observations  

1. In making this change, I realised that the citations in the log do not play nice with shortcut actions.  This was my fault and due to a misunderstanding of how the citations work.  Do you think I should do a bug fix PR on 2.10 to resolve the problem there @GiovanniBussi?  
2. Should we change everywhere in the code where someone has used an old style cite command so that we use the DOIs of the paper instead?
3. How should I ensure that the python script is used to keep the map of DOIs and up to date with what is in the syntax file?  Currently, I just assume that folks will run the script after they have added a DOI and commit the changes to the file that holds the map.  If they don't the DOI will be referenced in the log.  

On a completely separate note, what is the point of asking on this form: "I verified that all regtests are passed successfully on GitHub actions."?  If they don't pass all the tests, you see it below the PR.  Is it time to retire that bit of this form?

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __XXXXX__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
