### PR TITLE
 Passing by reference the string vectors of actionShortcuts

### DIFF
--- a/src/cltools/Driver.cpp
+++ b/src/cltools/Driver.cpp
@@ -714,7 +714,7 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
               def.push_back( "defaults " + aa->getDefaultString() );
               data[ as->getShortcutLabel() ] = def;
             }
-            std::vector<std::string> shortcut_commands = as->getSavedInputLines();
+            const auto & shortcut_commands = as->getSavedInputLines();
             if( shortcut_commands.size()==0 ) {
               continue;
             }
@@ -818,7 +818,7 @@ int Driver<real>::main(FILE* in,FILE*out,Communicator& pc) {
           }
           ActionShortcut* as=pp->castToActionShortcut();
           if( as ) {
-            std::vector<std::string> cnames( as->getSavedOutputs() );
+            const auto & cnames = as->getSavedOutputs();
             if( cnames.size()==0 ) {
               continue ;
             }

--- a/src/cltools/GenExample.cpp
+++ b/src/cltools/GenExample.cpp
@@ -282,7 +282,7 @@ std::vector<std::vector<std::string> > GenExample::createLongInput( const std::v
       myplumed.readInputLine( myinputline );
       ActionShortcut* as=dynamic_cast<ActionShortcut*>( myplumed.getActionSet()[myplumed.getActionSet().size()-1].get() );
       plumed_assert( as );
-      std::vector<std::string> shortcut_commands = as->getSavedInputLines();
+      const auto & shortcut_commands = as->getSavedInputLines();
       for(unsigned i=0; i<shortcut_commands.size(); ++i) {
         std::vector<std::string> words = Tools::getWords( shortcut_commands[i] );
         long_input.push_back( words );

--- a/src/core/ActionShortcut.cpp
+++ b/src/core/ActionShortcut.cpp
@@ -258,11 +258,11 @@ const std::string & ActionShortcut::getShortcutLabel() const {
   return shortcutlabel;
 }
 
-std::vector<std::string> ActionShortcut::getSavedInputLines() const {
+const std::vector<std::string>& ActionShortcut::getSavedInputLines() const {
   return savedInputLines;
 }
 
-std::vector<std::string> ActionShortcut::getSavedOutputs() const {
+const std::vector<std::string>& ActionShortcut::getSavedOutputs() const {
   return savedOutputs;
 }
 

--- a/src/core/ActionShortcut.h
+++ b/src/core/ActionShortcut.h
@@ -56,9 +56,9 @@ public:
 /// Do nothing.
   void apply() override {}
 /// Get the lines of the shortcut that were read in
-  std::vector<std::string> getSavedInputLines() const ;
+  const std::vector<std::string>& getSavedInputLines() const ;
 /// Get the labels of the actions that this creates
-  std::vector<std::string> getSavedOutputs() const ;
+  const std::vector<std::string>& getSavedOutputs() const ;
 /// Take everything that was input to this action and convert it to a string
   std::string convertInputLineToString();
 /// This sorts out the reading of arguments from shortcuts


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

As title, I think this should save some time in the manual, tests and support sites by avoiding copying the vector of strings that are produced by the shortcuts.
If you want a copy you still can call `vector<string> cnames = as->getSavedOutputs();` instead of `const auto & cnames = as->getSavedOutputs();`.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.11__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
