### PR TITLE
Correcting a missing pointer in the GROMACS2025.0 patch

### DIFF
--- a/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
+++ b/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
@@ -197,7 +197,7 @@ try
 
     if(replex_) {
         double bias=0.0;
-        cmd("getBias",&bias);
+        plumed_->cmd("getBias",&bias);
         if(bias!=0.0) {
             GMX_THROW(NotImplementedError("The PLUMED patch is still not compatible"
                 " with the replica exchange if PLUMED computes biases"));


### PR DESCRIPTION
This problem was found in https://github.com/plumed/plumed2/issues/1310

<!--
  Feel free to delete not relevant sections below
-->

##### Description

This problem was pointed out by @StefanGIT in https://github.com/plumed/plumed2/issues/1310
The solution was proposed by @Yoik in the same issue, @Yoik, do you prefer to propose the PR yourself?

The error is simple: there was a naked `cmd` call instead of a call to `plumed_->cmd` through the plumed object. Now the patch compiles with GROMACS 2025.2

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.10__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
