### PR TITLE
Removing some duplicated check in some data movements

### DIFF
--- a/src/core/ActionWithArguments.cpp
+++ b/src/core/ActionWithArguments.cpp
@@ -381,11 +381,7 @@ void ActionWithArguments::addForcesOnArguments( const unsigned& argstart, const 
     nargs=nargs-av->getNumberOfMasks();
   }
   for(unsigned i=0; i<nargs; ++i) {
-    unsigned nvals = arguments[i]->getNumberOfStoredValues();
-    for(unsigned j=0; j<nvals; ++j) {
-      arguments[i]->addForce( j, forces[ind], false );
-      ind++;
-    }
+    ind += arguments[i]->addForces(View(&forces[ind],forces.size()-ind));
   }
 }
 

--- a/src/core/ParallelTaskManager.h
+++ b/src/core/ParallelTaskManager.h
@@ -53,7 +53,8 @@ void ArgumentsBookkeeping::setupArguments( const ActionWithArguments* action ) {
   ranks.resize( nargs );
   shapestarts.resize( nargs );
   argstarts.resize( nargs );
-  std::size_t s = 0, ts = 0;
+  std::size_t s = 0;
+  std::size_t ts = 0;
   for(unsigned i=0; i<nargs; ++i) {
     Value* myarg = action->getPntrToArgument(i);
     shapestarts[i] = ts;

--- a/src/core/Value.cpp
+++ b/src/core/Value.cpp
@@ -22,9 +22,6 @@
 #include "Value.h"
 #include "ActionWithValue.h"
 #include "ActionAtomistic.h"
-#include "ActionWithArguments.h"
-#include "ActionWithVector.h"
-#include "ActionWithVirtualAtom.h"
 #include "tools/Exception.h"
 #include "tools/OpenMP.h"
 #include "tools/OFile.h"
@@ -277,7 +274,24 @@ std::size_t Value::getIndexInStore( const std::size_t& ival ) const {
   return ival;
 }
 
-double Value::get(const std::size_t& ival, const bool trueind) const {
+bool Value::checkValueIsActiveForMMul(const std::size_t task) const {
+  const auto ncol = getRowLength(task);
+  const auto base = task * getNumberOfColumns();
+  if (hasDeriv) {
+    for(unsigned k=base; k<base+ncol; ++k) {
+      if(std::fabs(data[k*(1+ngrid_der)])>0.0) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return std::any_of(&data[base],&data[base+ncol],[](double x) {
+    return std::fabs(x)>0.0;
+  });
+
+}
+
+double Value::get(const std::size_t ival, const bool trueind) const {
   if( hasDeriv ) {
     return data[ival*(1+ngrid_der)];
   }
@@ -287,15 +301,23 @@ double Value::get(const std::size_t& ival, const bool trueind) const {
   }
 #endif
   if( shape.size()==2 && trueind ) {
-    unsigned irow = std::floor( ival / shape[1] ), jcol = ival%shape[1];
+    const unsigned irow = std::floor( ival / shape[1] );
+    const unsigned jcol = ival%shape[1];
     // This is a special treatment for the lower triangular matrices that are used when
     // we do ITRE with COLLECT_FRAMES
     if( ncols==0 ) {
       if( jcol<=irow ) {
         return data[0.5*irow*(irow+1) + jcol];
       }
-      return 0;
+      return 0.0;
     }
+    /* I have to work on this
+    auto begin = matrix_bookeeping.begin()+(1+ncols)*irow+1;
+    auto end = matrix_bookeeping.begin()+(1+ncols)*irow+1+getRowLength(irow);
+    auto i=std::find(begin,end,jcol);
+    if (i!=end){
+    	return data[irow*ncols+end-i];
+    }*/
     for(unsigned i=0; i<getRowLength(irow); ++i) {
       if( getRowIndex(irow,i)==jcol ) {
         return data[irow*ncols+i];
@@ -305,6 +327,19 @@ double Value::get(const std::size_t& ival, const bool trueind) const {
   }
   plumed_massert( ival<data.size(), "cannot get value from " + name );
   return data[ival];
+}
+
+size_t Value::assignValues(View<double> target) {
+  const auto nvals=getNumberOfStoredValues ();
+  if( hasDeriv ) {
+    for(unsigned j=0; j<nvals; ++j) {
+      target[j] = data[j*(1+ngrid_der)];
+    }
+  } else {
+    plumed_massert( data.size()>=nvals, "cannot get value from " + name );
+    std::memcpy(target.data(),data.data(),nvals*sizeof(double));
+  }
+  return nvals;
 }
 
 void Value::addForce(const std::size_t& iforce, double f, const bool trueind) {
@@ -324,6 +359,27 @@ void Value::addForce(const std::size_t& iforce, double f, const bool trueind) {
   inputForce[iforce]+=f;
 }
 
+size_t Value::addForces(View<const double> const forces) {
+  hasForce=true;
+  const auto nvals = getNumberOfStoredValues();
+  plumed_massert( inputForce.size()>=nvals, "can't add force to " + name );
+  //I need at least nvals elements in forces
+  plumed_massert( forces.size()>=nvals, "can't add force to " + name );
+  const auto end=inputForce.begin()+nvals;
+  /*
+    {//this gives a very little speedup (+1 step in the 60s dragrace)
+      auto f = forces.begin();
+      for(auto iptf=inputForce.begin()  ; iptf<end; ++iptf, ++f) {
+        *iptf+=*f;
+      }
+    }
+  */
+  //is this daxpy?
+  for(auto i=0u; i<nvals; ++i) {
+    inputForce[i]+=forces[i];
+  }
+  return nvals;
+}
 
 void Value::reshapeMatrixStore( const unsigned& n ) {
   plumed_dbg_assert( shape.size()==2 && !hasDeriv );

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -29,6 +29,7 @@
 #include "tools/Tools.h"
 #include "tools/AtomNumber.h"
 #include "tools/Vector.h"
+#include "tools/View.h"
 
 namespace PLMD {
 
@@ -126,7 +127,11 @@ public:
 /// Get the location of this element of in the store
   std::size_t getIndexInStore( const std::size_t& ival ) const ;
 /// Get the value of the function
-  double get( const std::size_t& ival=0, const bool trueind=true ) const;
+  double get( const std::size_t ival=0, const bool trueind=true ) const;
+/// A variant of get() for checking that at least one of the values on the row is !=0
+  bool checkValueIsActiveForMMul(std::size_t task) const;
+/// A variant of get() for assigning data to an external view (assuems trueind=false), returns the number of arguments assigned
+  std::size_t assignValues(View<double> target);
 /// Find out if the value has been set
   bool valueHasBeenSet() const;
 /// Check if the value is periodic
@@ -165,6 +170,8 @@ public:
   void addForce(double f);
 /// Add some force on the ival th component of this value
   void addForce( const std::size_t& ival, double f, const bool trueind=true );
+  ///Add forces from a vector, imples trueInd=false and retunrs the number of forces assigned
+  std::size_t addForces(View<const double> f);
 /// Get the value of the force on this colvar
   double getForce( const std::size_t& ival=0 ) const ;
 /// Apply the forces to the derivatives using the chain rule (if there are no forces this routine returns false)
@@ -226,7 +233,7 @@ public:
 ///
   unsigned getRowLength( const std::size_t& irow ) const ;
 ///
-  unsigned getRowIndex( const std::size_t& irow, const std::size_t& jind ) const ;
+  unsigned getRowIndex( std::size_t irow, std::size_t jind ) const ;
 ///
   void setRowIndices( const std::size_t& irow, const std::vector<std::size_t>& ind );
 ///
@@ -482,7 +489,7 @@ unsigned Value::getRowLength( const std::size_t& irow ) const {
 }
 
 inline
-unsigned Value::getRowIndex( const std::size_t& irow, const std::size_t& jind ) const {
+unsigned Value::getRowIndex(const std::size_t irow, const std::size_t jind ) const {
   plumed_dbg_massert( (1+ncols)*irow+1+jind<matrix_bookeeping.size() && jind<matrix_bookeeping[(1+ncols)*irow], "failing in value " + name );
   return matrix_bookeeping[(1+ncols)*irow+1+jind];
 }

--- a/src/function/FunctionOfMatrix.h
+++ b/src/function/FunctionOfMatrix.h
@@ -232,8 +232,7 @@ std::vector<unsigned>& FunctionOfMatrix<T>::getListOfActiveTasks( ActionWithVect
   }
   active_tasks.resize( atsize );
 
-  unsigned base=0, k=0;
-  for(unsigned i=0; i<nrows; ++i) {
+  for(unsigned i=0, base=0,k=0; i<nrows; ++i) {
     unsigned ncols = myarg->getRowLength(i);
     for(unsigned j=0; j<ncols; ++j) {
       active_tasks[k] = base+j;

--- a/src/matrixtools/MatrixTimesVectorBase.h
+++ b/src/matrixtools/MatrixTimesVectorBase.h
@@ -297,12 +297,8 @@ int MatrixTimesVectorBase<T>::checkTaskIsActive( const unsigned& itask ) const {
     if( myarg->getRank()==1 && !myarg->hasDerivatives() ) {
       return 0;
     } else if( myarg->getRank()==2 && !myarg->hasDerivatives() ) {
-      unsigned ncol = myarg->getRowLength(itask);
-      unsigned base = itask*myarg->getNumberOfColumns();
-      for(unsigned k=0; k<ncol; ++k) {
-        if( fabs(myarg->get(base+k,false))>0 ) {
-          return 1;
-        }
+      if (myarg->checkValueIsActiveForMMul(itask)) {
+        return 1;
       }
     } else {
       plumed_merror("should not be in action " + getName() );


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

This should complement #1327 

by changing some for loops into functions now we have
```
fn{
 check
 loop{
  action
 }
}
```
instead of
```
loop{
 fn{
  check
  action
 }
}
```
This should make the cache happier

I also changed a loop into a `memcpy`, so that it is a single instruction.

About measurements: I started to add also the SymFuncVol run (with 120000 atoms and 13 as the radius of the mask - LQ6 is using 10000 atoms for memory reasons)

And we have:

|Nsteps in 60s+1step for |master| #1327  | this (on #1327)|
|:-:|:-:|:-:|:-:|
|LQ6Vol| 15 | 25 | 44 |
|SymFuncVol| 12 | 15 |26 |

The numbers are Nsteps in (60s+1step), because plumed benchmarks stops the steps after the time limit.

Reducing the data movement has made the % of the time passed in `gomp_barrier_wait_end` rise, Expecially in Q6.

`PLMD::ArgumentsBookkeeping::setupArguments` occupies >10% of the time for both the runs. But as now I do not see a way of optimizing that function

In SymFunc `PLMD::ActionWithArguments::addForcesOnArguments` is the hottest function, even with my new `PLMD::Value::addForces`, with >17% of the time passed there, but that is less than the 31% in master

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.11__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
