### PR TITLE
Use Python 3.10 in CI instead of Python 3.9

### DIFF
--- a/.github/workflows/linuxWF.yml
+++ b/.github/workflows/linuxWF.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Set paths
       run: |
         echo "$HOME/opt/bin" >> $GITHUB_PATH


### PR DESCRIPTION
##### Description

Use Python 3.10 in CI instead of Python 3.9 which is EOL (see https://github.com/plumed/plumed2/pull/1348#issuecomment-3542694561)

There are also references to Python 3.9 in the following places, I can also update them if you want:
- `plugins/pycv/pyproject.toml` sets `requires-python = ">=3.9"`
- `docker/rocky8` is installing Python 3.9.16
- `conda/py-plumed/conda_build_config.yaml` is building for 3.8, 3.9, 3.10


There are also multiple bash script doing something like 
```bash
for python_bin in python python3 python3.12 python3.11 python3.10 python3.9 python3.8 python3.7; do
    if $python_bin -c "import plumed" 2>/dev/null; then
        if [ $python_bin != python ]; then
            PYTHON=$python_bin
        fi
        return 1
    fi
done
```

But I think these can stay as-is.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release v2.10

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
