### PR TITLE
change make.rules to allow compiling with clang on mac with -Werror

### DIFF
--- a/src/maketools/make.rules
+++ b/src/maketools/make.rules
@@ -35,7 +35,7 @@ endif
 	@echo "compiling " $*.c
 	@-test -d deps || mkdir deps
 ifneq ($(disable_dependency_tracking),yes)
-	$(AT)$(CXXDEP) -MMD -MP -MF $*.d $(CPPFLAGS) $(ADDCPPFLAGS) \
+	$(AT)$(CCDEP) -MMD -MP -MF $*.d $(CPPFLAGS) $(ADDCPPFLAGS) \
 	-DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $(CFLAGS) \
 	-c $*.c -o $*.o
 	@cp -f $*.d $*.d.tmp
@@ -44,7 +44,7 @@ ifneq ($(disable_dependency_tracking),yes)
 	@mv $*.d deps/$*.d
 	@rm -f $*.d.tmp
 else
-	$(AT)$(CXX) -c $(CPPFLAGS) $(ADDCPPFLAGS) $(CFLAGS) \
+	$(AT)$(CC) -c $(CPPFLAGS) $(ADDCPPFLAGS) $(CFLAGS) \
 	-DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $*.c -o $*.o
 endif
 ifndef XLF

--- a/src/maketools/make.rules
+++ b/src/maketools/make.rules
@@ -36,7 +36,7 @@ endif
 	@-test -d deps || mkdir deps
 ifneq ($(disable_dependency_tracking),yes)
 	$(AT)$(CXXDEP) -MMD -MP -MF $*.d $(CPPFLAGS) $(ADDCPPFLAGS) \
-	-DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $(CXXFLAGS) \
+	-DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $(CFLAGS) \
 	-c $*.c -o $*.o
 	@cp -f $*.d $*.d.tmp
 	@sed -e 's/.*://' -e 's/\\$$//' < $*.d.tmp | fmt -1 | \
@@ -44,7 +44,7 @@ ifneq ($(disable_dependency_tracking),yes)
 	@mv $*.d deps/$*.d
 	@rm -f $*.d.tmp
 else
-	$(AT)$(CXX) -c $(CPPFLAGS) $(ADDCPPFLAGS) $(CXXFLAGS) \
+	$(AT)$(CXX) -c $(CPPFLAGS) $(ADDCPPFLAGS) $(CFLAGS) \
 	-DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $*.c -o $*.o
 endif
 ifndef XLF

--- a/src/maketools/make.rules
+++ b/src/maketools/make.rules
@@ -14,12 +14,17 @@ endif
 	@echo "compiling " $*.cpp
 	@-test -d deps || mkdir deps
 ifneq ($(disable_dependency_tracking),yes)
-	$(AT)$(CXXDEP) -c -MM -MF $*.d $(CPPFLAGS) $(ADDCPPFLAGS) -DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $(CXXFLAGS) $*.cpp
+	$(AT)$(CXXDEP) -MMD -MP -MF $*.d $(CPPFLAGS) $(ADDCPPFLAGS) \
+	-DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $(CXXFLAGS) \
+	-c $*.cpp -o $*.o
 	@cp -f $*.d $*.d.tmp
 	@sed -e 's/.*://' -e 's/\\$$//' < $*.d.tmp | fmt -1 | \
 	 sed -e 's/^ *//' -e 's/$$/:/' >> $*.d
 	@mv $*.d deps/$*.d
 	@rm -f $*.d.tmp
+else
+	$(AT)$(CXX) -c $(CPPFLAGS) $(ADDCPPFLAGS) $(CXXFLAGS) \
+	-DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $*.cpp -o $*.o
 endif
 ifndef XLF
 	$(AT)$(CXX) -c $(CPPFLAGS) $(ADDCPPFLAGS) $(CXXFLAGS) -DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $*.cpp -o $*.o
@@ -30,12 +35,17 @@ endif
 	@echo "compiling " $*.c
 	@-test -d deps || mkdir deps
 ifneq ($(disable_dependency_tracking),yes)
-	$(AT)$(CCDEP) -c -MM -MF $*.d $(CPPFLAGS) $(ADDCPPFLAGS) $(CFLAGS) $*.c -o $*.o
+	$(AT)$(CXXDEP) -MMD -MP -MF $*.d $(CPPFLAGS) $(ADDCPPFLAGS) \
+	-DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $(CXXFLAGS) \
+	-c $*.c -o $*.o
 	@cp -f $*.d $*.d.tmp
 	@sed -e 's/.*://' -e 's/\\$$//' < $*.d.tmp | fmt -1 | \
 	 sed -e 's/^ *//' -e 's/$$/:/' >> $*.d
 	@mv $*.d deps/$*.d
 	@rm -f $*.d.tmp
+else
+	$(AT)$(CXX) -c $(CPPFLAGS) $(ADDCPPFLAGS) $(CXXFLAGS) \
+	-DPLUMED_MODULE_DIR=\"$(notdir $(CURDIR))/\" $*.c -o $*.o
 endif
 ifndef XLF
 	$(AT)$(CC) -c $(CPPFLAGS) $(ADDCPPFLAGS) $(CFLAGS) $*.c -o $*.o


### PR DESCRIPTION
-c and -MM cannot be used together, gcc ignores them while clang gives a warning 