### PR TITLE
Update doc about multi option

### DIFF
--- a/src/cltools/Driver.cpp
+++ b/src/cltools/Driver.cpp
@@ -174,6 +174,13 @@ Notice that the xdrfile implementation of xtc and trr
 is more robust than the molfile one, since it provides support for generic cell shapes.
 In addition, it allows \ref DUMPATOMS to write compressed xtc files.
 
+\par Multiple replicas
+
+When PLUMED is compiled with MPI support, you can emulate a multi-simulation setup with the `driver` by providing the `--multi`
+option with the appropriate number of ranks. This allows to use the \ref special-replica-syntax and to analyze multiple
+trajectories (see \ref trieste-5-replicas). PLUMED will automatically append a numbered suffix to output files
+(e.g. `COLVAR.0`, `COLVAR.1`, …). Similarly, each replica will search for the corresponding suffixed input file (e.g. `traj.0.xtc`, …)
+or default to the unsuffixed one.
 
 */
 //+ENDPLUMEDOC


### PR DESCRIPTION
##### Description

Added a section in the `driver` documentation about using `--multi`, following my own [confusion about the topic](https://github.com/plumed/plumed2/issues/1196)

##### Target release

I would like my code to appear in release v2.10

##### Type of contribution

- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

N.A.