### PR TITLE
Added new mechanism for forces in ParallelTaskManager

### DIFF
--- a/src/core/ParallelTaskManager.h
+++ b/src/core/ParallelTaskManager.h
@@ -43,6 +43,10 @@ struct ParallelActionsInput {
   unsigned ncomponents{0};
 //// The number of indexes that you use per task
   unsigned nindices_per_task{0};
+/// The end of the derivatives that are only affected by one task
+  unsigned threadsafe_derivatives_end{0};
+/// The start of the thread unsafe forces
+  unsigned threadunsafe_forces_start{0};
 /// This holds all the input data that is required to calculate all values for all tasks
   unsigned dataSize{0};
   double *inputdata{nullptr};
@@ -57,6 +61,8 @@ struct ParallelActionsInput {
       pbc  {other.pbc},
       ncomponents {other.ncomponents},
       nindices_per_task {other.nindices_per_task},
+      threadsafe_derivatives_end {other.threadsafe_derivatives_end},
+      threadunsafe_forces_start {other.threadunsafe_forces_start},
       dataSize {other.dataSize},
       //just copies the value of the pointer
       inputdata  {other.inputdata}
@@ -66,7 +72,7 @@ struct ParallelActionsInput {
 
   //helper function to bring data to the device in a controlled way
   void toACCDevice()const {
-#pragma acc enter data copyin(this[0:1], noderiv, pbc[0:1],ncomponents, nindices_per_task, dataSize, inputdata[0:dataSize])
+#pragma acc enter data copyin(this[0:1], noderiv, pbc[0:1],ncomponents, nindices_per_task, threadsafe_derivatives_end, threadunsafe_forces_start, dataSize, inputdata[0:dataSize])
 
     pbc->toACCDevice();
   }
@@ -74,7 +80,7 @@ struct ParallelActionsInput {
   void removeFromACCDevice() const  {
     pbc->removeFromACCDevice();
     // assuming dataSize is not changed
-#pragma acc exit data delete(inputdata[0:dataSize],dataSize,nindices_per_task,ncomponents, pbc[0:1],noderiv,this[0:1])
+#pragma acc exit data delete(inputdata[0:dataSize],dataSize,nindices_per_task,ncomponents, threadsafe_derivatives_end, threadunsafe_forces_start, pbc[0:1],noderiv,this[0:1])
   }
 };
 
@@ -163,8 +169,6 @@ private:
   bool useacc;
 /// Number of derivatives for quantity being calculated
   std::size_t nderivatives_per_component;
-/// The number of forces on each thread
-  std::size_t nthreaded_forces;
 /// This holds the values before we pass them to the value
   std::vector<double> value_stash;
 /// A tempory set of vectors for holding forces over threads
@@ -183,8 +187,9 @@ public:
 /// Setup the parallel task manager the three arguments are
 /// nind = the number of indices that are used per task
 /// nder = number of derivatives per component that is being calculated
-/// nt = number of derivatives that need to gathered over the threads (default of zero means all derivatives need to be calculated in a way that is thread safe)
-  void setupParallelTaskManager( std::size_t nind, std::size_t nder, int nt=-1 );
+/// nder_tus = number of derivatives that can be directly added to the applyForces array
+/// nforce_ts = size of part of forces array that need to be handled with thread safe procedure
+  void setupParallelTaskManager( std::size_t nind, std::size_t nder, std::size_t nder_tus, std::size_t nforce_ts );
 /// Copy the data from the underlying colvar into this parallel action
   void setActionInput( const input_type& adata );
 /// Get the action input so we can use it
@@ -193,6 +198,16 @@ public:
   void runAllTasks();
 /// Apply the forces on the parallel object
   void applyForces( std::vector<double>& forcesForApply );
+/// This is used to gather forces that are thread safe
+  static void gatherThreadSafeForces( const ParallelActionsInput& input,
+                                      View<std::size_t,helpers::dynamic_extent> force_indices,
+                                      const ForceInput& fdata,
+                                      View<double,helpers::dynamic_extent> forces );
+/// This is used to gather forces that are not thread safe
+  static void gatherThreadUnsafeForces( const ParallelActionsInput& input,
+                                        View<std::size_t,helpers::dynamic_extent> force_indices,
+                                        const ForceInput& fdata,
+                                        View<double,helpers::dynamic_extent> forces ); 
 };
 
 template <class T>
@@ -207,7 +222,6 @@ ParallelTaskManager<T>::ParallelTaskManager(ActionWithVector* av):
   ismatrix(false),
   useacc(false),
   nderivatives_per_component(0),
-  nthreaded_forces(0),
   myinput(av->getPbc()) {
   ActionWithMatrix* am=dynamic_cast<ActionWithMatrix*>(av);
   if(am) {
@@ -229,7 +243,9 @@ template <class T>
 void ParallelTaskManager<T>::setupParallelTaskManager(
   std::size_t nind,
   std::size_t nder,
-  int nt ) {
+  std::size_t nder_tus,
+  std::size_t nforce_ts ) {
+  //int nt ) {
   plumed_massert( action->getNumberOfComponents()>0, "there should be some components wen you setup the index list" );
   std::size_t valuesize=(action->getConstPntrToComponent(0))->getNumberOfStoredValues();
   for(unsigned i=1; i<action->getNumberOfComponents(); ++i) {
@@ -239,23 +255,16 @@ void ParallelTaskManager<T>::setupParallelTaskManager(
   nderivatives_per_component = nder;
   value_stash.resize( valuesize*action->getNumberOfComponents() );
   myinput.nindices_per_task = nind;
-  if( nt<0 ) {
-    //nvc++ seems to give problem on thrown exceptions
-    plumed_massert(
-      !(useacc && ! has_custom_gather),
-      "This action needs to specify a custom GatherForces function for the derivatives (see ParallelTaskManager manual)"
-    );
-    nthreaded_forces = action->getNumberOfDerivatives();
-  } else {
-    nthreaded_forces = nt;
-  }
+  plumed_massert( nder_tus<nder, "number of derivatives that can be handled in thread safe manner must be less than total number of derivatives");
+  myinput.threadsafe_derivatives_end = nder_tus;
+  myinput.threadunsafe_forces_start = action->getNumberOfDerivatives() - nforce_ts;
   unsigned t=OpenMP::getNumThreads();
   if( useacc ) {
     t = 1;
   }
   omp_forces.resize(t);
   for(unsigned i=0; i<t; ++i) {
-    omp_forces[i].resize(nthreaded_forces);
+    omp_forces[i].resize(nforce_ts);
   }
 }
 
@@ -410,16 +419,18 @@ void ParallelTaskManager<T>::applyForces( std::vector<double>& forcesForApply ) 
     auto forcesForApply_data = ffa.devicePtr();
     const auto forcesForApply_size = ffa.size();
 
-    OpenACC::memoryManager ofd {omp_forces[0]};
-    auto omp_forces_data = ofd.devicePtr();
-    const auto omp_forces_size = ofd.size();
-    const auto reduction_size = (has_custom_gather)
-                                ? 0:omp_forces_size;
+//    OpenACC::memoryManager ofd {omp_forces[0]};
+//    auto omp_forces_data = ofd.devicePtr();
+//    const auto omp_forces_size = ofd.size();
+//    const auto reduction_size = (has_custom_gather)
+//                                ? 0:omp_forces_size;
     const auto nderivPerComponent = nderivatives_per_component;
     const auto ndev_per_task = input.ncomponents*nderivPerComponent;
 
     OpenACC::memoryManager<double> dev{ndev_per_task*nactive_tasks};
     auto derivatives = dev.devicePtr();
+    OpenACC::memoryManager<std::size_t> ind{ndev_per_task*nactive_tasks};
+    auto indices = ind.devicePtr();
     OpenACC::memoryManager<double> vtmp{input.ncomponents*nactive_tasks};
     auto valstmp = vtmp.devicePtr();
 
@@ -427,17 +438,17 @@ void ParallelTaskManager<T>::applyForces( std::vector<double>& forcesForApply ) 
                   copyin(nactive_tasks, \
                          nderivPerComponent, \
                          forcesForApply_size, \
-                         ndev_per_task, \
-                         omp_forces_size) \
+                         ndev_per_task) \
                deviceptr(derivatives, \
-                         omp_forces_data, \
+                         indices, \
                          value_stash_data, \
                          partialTaskList_data, \
                          forcesForApply_data, \
                          valstmp) \
                  default(none)
     {
-#pragma acc parallel loop reduction(+:omp_forces_data[0:reduction_size])
+      View<double,helpers::dynamic_extent> forces( forcesForApply_data, forcesForApply_size );
+#pragma acc parallel loop
       for(unsigned i=0; i<nactive_tasks; ++i) {
         std::size_t task_index = partialTaskList_data[i];
         ParallelActionsOutput myout { input.ncomponents,
@@ -446,66 +457,118 @@ void ParallelTaskManager<T>::applyForces( std::vector<double>& forcesForApply ) 
                                       derivatives+ndev_per_task*i};
         // Calculate the stuff in the loop for this action
         T::performTask( task_index, t_actiondata, input, myout );
-        if constexpr (!has_custom_gather) {
-          // Gather the forces from the values
-          T::gatherForces( task_index,
-                           t_actiondata,
-                           input,
-                           ForceInput { input.ncomponents,
-                                        value_stash_data+input.ncomponents*task_index,
-                                        nderivPerComponent,
-                                        derivatives+ndev_per_task*i},
-                           ForceOutput { omp_forces_data,
-                                         omp_forces_size,
-                                         forcesForApply_data,
-                                         forcesForApply_size }
-                         );
-        }
+        // Get the indices that are used here
+        View<std::size_t,helpers::dynamic_extent> force_indices( force_indices_data + ndev_per_task*i, ndev_per_task );
+        T::getForceIndices( task_index,
+                            forcesForApply_size,
+                            t_actiondata,
+                            input,
+                            force_indices );
+        // Gather forces that can be gathered locally
+        gatherThreadSafeForces( task_index,
+                                force_indices,
+                                ForceInput{ input.ncomponents,
+                                            value_stash_data+input.ncomponents*task_index,
+                                            nderivPerComponent,
+                                            derivatives+ndev_per_task*i},
+                                forces );
       }
-
-      if constexpr (has_custom_gather) {
 #pragma acc parallel loop
-        for(unsigned v=0;
-            v<nthreaded_forces-T::customGatherStopBefore;
-            v+=T::customGatherStep) {
-          T::gatherForces_custom(
-            v,nderivPerComponent,ndev_per_task,t_actiondata,input,
-            View{partialTaskList_data,nactive_tasks},
-            value_stash_data,
-            derivatives,
-            View{omp_forces_data,omp_forces_size}
-          );
-        }
-      }
-
-      if constexpr (has_custom_gather&&T::virialSize>0) {
-#pragma acc parallel loop
-        for(unsigned v=0; v<T::virialSize; ++v) {
-          const  unsigned m = input.nindices_per_task*3 + v;
-          double tmp=0.0;
-          //#pragma acc loop vectors
+      for(unsigned v=input.threadunsafe_forces_start; v<forcesForApply_size; ++v) {
+          double tmp = 0.0;
 #pragma acc loop reduction(+:tmp)
           for(unsigned t=0; t<nactive_tasks; ++t) {
-            std::size_t task_index = partialTaskList_data[t];
-            auto fdata = ForceInput { input.ncomponents,
-                                      value_stash_data+input.ncomponents*task_index,
-                                      nderivPerComponent,
-                                      derivatives+ndev_per_task*t};
-            for(unsigned i=0; i<input.ncomponents; ++i) {
-              tmp += fdata.force[i]*fdata.deriv[i][m];
-            }
+              int m=-1; 
+              std::size_t task_index = partialTaskList_data[t];
+              View<const std::size_t,helpers::dynamic_extent> force_indices( force_indices_data + ndev_per_task*t, ndev_per_task );
+              for(unsigned d=input.threadsafe_derivatives_end; d<ndev_per_task; ++i) {
+                  if( force_indices[d]==v ) {
+                      m=d;
+                      break;
+                  }
+              }
+              if( m<0 ) continue ;
+              auto fdata = ForceInput { input.ncomponents,
+                                        value_stash_data+input.ncomponents*task_index,
+                                        nderivPerComponent,
+                                        derivatives+ndev_per_task*t};
+              double tmp = 0.0;
+              for(unsigned i=0; i<input.ncomponents; ++i) {
+                  tmp += fdata.force[i]*fdata.deriv[i][m];
+              }
           }
-          omp_forces_data[nthreaded_forces-9+v] = tmp;
-        }
+          forces[v] = tmp;
       }
     }
+// #pragma acc parallel loop reduction(+:omp_forces_data[0:reduction_size])
+//       for(unsigned i=0; i<nactive_tasks; ++i) {
+//         std::size_t task_index = partialTaskList_data[i];
+//         ParallelActionsOutput myout { input.ncomponents,
+//                                       valstmp+input.ncomponents*i,
+//                                       ndev_per_task,
+//                                       derivatives+ndev_per_task*i};
+//         // Calculate the stuff in the loop for this action
+//         T::performTask( task_index, t_actiondata, input, myout );
+//         if constexpr (!has_custom_gather) {
+//           // Gather the forces from the values
+//           T::gatherForces( task_index,
+//                            t_actiondata,
+//                            input,
+//                            ForceInput { input.ncomponents,
+//                                         value_stash_data+input.ncomponents*task_index,
+//                                         nderivPerComponent,
+//                                         derivatives+ndev_per_task*i},
+//                            ForceOutput { omp_forces_data,
+//                                          omp_forces_size,
+//                                          forcesForApply_data,
+//                                          forcesForApply_size }
+//                          );
+//         }
+//       }
+// 
+//       if constexpr (has_custom_gather) {
+// #pragma acc parallel loop
+//         for(unsigned v=0;
+//             v<nthreaded_forces-T::customGatherStopBefore;
+//             v+=T::customGatherStep) {
+//           T::gatherForces_custom(
+//             v,nderivPerComponent,ndev_per_task,t_actiondata,input,
+//             View{partialTaskList_data,nactive_tasks},
+//             value_stash_data,
+//             derivatives,
+//             View{omp_forces_data,omp_forces_size}
+//           );
+//         }
+//       }
+// 
+//       if constexpr (has_custom_gather&&T::virialSize>0) {
+// #pragma acc parallel loop
+//         for(unsigned v=0; v<T::virialSize; ++v) {
+//           const  unsigned m = input.nindices_per_task*3 + v;
+//           double tmp=0.0;
+//           //#pragma acc loop vectors
+// #pragma acc loop reduction(+:tmp)
+//           for(unsigned t=0; t<nactive_tasks; ++t) {
+//             std::size_t task_index = partialTaskList_data[t];
+//             auto fdata = ForceInput { input.ncomponents,
+//                                       value_stash_data+input.ncomponents*task_index,
+//                                       nderivPerComponent,
+//                                       derivatives+ndev_per_task*t};
+//             for(unsigned i=0; i<input.ncomponents; ++i) {
+//               tmp += fdata.force[i]*fdata.deriv[i][m];
+//             }
+//           }
+//           omp_forces_data[nthreaded_forces-9+v] = tmp;
+//         }
+//       }
+    }
     ffa.copyFromDevice(forcesForApply.data());
-    ofd.copyFromDevice(omp_forces[0].data());
+//    ofd.copyFromDevice(omp_forces[0].data());
     // for(unsigned v=0; v<9; ++v) {
     //   std::cout << omp_forces[0][v] << " ";
     // }
     // std::cout << "\n";
-    gatherThreads(ForceOutput{ omp_forces[0], forcesForApply });
+//    gatherThreads(ForceOutput{ omp_forces[0], forcesForApply });
 #else
     plumed_merror("cannot use USEGPU flag if PLUMED has not been compiled with openACC");
 #endif
@@ -530,10 +593,12 @@ void ParallelTaskManager<T>::applyForces( std::vector<double>& forcesForApply ) 
     #pragma omp parallel num_threads(nt)
     {
       const unsigned t=OpenMP::getThreadNum();
-      omp_forces[t].assign( nthreaded_forces, 0.0 );
+      omp_forces[t].assign( forcesForApply.size()-myinput.threadunsafe_forces_start, 0.0 );
       ForceOutput forces{ omp_forces[t], forcesForApply };
       std::vector<double> fake_vals( myinput.ncomponents );
       std::vector<double> derivatives( myinput.ncomponents*nderivatives_per_component );
+      std::vector<std::size_t> indices( nderivatives_per_component );
+      View<std::size_t,helpers::dynamic_extent> force_indices( indices.data(), nderivatives_per_component ); 
       #pragma omp for nowait
       for(unsigned i=rank; i<nactive_tasks; i+=stride) {
         std::size_t task_index = partialTaskList[i];
@@ -544,15 +609,30 @@ void ParallelTaskManager<T>::applyForces( std::vector<double>& forcesForApply ) 
         // Calculate the stuff in the loop for this action
         T::performTask( task_index, actiondata, myinput, myout );
 
-        // Gather the forces from the values
-        T::gatherForces( task_index,
-                         actiondata,
-                         myinput,
-                         ForceInput( myinput.ncomponents,
-                                     value_stash.data()+myinput.ncomponents*task_index,
-                                     nderivatives_per_component,
-                                     derivatives.data()),
-                         forces );
+        // Get the force indices
+        T::getForceIndices( task_index,
+                            forcesForApply.size(), 
+                            actiondata,
+                            myinput,
+                            force_indices );  
+
+        // Create a force input object
+        ForceInput finput( myinput.ncomponents,
+                           value_stash.data()+myinput.ncomponents*task_index,
+                           nderivatives_per_component,
+                           derivatives.data()); 
+
+        // Gather forces that are thread safe 
+        gatherThreadSafeForces( myinput,
+                                force_indices, 
+                                finput,
+                                View<double,helpers::dynamic_extent>(forcesForApply.data(),forcesForApply.size()) );
+
+        // Gather forces that are not thread safe
+        gatherThreadUnsafeForces( myinput, 
+                                  force_indices,
+                                  finput,
+                                  View<double,helpers::dynamic_extent>(omp_forces[t].data(),omp_forces[t].size()) );
       }
 
       #pragma omp critical
@@ -564,6 +644,32 @@ void ParallelTaskManager<T>::applyForces( std::vector<double>& forcesForApply ) 
     }
   }
 
+}
+
+template <class T>
+void ParallelTaskManager<T>::gatherThreadSafeForces( const ParallelActionsInput& input, 
+                                                     View<std::size_t,helpers::dynamic_extent> force_indices, 
+                                                     const ForceInput& fdata, 
+                                                     View<double,helpers::dynamic_extent> forces ) {
+  for(unsigned i=0; i<input.ncomponents; ++i) {
+      double ff = fdata.force[i]; 
+      for(unsigned j=0; j<input.threadsafe_derivatives_end; ++j) {
+          forces[ force_indices[j] ] += ff*fdata.deriv[i][j];
+      }
+  }
+}
+
+template <class T>
+void ParallelTaskManager<T>::gatherThreadUnsafeForces( const ParallelActionsInput& input, 
+                                                       View<std::size_t,helpers::dynamic_extent> force_indices, 
+                                                       const ForceInput& fdata, 
+                                                       View<double,helpers::dynamic_extent> forces ) {
+  for(unsigned i=0; i<input.ncomponents; ++i) {
+      double ff = fdata.force[i];
+      for(unsigned j=input.threadsafe_derivatives_end; j<force_indices.size(); ++j) {
+          forces[ force_indices[j] - input.threadunsafe_forces_start ] += ff*fdata.deriv[i][j];
+      }
+  }
 }
 
 template <class T>

--- a/src/secondarystructure/SecondaryStructureBase.h
+++ b/src/secondarystructure/SecondaryStructureBase.h
@@ -59,7 +59,7 @@ public:
   }
   void applyNonZeroRankForces( std::vector<double>& outforces ) override ;
   static void performTask( unsigned task_index, const T& actiondata, ParallelActionsInput& input, ParallelActionsOutput& output );
-  static void gatherForces( unsigned task_index, const T& actiondata, const ParallelActionsInput& input, const ForceInput& fdata, ForceOutput forces );
+  static void getForceIndices( std::size_t task_index, std::size_t ntotal_force, const T& actiondata, const ParallelActionsInput& input, View<std::size_t,helpers::dynamic_extent> force_indices );
   static void gatherForces_custom( unsigned atomIndex,
                                    size_t nderivPerComponent,
                                    size_t ndev_per_task,
@@ -264,7 +264,7 @@ SecondaryStructureBase<T>::SecondaryStructureBase(const ActionOptions&ao):
   for(unsigned i=0; i<getNumberOfComponents(); ++i) {
     getPntrToComponent(i)->setDerivativeIsZeroWhenValueIsZero();
   }
-  taskmanager.setupParallelTaskManager( colvar_atoms[0].size(), 3*colvar_atoms[0].size() + virialSize);//, 3*colvar_atoms[0].size());
+  taskmanager.setupParallelTaskManager( colvar_atoms[0].size(), 3*colvar_atoms[0].size() + virialSize, 0, 3*getNumberOfAtoms() + 9 );
   taskmanager.setActionInput( myinput );
 }
 
@@ -336,28 +336,24 @@ void SecondaryStructureBase<T>::applyNonZeroRankForces( std::vector<double>& out
 }
 
 template <class T>
-void SecondaryStructureBase<T>::gatherForces( unsigned task_index,
-    const T& actiondata,
-    const ParallelActionsInput& input,
-    const ForceInput& fdata,
-    ForceOutput forces ) {
-  for(unsigned i=0; i<input.ncomponents; ++i) {
-    unsigned m = 0;
-    double ff = fdata.force[i];
-    for(unsigned j=0; j<input.nindices_per_task; ++j) {
+void SecondaryStructureBase<T>::getForceIndices( std::size_t task_index,
+                                                 std::size_t ntotal_force,
+                                                 const T& actiondata,
+                                                 const ParallelActionsInput& input,
+                                                 View<std::size_t,helpers::dynamic_extent> force_indices ) {
+  std::size_t m = 0;
+  for(unsigned j=0; j<input.nindices_per_task; ++j) {
       std::size_t base = 3*actiondata.colvar_atoms[task_index][j];
-      forces.thread_safe[base + 0] += ff*fdata.deriv[i][m];
+      force_indices[m] = base + 0;
       ++m;
-      forces.thread_safe[base + 1] += ff*fdata.deriv[i][m];
+      force_indices[m] = base + 1;
       ++m;
-      forces.thread_safe[base + 2] += ff*fdata.deriv[i][m];
+      force_indices[m] = base + 2;
+      ++m; 
+  }
+  for(unsigned n=ntotal_force-virialSize; n<ntotal_force; ++n) {
+      force_indices[m] = n;
       ++m;
-    }
-
-    for(unsigned n=forces.thread_safe.size()-virialSize; n<forces.thread_safe.size(); ++n) {
-      forces.thread_safe[n] += ff*fdata.deriv[i][m];
-      ++m;
-    }
   }
 }
 

--- a/src/volumes/ActionVolume.h
+++ b/src/volumes/ActionVolume.h
@@ -104,7 +104,7 @@ public:
     plumed_error();
   }
   static void performTask( std::size_t task_index, const VolumeData<T>& actiondata, ParallelActionsInput& input, ParallelActionsOutput& output );
-  static void gatherForces( std::size_t task_index, const VolumeData<T>& actiondata, const ParallelActionsInput& input, const ForceInput& fdata, ForceOutput& forces );
+  static void getForceIndices( std::size_t task_index, std::size_t ntotal_force, const VolumeData<T>& actiondata, const ParallelActionsInput& input, View<std::size_t,helpers::dynamic_extent> force_indices );
 };
 
 template <class T>
@@ -160,7 +160,7 @@ ActionVolume<T>::ActionVolume(const ActionOptions&ao):
   setNotPeriodic();
   getPntrToComponent(0)->setDerivativeIsZeroWhenValueIsZero();
 
-  taskmanager.setupParallelTaskManager( 1, 3*(1+refatoms.size())+9, 3*refatoms.size()+9 );
+  taskmanager.setupParallelTaskManager( 1, 3*(1+refatoms.size())+9, 3, 3*refatoms.size()+9 );
   taskmanager.setActionInput( actioninput );
 }
 
@@ -235,17 +235,20 @@ void ActionVolume<T>::performTask( std::size_t task_index, const VolumeData<T>& 
   }
 }
 
-template <class T>
-void ActionVolume<T>::gatherForces( std::size_t task_index, const VolumeData<T>& actiondata, const ParallelActionsInput& input, const ForceInput& fdata, ForceOutput& forces ) {
+template<class T>
+void ActionVolume<T>::getForceIndices( std::size_t task_index,
+                                       std::size_t ntotal_force,
+                                       const VolumeData<T>& actiondata,
+                                       const ParallelActionsInput& input,
+                                       View<std::size_t,helpers::dynamic_extent> force_indices ) {
   std::size_t base = 3*task_index;
-  unsigned m = 3;
-  double ff = fdata.force[0];
-  forces.thread_unsafe[base + 0] += ff*fdata.deriv[0][0];
-  forces.thread_unsafe[base + 1] += ff*fdata.deriv[0][1];
-  forces.thread_unsafe[base + 2] += ff*fdata.deriv[0][2];
-  for(unsigned n=3*actiondata.numberOfNonReferenceAtoms; n<forces.thread_unsafe.size(); ++n) {
-    forces.thread_safe[m-3] += ff*fdata.deriv[0][m];
-    m++;
+  force_indices[0] = base;
+  force_indices[1] = base + 1;
+  force_indices[2] = base + 2;
+  std::size_t m=3;
+  for(unsigned n=3*actiondata.numberOfNonReferenceAtoms; n<ntotal_force; ++n) {
+      force_indices[m] = n;
+      ++m; 
   }
 }
 


### PR DESCRIPTION
##### Description

@Iximiel and @GiovanniBussi, I am not entirely happy with the GPU implementations we have thus far.  My concern is that we have thus far implemented the GPU parallelization in three of the methods that use the ParallelTaskManager class.  All three of these implementations use applyForces part of the ParallalTaskManager differently.

* `MultiColvarTemplate` gathers the derivatives on the atoms using the `gatherForces` method I wrote and then uses a mechanism for gathering the virial that is implemented in `ParallelTaskManager`
*  `SecondaryStructureBase` has a custom method for gathering the forces on the atoms that is implemented in `SecondaryStructureBase` and then uses the mechanism for gathering the virial in `ParallelTaskManager`
*  `QuaternionBondProductMatrix` uses a custom method for gathering the forces and does not use the mechanism for gathering the virial in `ParallelTaskManager` because there is no virial.

Our objective when we started this project was to write a `ParallelTaskManager` action that could handle the parallelism across many of the classes.  My view is that if every class uses this method differently, we might as well abandon the abstraction and move to local implementations of the parallelism in each method.  If we are introducing an abstract class, we shouldn't be using it differently in every action we are using it in. 

With that in mind, I am proposing the following rethink of the `applyForces` part of the `ParallelTaskManager`.  Now, rather than having a `gatherForces` method in `MultiColvarTemplate`, `SecondaryStructureBase` and `QuaternionBondProductMatrix`, we instead have a `getForceIndices` method.  This method returns the indexes in `forcestoApply`  the forces for task `task_index` act upon.  This makes it straightforward to do the gathering of forces within `ParallelTaskManager` directly.

I have tried to modify the GPU code so that it also uses this mechanism in a way that is what is compatible with what was done in `final-backpropegation`, but I have obviously not tested it.  Can we investigate whether this is a viable strategy for getting rid of the customisation, please?  If it is I will then port these changes onto the gpuwork/matrices branch and will use it for all the additional functionalities that use the PTM on that branch.

I would like to do this now before we go much further with the current strategy.  If @Iximiel you want to have a meeting to discuss what I am proposing here then I am free all day tomorrow and Friday as well as most days next week.  Let's try to keep it constructive, though.  I am not saying that what you did is wrong.  In hindsight, I didn't fully understand how the GPU works when I wrote the API that was based on `gatherForces`.  I think that we can do better now that I have a slightly better understanding.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __XXXXX__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
