### PR TITLE
Fixed bug with shortcuts and citation manager

### DIFF
--- a/src/core/ActionShortcut.cpp
+++ b/src/core/ActionShortcut.cpp
@@ -92,19 +92,18 @@ void ActionShortcut::readInputLine( const std::string& input, bool saveline ) {
     founds=true;
   }
   if( found ) {
-    std::string f_input = input;
     if( !founds && saveline ) {
       addToSavedInputLines( input );
     }
     if( keywords.exists("RESTART") ) {
       if( restart ) {
-        f_input += " RESTART=YES";
+        words.push_back("RESTART=YES");
       }
       if( !restart ) {
-        f_input += " RESTART=NO";
+        words.push_back("RESTART=NO");
       }
     }
-    plumed.readInputLine( f_input );
+    plumed.readInputWords( words, false);
     if( !founds ) {
       ActionWithValue* av=NULL;
       for(auto pp=plumed.getActionSet().rbegin(); pp!=plumed.getActionSet().rend(); ++pp) {

--- a/src/core/PlumedMain.cpp
+++ b/src/core/PlumedMain.cpp
@@ -1067,6 +1067,9 @@ void PlumedMain::readInputLine(const std::string & str, const bool& before_init)
     return;
   }
   std::vector<std::string> words=Tools::getWords(str);
+  if( before_init ) {
+    plumed_assert( citations.empty() );
+  }
   citations.clear();
   readInputWords(words,before_init);
   if(!citations.empty()) {
@@ -1729,7 +1732,7 @@ bool PlumedMain::DeprecatedAtoms::usingNaturalUnits() const {
 }
 
 void PlumedMain::DeprecatedAtoms::setCollectEnergy(bool b) const {
-  plumed.readInputLine( plumed.MDEngine + "_energy: ENERGY" );
+  plumed.readInputWords( Tools::getWords(plumed.MDEngine + "_energy: ENERGY"), false );
   plumed.setEnergyValue( plumed.MDEngine + "_energy" );
 }
 

--- a/src/gridtools/KDE.cpp
+++ b/src/gridtools/KDE.cpp
@@ -157,20 +157,20 @@ KDE::KDE(const ActionOptions&ao):
             band += "," + bwidths[i];
           }
         }
-        plumed.readInputLine( getLabel() + "_sigma: CONSTANT " + band );
-        plumed.readInputLine( getLabel() + "_cov: CUSTOM ARG=" + getLabel() + "_sigma FUNC=x*x PERIODIC=NO" );
-        plumed.readInputLine( getLabel() + "_icov: CUSTOM ARG=" + getLabel() + "_cov FUNC=1/x PERIODIC=NO" );
+        plumed.readInputWords( Tools::getWords(getLabel() + "_sigma: CONSTANT " + band), false );
+        plumed.readInputWords( Tools::getWords(getLabel() + "_cov: CUSTOM ARG=" + getLabel() + "_sigma FUNC=x*x PERIODIC=NO"), false );
+        plumed.readInputWords( Tools::getWords(getLabel() + "_icov: CUSTOM ARG=" + getLabel() + "_cov FUNC=1/x PERIODIC=NO"), false );
         bandwidth = getLabel() + "_icov";
 
         if( (kerneltype=="gaussian" || kerneltype=="GAUSSIAN") && weights_are_volumes ) {
           std::string pstr;
           Tools::convert( sqrt(pow(2*pi,bwidths.size())), pstr );
-          plumed.readInputLine( getLabel() + "_bwprod: PRODUCT ARG=" + getLabel() + "_cov");
-          plumed.readInputLine( getLabel() + "_vol: CUSTOM ARG=" + getLabel() + "_bwprod FUNC=(sqrt(x)*" + pstr + ") PERIODIC=NO");
+          plumed.readInputWords( Tools::getWords(getLabel() + "_bwprod: PRODUCT ARG=" + getLabel() + "_cov"), false );
+          plumed.readInputWords( Tools::getWords(getLabel() + "_vol: CUSTOM ARG=" + getLabel() + "_bwprod FUNC=(sqrt(x)*" + pstr + ") PERIODIC=NO"), false );
           if( hasheight ) {
-            plumed.readInputLine( getLabel() + "_height: CUSTOM ARG=" + weight_str[0] + "," + getLabel() + "_vol FUNC=x/y PERIODIC=NO");
+            plumed.readInputWords( Tools::getWords(getLabel() + "_height: CUSTOM ARG=" + weight_str[0] + "," + getLabel() + "_vol FUNC=x/y PERIODIC=NO"), false);
           } else {
-            plumed.readInputLine( getLabel() + "_height: CUSTOM ARG=" + getLabel() + "_vol FUNC=1/x PERIODIC=NO");
+            plumed.readInputWords( Tools::getWords(getLabel() + "_height: CUSTOM ARG=" + getLabel() + "_vol FUNC=1/x PERIODIC=NO"), false);
           }
           hasheight=true;
           weight_str.resize(1);

--- a/src/valtools/SelectWithMask.cpp
+++ b/src/valtools/SelectWithMask.cpp
@@ -110,7 +110,7 @@ SelectWithMask::SelectWithMask(const ActionOptions& ao):
       for(unsigned i=1; i<getPntrToArgument(0)->getShape()[1]; ++i) {
         con += ",0";
       }
-      plumed.readInputLine( getLabel() + "_colmask: CONSTANT VALUES=" + con );
+      plumed.readInputWords( Tools::getWords(getLabel() + "_colmask: CONSTANT VALUES=" + con), false );
       std::vector<std::string> labs(1, getLabel() + "_colmask");
       ActionWithArguments::interpretArgumentList( labs, plumed.getActionSet(), this, cmask );
     } else if( rmask.size()==0 ) {
@@ -118,7 +118,7 @@ SelectWithMask::SelectWithMask(const ActionOptions& ao):
       for(unsigned i=1; i<getPntrToArgument(0)->getShape()[0]; ++i) {
         con += ",0";
       }
-      plumed.readInputLine( getLabel() + "_rowmask: CONSTANT VALUES=" + con );
+      plumed.readInputWords( Tools::getWords(getLabel() + "_rowmask: CONSTANT VALUES=" + con), false );
       std::vector<std::string> labs(1, getLabel() + "_rowmask");
       ActionWithArguments::interpretArgumentList( labs, plumed.getActionSet(), this, rmask );
     }


### PR DESCRIPTION
##### Description

This is a fix for a bug that I discovered while working on PR #1199 

When creating actions from shortcuts you need to use readInputWords rather than readInputLine as readInputLine prints and clears the bibliography after creating the action.  In contrast readInputWords keeps the bibliography and only prints it at the end of the log one the whole plumed input is read.  This PR changes all the readInputLine commands in shortcuts to readInputWord commands so the bibliography is rendered properly again.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
