### PR TITLE
Unifying the behaviour of the "too big NL" along mac and linux

### DIFF
--- a/regtest/basic/rt-NeigbourlistInitializationError/config
+++ b/regtest/basic/rt-NeigbourlistInitializationError/config
@@ -5,6 +5,11 @@ plumed_regtest_after(){
   #"(tools/NeighborList.cpp:98) void PLMD::NeighborList::initialize()"
   # in this way if NeighborList.cpp is moved or modified this test won't 
   #trigger a (false) error
-  awk '/(Single|Double|neighbor) list/{print} 
-       /Exception text/{print}' ./unitTest > unitTest.proc
+
+  #I am using perl since it does not have the "GNU vs POSIX" problem
+  #I am avoiding the lines between the ***** STACK DUMP ***** to make this test work with and without the stack dump environment variable set up
+  perl -pe "s/cpp:[0-9]+/cpp:###/g;s/[0-9]+ GB/## GB/g" ./unitTest |
+    awk 'BEGIN{f=1} /.*STACK.*/{f=!f} NF&&f&&!/.*STACK.*/{print}' \
+   > unitTest.proc
 }
+

--- a/regtest/basic/rt-NeigbourlistInitializationError/main.cpp
+++ b/regtest/basic/rt-NeigbourlistInitializationError/main.cpp
@@ -18,6 +18,8 @@ using PLMD::Pbc;
 
 int main(int, char **) {
   std::ofstream report("unitTest");
+  //leaving here a small point because I forgot about it:
+  report << "To future you/me: this \"unitTest\" file will get preprocessed, see the \"configure\" file for this test\n";
   Pbc pbc{};
   pbc.setBox(PLMD::Tensor({1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}));
   Communicator cm{};

--- a/regtest/basic/rt-NeigbourlistInitializationError/unitTest.proc.reference
+++ b/regtest/basic/rt-NeigbourlistInitializationError/unitTest.proc.reference
@@ -1,6 +1,11 @@
+To future you/me: this "unitTest" file will get preprocessed, see the "configure" file for this test
 Single list:
 [100000]Exception text: 
-An error happened while allocating the neighbor list, please decrease the number of atoms used
+(tools/NeighborList.cpp:###) void PLMD::NeighborList::initialize()
+A NeighborList is trying to allocate ## GB of data for the list of neighbors
+You can skip this error by exporting "PLUMED_IGNORE_NL_MEMORY_ERROR"
 Double list, no pairs:
 [100000, 90000]Exception text: 
-An error happened while allocating the neighbor list, please decrease the number of atoms used
+(tools/NeighborList.cpp:###) void PLMD::NeighborList::initialize()
+A NeighborList is trying to allocate ## GB of data for the list of neighbors
+You can skip this error by exporting "PLUMED_IGNORE_NL_MEMORY_ERROR"


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

I was getting some "non-deterministic" outcomes from `basic/rt-NeigbourlistInitializationError`.
So I changed the behavior in how the NL fails if it is allocating too much memory. I expanded the the error I setup only for mac also to linux because it reliably intercepts the problem, with no dependency on the exception due to the memory allocation. And also it fails instantly and not after the OS trying desperately to accommodate everything in the swap for a lot of time.

The user can still override this check with an environmental variable and I made this clear in the error message;

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.10__ (maybe I should backport this to the oldest version with this check @GiovanniBussi ?)

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [ ] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
