### PR TITLE
Changed the order of the includes and when include <memory> in the wrapper

### DIFF
--- a/src/wrapper/Plumed.h
+++ b/src/wrapper/Plumed.h
@@ -1777,29 +1777,29 @@ __PLUMED_WRAPPER_EXTERN_C_END /*}*/
 #include <new> /* bad_alloc bad_array_new_length (C++11) */
 #include <typeinfo> /* bad_typeid bad_cast */
 #include <limits> /* numeric_limits */
+//C++11 functionalities
+#if __cplusplus > 199711L
+#include <array> /* array */
+#include <initializer_list> /* initializer_list */
+#include <type_traits> /* std::enable_if */
+#include <memory> /* unique_ptr */
+#endif
 #if __cplusplus > 199711L && __PLUMED_WRAPPER_LIBCXX11
 #include <system_error> /* system_error generic_category system_category */
 #include <future> /* future_category */
-#include <memory> /* bad_weak_ptr */
 #include <functional> /* bad_function_call */
 #include <regex> /* regex_error */
+#endif
+
+//C++17 functionalities
+#if __cplusplus >= 201703L
+#include <string_view> /* string_view */
 #endif
 #if __cplusplus >= 201703L && __PLUMED_WRAPPER_LIBCXX17
 #include <any> /* bad_any_cast */
 #include <variant> /* bad_variant_access */
 #include <optional> /* bad_optional_access */
 #include <filesystem> /* filesystem_error */
-#endif
-
-#if __cplusplus >= 201703L
-#include <memory> /* unique_ptr */
-#include <string_view> /* string_view */
-#endif
-
-#if __cplusplus > 199711L
-#include <array> /* array */
-#include <initializer_list> /* initializer_list */
-#include <type_traits> /* std::enable_if */
 #endif
 
 /* C++ interface is hidden in PLMD namespace (same as plumed library) */


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

<!-- describe here your pull request -->
Following the problems raised in #1358 I made a few modifications in Plumed.h, these changes solve the issue:

since some `unique_ptr` capabilities are used if the compiler supports c++11 even if `__PLUMED_WRAPPER_LIBCXX11` is not activated, I moved the  `#include <memory>` in the `#if __cplusplus > 199711L` include block.

I removed the `#include <memory>` from the C++17 include block, since if `#if __cplusplus >= 201703L` passes the `#if __cplusplus > 199711L` passes too.

The movement of the includes is just an aesthetic choice, I can revert to the previous order if you prefer.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.10+__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
