### PR TITLE
plumed benchmark can now read trajectory files

### DIFF
--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -449,6 +449,7 @@ struct tiledSimpleCubic:public AtomDistribution {
   }
 };
 
+/// atomic distribution from a trajectory file
 class fileTraj:public AtomDistribution {
   TrajectoryParser parser;
   bool positionRead=false;
@@ -459,8 +460,12 @@ class fileTraj:public AtomDistribution {
   std::vector<Vector> coordinates{};
   std::vector<double> cell{};
   void rewind() {
-    parser.rewind();
-    //do rewind to false to not loop
+    auto errormessage=parser.rewind();
+    if (errormessage) {
+      // A workarounf for not implemented rewind is to dump the trajectory in an xyz and then read that
+      plumed_error()<<*errormessage;
+    }
+    //the extra false prevents an infinite loop in case of unexpected consecutice EOFs after a rewind
     step(false);
   }
   //read the next step

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -459,9 +459,12 @@ class fileTraj:public AtomDistribution {
   std::vector<Vector> coordinates{};
   std::vector<double> cell{};
   void rewind() {
+    parser.rewind();
+    //do rewind to false to not loop
+    step(false);
   }
   //read the next step
-  void step() {
+  void step(bool doRewind=true) {
     positionRead=false;
     boxRead=false;
     long long int mystep=0;
@@ -508,7 +511,7 @@ class fileTraj:public AtomDistribution {
     }
 
     if (errormessage) {
-      if (*errormessage =="EOF") {
+      if (*errormessage =="EOF" && doRewind) {
         rewind();
       } else {
         plumed_error()<<*errormessage;

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -588,9 +588,7 @@ public:
   std::optional<std::unique_ptr<AtomDistribution>> parseAtomDistribution(Log& log) {
     {
       std::string trajectoryFile(""), pdbfile(""), mcfile("");
-      bool pbc_cli_given=false;
       std::vector<double> pbc_cli_box(9,0.0);
-      int command_line_natoms=-1;
 
       TrajectoryParser parser;
 
@@ -651,6 +649,7 @@ public:
       log << "Using --atom-distribution=" << atomicDistr << "\n";
       return getAtomDistribution(atomicDistr);
     }
+    return std::nullopt;
   }
 };
 
@@ -661,12 +660,12 @@ void Benchmark::registerKeywords( Keywords& keys ) {
   keys.add("compulsory","--plumed","plumed.dat","colon separated path(s) to the input file(s)");
   keys.add("compulsory","--kernel","this","colon separated path(s) to kernel(s)");
   keys.add("compulsory","--natoms","100000","the number of atoms to use for the simulation");
-  // I do not know, maybe use this can be more clear with --help? keys.reset_style("--natoms","atoms");
+  // Maybe "--natoms" can be more clear when calling --help if we use reset_style to "atoms"
   keys.add("compulsory","--nsteps","2000","number of steps of MD to perform (-1 means forever)");
   keys.add("compulsory","--maxtime","-1","maximum number of seconds (-1 means forever)");
   keys.add("compulsory","--sleep","0","number of seconds of sleep, mimicking MD calculation");
   keys.add("compulsory","--atom-distribution","line","the kind of possible atomic displacement at each step");
-  // I do not know, maybe use this can be more clear with --help? keys.reset_style("--atom-distribution","atoms");
+  // Maybe "--atom-distribution" can be more clear when calling --help if we use reset_style to "atoms"
   keys.add("optional","--dump-trajectory","dump the trajectory to this file");
   keys.addFlag("--domain-decomposition",false,"simulate domain decomposition, implies --shuffle");
   keys.addFlag("--shuffled",false,"reshuffle atoms");

--- a/src/tools/TrajectoryParser.cpp
+++ b/src/tools/TrajectoryParser.cpp
@@ -126,6 +126,9 @@ public:
       float* charges,
       float* coordinates,
       float* cell ) =0;
+
+  virtual void rewind() {}
+
 };
 namespace {
 
@@ -254,6 +257,9 @@ public:
   }
   //see the template readAtoms_t for the implementation
   READATOMS;
+  void rewind() override {
+    std::rewind(fp);
+  }
 };
 
 class dlp4Parser final:public fileParser {
@@ -399,6 +405,9 @@ public:
   }
   //see the template readAtoms_t for the implementation
   READATOMS;
+  void rewind() override {
+    std::rewind(fp);
+  }
 };
 
 class groParser final:public fileParser {
@@ -532,6 +541,9 @@ public:
   }
   //see the template readAtoms_t for the implementation
   READATOMS;
+  void rewind() override {
+    std::rewind(fp);
+  }
 };
 
 
@@ -1067,4 +1079,9 @@ int TrajectoryParser::nOfAtoms() const {
   }
   return -1;
 }
+
+void TrajectoryParser::rewind() {
+  parser->rewind();
+}
+
 } // namespace PLMD

--- a/src/tools/TrajectoryParser.cpp
+++ b/src/tools/TrajectoryParser.cpp
@@ -127,7 +127,9 @@ public:
       float* coordinates,
       float* cell ) =0;
 
-  virtual void rewind() {}
+  virtual std::optional<std::string> rewind() {
+    return "rewind not (yet) implemented for this kind of trajectory file";
+  }
 
 };
 namespace {
@@ -257,8 +259,12 @@ public:
   }
   //see the template readAtoms_t for the implementation
   READATOMS;
-  void rewind() override {
-    std::rewind(fp);
+  std::optional<std::string> rewind() override {
+    int error = std::fseek(fp,0,SEEK_SET);
+    if (error) {
+      return "ERROR: Error rewinding trajectory file";
+    }
+    return std::nullopt;
   }
 };
 
@@ -405,8 +411,12 @@ public:
   }
   //see the template readAtoms_t for the implementation
   READATOMS;
-  void rewind() override {
-    std::rewind(fp);
+  std::optional<std::string> rewind() override {
+    int error = std::fseek(fp,0,SEEK_SET);
+    if (error) {
+      return "ERROR: Error rewinding trajectory file";
+    }
+    return std::nullopt;
   }
 };
 
@@ -541,8 +551,12 @@ public:
   }
   //see the template readAtoms_t for the implementation
   READATOMS;
-  void rewind() override {
-    std::rewind(fp);
+  std::optional<std::string> rewind() override {
+    int error = std::fseek(fp,0,SEEK_SET);
+    if (error) {
+      return "ERROR: Error rewinding trajectory file";
+    }
+    return std::nullopt;
   }
 };
 
@@ -1080,8 +1094,8 @@ int TrajectoryParser::nOfAtoms() const {
   return -1;
 }
 
-void TrajectoryParser::rewind() {
-  parser->rewind();
+std::optional<std::string> TrajectoryParser::rewind() {
+  return parser->rewind();
 }
 
 } // namespace PLMD

--- a/src/tools/TrajectoryParser.h
+++ b/src/tools/TrajectoryParser.h
@@ -109,7 +109,10 @@ public:
                                        float* charges,
                                        float* coordinates,
                                        float* cell );
+  /// Return the number of atoms
   int nOfAtoms() const;
+  /// Return the file pointer to the initial position (use at your own risk)
+  void rewind();
 };
 } //namespace PLMD
 #endif //__PLUMED_tools_TrajectoryParser_h

--- a/src/tools/TrajectoryParser.h
+++ b/src/tools/TrajectoryParser.h
@@ -112,7 +112,7 @@ public:
   /// Return the number of atoms
   int nOfAtoms() const;
   /// Return the file pointer to the initial position (use at your own risk)
-  void rewind();
+  std::optional<std::string> rewind();
 };
 } //namespace PLMD
 #endif //__PLUMED_tools_TrajectoryParser_h


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

I ported the trajectory reader to the benchmark utility, as planned. I also added a rewind  function for `FILE*`-style files (like internal xyz, gro) to loop over the file in the benchmark.

This can be used to benchmark on more real-world-alike trajectories for some complexe CVs

For the non rewindable trajectory readers the workaround is to run `plumed benchmark --dump-trajectory file.xyz` and then run the bench with the new file with `-ixyz`.

The next step is to  maybe add a way of replicate the trajectory respecting the pbcs

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.11__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
