### PR TITLE
A little speedup in neigbourlist

### DIFF
--- a/src/tools/NeighborList.cpp
+++ b/src/tools/NeighborList.cpp
@@ -187,10 +187,13 @@ std::vector<AtomNumber>& NeighborList::getReducedAtomList() {
       AtomNumber index0=fullatomlist_[neighbors_[i].first];
       AtomNumber index1=fullatomlist_[neighbors_[i].second];
 // I exploit the fact that requestlist_ is an ordered vector
-      auto p = std::find(requestlist_.begin(), requestlist_.end(), index0);
+// And I assume that index0 and index1 actually exists in the requestlist_ (see setRequestList())
+// so I can use lower_bond that uses binary seach instead of find
+      plumed_dbg_assert(std::is_sorted(requestlist_.begin(),requestlist_.end()));
+      auto p = std::lower_bound(requestlist_.begin(), requestlist_.end(), index0);
       plumed_dbg_assert(p!=requestlist_.end());
       newindex0=p-requestlist_.begin();
-      p = std::find(requestlist_.begin(), requestlist_.end(), index1);
+      p = std::lower_bound(requestlist_.begin(), requestlist_.end(), index1);
       plumed_dbg_assert(p!=requestlist_.end());
       newindex1=p-requestlist_.begin();
       neighbors_[i]=std::pair<unsigned,unsigned>(newindex0,newindex1);


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

<!-- describe here your pull request -->
I was reading the NL file when I found the comment `// I exploit the fact that requestlist_ is an ordered vector` followed by a `find`. I tried to substitute the finds with `std::lower_bound`, it returns the iterator highest values that satisfies `val<=arg` and since in this case all the `arg` we are searching are present in the atom list, it does actually return the iterator to the given atom.

I ran the patch against master wit the following script:
```bash
  perf record -F99 --call-graph dwarf --output="${fname}.pdata" \
    plumed --no-mpi benchmark --plumed="$plumedDat" \
    --kernel="this" \
    --maxtime=60 \
    --natoms=85184 \
    --nsteps=1000000 \
    --atom-distribution=sc \
    >"${fname}.out"
```

and the plumed.dat is:

```
DEBUG DETAILED_TIMERS
# one group of oxygen
WO1: GROUP ATOMS=273-84250:4
# same just to test
WO2: GROUP ATOMS=273-84250:4
# atom 92 is just a random atom on the protein for reference
cpu: COORDINATION GROUPA=WO1 GROUPB=WO2 SWITCH={RATIONAL R_0=0.3 NN=6 MM=10 D_MAX=1.0} NLIST NL_CUTOFF=3.0 NL_STRIDE=20
PRINT FILE=COLVAR STRIDE=1 ARG=*
```

I know it is a not ideal input, but:

The result in a run of 60s is:

- **1157** steps with the NL patched (on master)
- **381** steps with the NL from master.
- **1141** steps with this branch (patch on v2.9)
- **362** steps with the NL in v2.9

I backported this to V2.9 because I am sure that @carlocamilloni would ask me to do so. There is a tiny conflict when merging this to V2.10, I'll address that with a PR with the manual merge when this will be accepted


##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __V2.9__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
