### PR TITLE
Small performance optimisation in transferring matrices between stash and value

### DIFF
--- a/src/core/ActionWithMatrix.cpp
+++ b/src/core/ActionWithMatrix.cpp
@@ -98,30 +98,40 @@ void ActionWithMatrix::updateBookeepingArrays( RequiredMatrixElements& outmat ) 
 }
 
 void ActionWithMatrix::transferStashToValues( const std::vector<double>& stash ) {
+  unsigned ncomp = getNumberOfComponents();
   unsigned ncols = getPntrToComponent(0)->getNumberOfColumns();
   unsigned m=0, n=0, nrows = getPntrToComponent(0)->getShape()[0];
   for(unsigned i=0; i<nrows; ++i) {
-    for(unsigned j=0; j<ncols; ++j) {
-      for(unsigned k=0; k<getNumberOfComponents(); ++k) {
-        getPntrToComponent(k)->set( m, stash[n] );
-        n++;
-      }
-      m++;
+    unsigned ncr = getPntrToComponent(0)->getRowLength(i);
+    for(unsigned k=1; k<ncomp; ++k) {
+      plumed_assert( ncr == getPntrToComponent(k)->getRowLength(i) );
     }
+    for(unsigned j=0; j<ncr; ++j) {
+      for(unsigned k=0; k<ncomp; ++k) {
+        getPntrToComponent(k)->set( m+j, stash[n+j*ncomp+k] );
+      }
+    }
+    n += ncols*ncomp;
+    m += ncols;
   }
 }
 
 void ActionWithMatrix::transferForcesToStash( std::vector<double>& stash ) const {
+  unsigned ncomp = getNumberOfComponents();
   unsigned ncols = getConstPntrToComponent(0)->getNumberOfColumns();
   unsigned m=0, n=0, nrows = getConstPntrToComponent(0)->getShape()[0];
   for(unsigned i=0; i<nrows; ++i) {
-    for(unsigned j=0; j<ncols; ++j) {
-      for(unsigned k=0; k<getNumberOfComponents(); ++k) {
-        stash[n] = getConstPntrToComponent(k)->getForce( m );
-        n++;
-      }
-      m++;
+    unsigned ncr = getConstPntrToComponent(0)->getRowLength(i);
+    for(unsigned k=1; k<ncomp; ++k) {
+      plumed_assert( ncr == getConstPntrToComponent(k)->getRowLength(i) );
     }
+    for(unsigned j=0; j<ncr; ++j) {
+      for(unsigned k=0; k<ncomp; ++k) {
+        stash[n+j*ncomp+k] = getConstPntrToComponent(k)->getForce( m+j );
+      }
+    }
+    n += ncols*ncomp;
+    m += ncols;
   }
 }
 


### PR DESCRIPTION
##### Description

When you were transferring the matrices between the Value and stash at the start of the parallel task manager a lot of time is spent transferring zeros.  With this change we avoid spending that time on transferring zeros.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.11

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
