### PR TITLE
In the manual, now red keywords have a tooltip

### DIFF
--- a/new-manual/assets/plumedManual.css
+++ b/new-manual/assets/plumedManual.css
@@ -6,3 +6,7 @@
      */
     min-width: 17em;
 }
+
+.missingExample {
+    color: red;
+}

--- a/new-manual/build_manual.py
+++ b/new-manual/build_manual.py
@@ -636,6 +636,9 @@ def createCLToolPage( version, tool, value, plumeddocs, broken_inputs, undocumen
                 ref, ref_url = get_reference(doi)
                 f.write("- [" + ref + "](" + ref_url + ")\n") 
 
+def missingExample(key):
+   return f'<span class="plumedtooltip missingExample">{key}<span class="right">This keyword do not have examples</span></span>'
+
 def createActionPage( version, action, value, plumeddocs, neggs, nlessons) :
     undocumented_keyword = None
     broken_input = None
@@ -763,24 +766,24 @@ def createActionPage( version, action, value, plumeddocs, neggs, nlessons) :
                 if "argtype" in docs.keys() and "default" in docs.keys() : 
                    if len(docs["description"])==0 :
                      undoc = undoc + 1
-                   if not depracated and key in example_keywords : f.write("| <span style=\"color:red\">" + key + "</span> | input | " + docs["default"] + " | " + getKeywordDescription( docs ) + " | \n")
+                   if not depracated and key in example_keywords : f.write("| " + missingExample(key) + " | input | " + docs["default"] + " | " + getKeywordDescription( docs ) + " | \n")
                    else : f.write("| " + key + " | input | " + docs["default"] + " | " + getKeywordDescription( docs ) + " |\n")
                 elif docs["type"]=="atoms" or "argtype" in docs.keys() :
                    if len(docs["description"])==0 :
                      undoc = undoc + 1 
-                   if not depracated and key in example_keywords : f.write("| <span style=\"color:red\">" + key + "</span> | input | none | " + getKeywordDescription( docs ) + " | \n")
+                   if not depracated and key in example_keywords : f.write("| " + missingExample(key) + " | input | none | " + getKeywordDescription( docs ) + " | \n")
                    else : f.write("| " + key + " | input | none | " +  getKeywordDescription( docs ) + " |\n") 
             for key, docs in value["syntax"].items() : 
                 if key=="output" or "argtype" in docs.keys()  : continue
                 if docs["type"]=="compulsory" and "default" in docs.keys()  : 
                    if len(docs["description"])==0 :
                      undoc = undoc + 1
-                   if not depracated and key in example_keywords : f.write("| <span style=\"color:red\">" + key + "</span> | compulsory | "  + docs["default"] + " | " + getKeywordDescription( docs ) + " | \n")
+                   if not depracated and key in example_keywords : f.write("| " + missingExample(key) + " | compulsory | "  + docs["default"] + " | " + getKeywordDescription( docs ) + " | \n")
                    else : f.write("| " + key + " | compulsory | "  + docs["default"] + " | " + getKeywordDescription( docs ) + " |\n") 
                 elif docs["type"]=="compulsory" : 
                    if len(docs["description"])==0 :
                      undoc = undoc + 1
-                   if not depracated and key in example_keywords : f.write("| <span style=\"color:red\">" + key + "</span> | compulsory | none | " + getKeywordDescription( docs ) + " |\n")
+                   if not depracated and key in example_keywords : f.write("| " + missingExample(key) + " | compulsory | none | " + getKeywordDescription( docs ) + " |\n")
                    else : f.write("| " + key + " | compulsory | none | " + getKeywordDescription( docs ) + " |\n")
             ndep = 0
             for key, docs in value["syntax"].items() :
@@ -788,12 +791,12 @@ def createActionPage( version, action, value, plumeddocs, neggs, nlessons) :
                 if docs["type"]=="flag" : 
                    if len(docs["description"])==0 :
                      undoc = undoc + 1
-                   if not depracated and key in example_keywords and "pagelink" not in docs.keys() : f.write("| <span style=\"color:red\">" + key + "</span> | optional | false | " + getKeywordDescription( docs ) + " | \n")
+                   if not depracated and key in example_keywords and "pagelink" not in docs.keys() : f.write("| " + missingExample(key) + " | optional | false | " + getKeywordDescription( docs ) + " | \n")
                    else : f.write("| " + key + " | optional | false | " + getKeywordDescription( docs ) + " |\n")
                 if docs["type"]=="optional" :
                    if len(docs["description"])==0 :
                      undoc = undoc + 1 
-                   if not depracated and key in example_keywords : f.write("| <span style=\"color:red\">" + key + "</span> | optional | not used | " + getKeywordDescription( docs ) + " | \n")
+                   if not depracated and key in example_keywords : f.write("| " + missingExample(key) + " | optional | not used | " + getKeywordDescription( docs ) + " | \n")
                    else : f.write("| " + key + " | optional | not used | " + getKeywordDescription( docs ) + " |\n")
                 if docs["type"]=="deprecated" :
                    ndep = ndep + 1


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

Since in the manual some keywords are red, but the explanation is only in summary.md, I think that adding a simple tooltip to them might be easier to understand,or maybe the best thing is to add the legend before the table, but the red text and the underline attract the eye.

Since I am lazy, I did not want to correct different things, I put the "keyword is example-less" in a function to modify all the cases at once in build_manual.py.

When you hover over the kw the result is this (I used the css already present in plumedToHTML):

![image](https://github.com/user-attachments/assets/3946c764-0ff7-4efc-aba9-a24e5f8f1095)

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __V2.11__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
