### PR TITLE
Exploiting VectorTyped to avoid copies during the NL construction

### DIFF
--- a/src/tools/NeighborList.cpp
+++ b/src/tools/NeighborList.cpp
@@ -40,6 +40,7 @@
 
 namespace PLMD {
 
+
 NeighborList::NeighborList(const std::vector<AtomNumber>& list0,
                            const std::vector<AtomNumber>& list1,
                            const bool serial,
@@ -144,28 +145,29 @@ std::vector<AtomNumber>& NeighborList::getFullAtomList() {
   return fullatomlist_;
 }
 
-NeighborList::pairIDs NeighborList::getIndexPair(const unsigned ipair) const {
-  pairIDs index;
+NeighborList::couple NeighborList::getIndexPair(const unsigned ipair) const {
+  couple index;
   switch (style_) {
   case NNStyle::Pair : {
-    index=pairIDs(ipair,ipair+nlist0_);
+    index=couple{ipair,static_cast<unsigned>(ipair+nlist0_)};
   }
   break;
   case NNStyle::TwoList : {
-    index=pairIDs(ipair/nlist1_,ipair%nlist1_+nlist0_);
+    index=couple{static_cast<unsigned>(ipair/nlist1_),static_cast<unsigned>(ipair%nlist1_+nlist0_)};
   }
   break;
   case NNStyle::SingleList: {
     unsigned ii = nallpairs_-1-ipair;
     unsigned  K = unsigned(std::floor((std::sqrt(double(8*ii+1))+1)/2));
     unsigned jj = ii-K*(K-1)/2;
-    index=pairIDs(nlist0_-1-K,nlist0_-1-jj);
+    index=couple{static_cast<unsigned>(nlist0_-1-K),static_cast<unsigned>(nlist0_-1-jj)};
   }
   }
   return index;
 }
 
 void NeighborList::update(const std::vector<Vector>& positions) {
+  static_assert(sizeof(NeighborList::couple)==2*sizeof(unsigned), "code cannot work if this is not satisfied");
   neighbors_.clear();
   // check if positions array has the correct length
   plumed_assert(positions.size()==fullatomlist_.size());
@@ -244,67 +246,65 @@ void NeighborList::update(const std::vector<Vector>& positions) {
     const unsigned elementsPerRank = std::ceil(double(nallpairs_)/stride);
     const unsigned int start= rank*elementsPerRank;
     const unsigned int end = ((start + elementsPerRank)< nallpairs_)?(start + elementsPerRank): nallpairs_;
-    std::vector<unsigned> local_flat_nl;
+    const bool mpiCollaboration=!serial_ && comm.initialized();
+    std::vector<couple> merge_work(0);
+    //a little sugar to avoid a copy if mpi is not used
+    std::vector<couple>& merge = (mpiCollaboration) ? merge_work : neighbors_;
 
     #pragma omp parallel num_threads(nt)
     {
-      std::vector<unsigned> private_flat_nl;
+      std::vector<couple> private_flat_nl;
       #pragma omp for nowait
       for(unsigned int i=start; i<end; ++i) {
-        auto [index0, index1 ] = getIndexPair(i);
+        auto idx = getIndexPair(i);
         Vector distance;
         if(do_pbc_) {
-          distance=pbc_->distance(positions[index0],positions[index1]);
+          distance=pbc_->distance(positions[idx[0]],positions[idx[1]]);
         } else {
-          distance=delta(positions[index0],positions[index1]);
+          distance=delta(positions[idx[0]],positions[idx[1]]);
         }
         double value=modulo2(distance);
         if(value<=d2) {
-          private_flat_nl.push_back(index0);
-          private_flat_nl.push_back(index1);
+          private_flat_nl.push_back(idx);
         }
       }
       #pragma omp critical
-      local_flat_nl.insert(local_flat_nl.end(),
-                           private_flat_nl.begin(),
-                           private_flat_nl.end());
+      merge.insert(merge.end(),
+                   private_flat_nl.begin(),
+                   private_flat_nl.end());
     }
 
-    // find total dimension of neighborlist
-    std::vector <int> local_nl_size(stride, 0);
-    local_nl_size[rank] = local_flat_nl.size();
-    if(!serial_) {
-      comm.Sum(&local_nl_size[0], stride);
+    if(mpiCollaboration) {
+      // find total dimension of neighborlist
+      std::vector <int> local_nl_size(stride, 0);
+      //the *2 will be used in the communications, since each couple is 2 unsigned values
+      local_nl_size[rank] = merge.size()*2;
+      comm.Sum(local_nl_size.data(), stride);
+
+      int tot_size = std::accumulate(local_nl_size.begin(), local_nl_size.end(), 0)/2;
+      if(tot_size!=0) {
+        neighbors_.resize(tot_size);
+        // merge
+        // calculate vector of displacement
+        std::vector<int> disp(stride);
+        disp[0] = 0;
+        int rank_size = 0;
+        for(unsigned i=0; i<stride-1; ++i) {
+          rank_size += local_nl_size[i];
+          disp[i+1] = rank_size;
+        }
+
+        // Allgather neighbor list
+        comm.Allgatherv(
+          (!merge.empty()?merge[0].data():nullptr),
+          local_nl_size[rank],
+          neighbors_[0].data(),
+          &local_nl_size[0],
+          &disp[0]);
+      }
+      // no need for an else neighbors_.resize(0);
     }
-    int tot_size = std::accumulate(local_nl_size.begin(), local_nl_size.end(), 0);
-    if(tot_size!=0) {
-      // merge
-      std::vector<unsigned> merge_nl(tot_size, 0);
-      // calculate vector of displacement
-      std::vector<int> disp(stride);
-      disp[0] = 0;
-      int rank_size = 0;
-      for(unsigned i=0; i<stride-1; ++i) {
-        rank_size += local_nl_size[i];
-        disp[i+1] = rank_size;
-      }
-      // Allgather neighbor list
-      if(comm.initialized()&&!serial_) {
-        comm.Allgatherv((!local_flat_nl.empty()?&local_flat_nl[0]:NULL),
-                        local_nl_size[rank],
-                        &merge_nl[0],
-                        &local_nl_size[0],
-                        &disp[0]);
-      } else {
-        merge_nl = local_flat_nl;
-      }
-      // resize neighbor stuff
-      neighbors_.resize(tot_size/2);
-      for(int i=0; i<tot_size/2; i++) {
-        unsigned j=2*i;
-        neighbors_[i] = std::make_pair(merge_nl[j],merge_nl[j+1]);
-      }
-    }
+
   }
   listBuilded=true;
   if (stride_ >1) {
@@ -320,8 +320,8 @@ void NeighborList::setRequestList() {
   // so as now it is not necessary to add extra logic in this function
   requestlist_.clear();
   for(unsigned int i=0; i<size(); ++i) {
-    requestlist_.push_back(fullatomlist_[neighbors_[i].first]);
-    requestlist_.push_back(fullatomlist_[neighbors_[i].second]);
+    requestlist_.push_back(fullatomlist_[neighbors_[i][0]]);
+    requestlist_.push_back(fullatomlist_[neighbors_[i][1]]);
   }
   Tools::removeDuplicates(requestlist_);
   reduced=false;
@@ -331,8 +331,8 @@ std::vector<AtomNumber>& NeighborList::getReducedAtomList() {
   if(stride_>1) {
     if(!reduced) {
       for(unsigned int i=0; i<size(); ++i) {
-        AtomNumber index0=fullatomlist_[neighbors_[i].first];
-        AtomNumber index1=fullatomlist_[neighbors_[i].second];
+        AtomNumber index0=fullatomlist_[neighbors_[i][0]];
+        AtomNumber index1=fullatomlist_[neighbors_[i][1]];
 // I exploit the fact that requestlist_ is an ordered vector
 // And I assume that index0 and index1 actually exists in the requestlist_ (see setRequestList())
 // so I can use lower_bond that uses binary seach instead of find
@@ -343,7 +343,7 @@ std::vector<AtomNumber>& NeighborList::getReducedAtomList() {
         p = std::lower_bound(requestlist_.begin(), requestlist_.end(), index1);
         plumed_dbg_assert(p!=requestlist_.end());
         unsigned newindex1=p-requestlist_.begin();
-        neighbors_[i]=pairIDs(newindex0,newindex1);
+        neighbors_[i]=couple{newindex0,newindex1};
       }
     }
     reduced=true;
@@ -376,15 +376,16 @@ unsigned NeighborList::size() const {
 
 NeighborList::pairIDs NeighborList::getClosePair(const unsigned i) const {
   if(listBuilded) {
-    return neighbors_[i];
+    return {neighbors_[i][0],neighbors_[i][1]};
   } else {
-    return getIndexPair(i);
+    auto p = getIndexPair(i);
+    return {p[0],p[1]};
   }
 }
 
 NeighborList::pairIDs NeighborList::getUpdatedPair(const unsigned i) const {
   plumed_dbg_assert(listBuilded) << "NeighborList::getUpdatedPair should be called after update()";
-  return neighbors_[i];
+  return {neighbors_[i][0],neighbors_[i][1]};
 }
 
 bool NeighborList::ready() const {
@@ -395,13 +396,13 @@ NeighborList::pairAtomNumbers
 NeighborList::getClosePairAtomNumber(const unsigned i) const {
   if(listBuilded)
     return pairAtomNumbers{
-    fullatomlist_[neighbors_[i].first],
-    fullatomlist_[neighbors_[i].second]};
+    fullatomlist_[neighbors_[i][0]],
+    fullatomlist_[neighbors_[i][1]]};
   else {
     auto p = getIndexPair(i);
     return pairAtomNumbers{
-      fullatomlist_[p.first],
-      fullatomlist_[p.second]};
+      fullatomlist_[p[0]],
+      fullatomlist_[p[1]]};
   }
 }
 
@@ -409,21 +410,21 @@ std::vector<unsigned> NeighborList::getNeighbors(const unsigned index) const {
   std::vector<unsigned> neighbors;
   if (listBuilded) {
     for(unsigned int i=0; i<size(); ++i) {
-      if(neighbors_[i].first==index) {
-        neighbors.push_back(neighbors_[i].second);
+      if(neighbors_[i][0]==index) {
+        neighbors.push_back(neighbors_[i][1]);
       }
-      if(neighbors_[i].second==index) {
-        neighbors.push_back(neighbors_[i].first);
+      if(neighbors_[i][1]==index) {
+        neighbors.push_back(neighbors_[i][0]);
       }
     }
   } else {
     for(unsigned int i=0; i<size(); ++i) {
-      auto neigh = getClosePair(i);
-      if(neigh.first==index) {
-        neighbors.push_back(neigh.second);
+      auto neigh = getIndexPair(i);
+      if(neigh[0]==index) {
+        neighbors.push_back(neigh[1]);
       }
-      if(neigh.second==index) {
-        neighbors.push_back(neigh.first);
+      if(neigh[1]==index) {
+        neighbors.push_back(neigh[0]);
       }
     }
   }

--- a/src/tools/NeighborList.h
+++ b/src/tools/NeighborList.h
@@ -41,6 +41,7 @@ public:
   using pairIDs=std::pair<unsigned,unsigned>;
   using pairAtomNumbers=std::pair<PLMD::AtomNumber,PLMD::AtomNumber>;
 private:
+  using couple=std::array<unsigned,2>;
   enum class NNStyle {Pair,TwoList,SingleList};
   bool reduced=false;
   bool listBuilded=false;
@@ -54,7 +55,7 @@ private:
   std::vector<PLMD::AtomNumber> requestlist_{};
   //The size of this vectior is nallpairs_ if stride==0 (aka the NL is deactivated) or if the size is relatively small
   //In case neighbors_.size() != nallpairs_,
-  std::vector<pairIDs > neighbors_{};
+  std::vector<couple> neighbors_{};
   double distance_;
   size_t nlist0_=0;
   size_t nlist1_=0;
@@ -65,7 +66,7 @@ private:
   void initialize();
 /// Return the pair of indexes in the positions array
 /// of the two atoms forming the i-th pair among all possible pairs
-  pairIDs getIndexPair(unsigned i) const;
+  couple getIndexPair(unsigned i) const;
 /// Extract the list of atoms from the current list of close pairs
   void setRequestList();
 public:


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

First of all I added a set of test that can be useful to understand how the NL is breaking in all the possible situations (serial, serial+omp, mpi, mpi+omp)

Then I exploited the trick PLUMED uses to transfer `Vector`s wit MPI to avoid creating an extra unsigned array to be gathered and then copied into the local neigborlist.
In a serial or non mpi run this skips a significant portion of code since it works directly on the `neighbors_` array. In a MPI run the code still uses a temporary array, but communicate directly into the main `neighbors_` array, skipping the last copy.

I think this will lower the RAM tax that the NL imposes on the PC for larger systems

I have a fast benchmark on drag races of 60 seconds (how many steps in 60 seconds) with 4 omp threads:

| Atomi | LC     | LC-v   | Δ% LC→LC-v | NL     | NL-v  | Δ% NL→NL-v |
|-------|--------|--------|------------|--------|-------|------------|
| 125   | 506813 | 557075 | +9.92%     | 445501 | 456190| +2.40%     |
| 1000  | 42082  | 44953  | +6.82%     | 38427  | 40167 | +4.53%     |
| 8000  | 6705   | 6732   | +0.40%     | 3201   | 3342  | +4.40%     |
| 27000 | 1559   | 1586   | +1.73%     | 501    | 517   | +3.19%     |
| 42875 | 946    | 960    | +1.48%     | 201    | 221   | +9.95%     |

And with 2 MPI processes with 3 opemMPtreads:

| Atomi | LC     | LC-v   | Δ% LC→LC-v | NL     | NL-v  | Δ% NL→NL-v |
|-------|--------|--------|------------|--------|-------|------------|
| 125   | 329986 | 335234 | +1.59%     | 278411 | 278566 | +0.06%     |
| 1000  | 29640  | 29800  | +0.54%     | 25404  | 25970  | +2.23%     |
| 8000  | 3909   | 3879   | −0.77%     | 1941   | 2001   | +3.09%     |
| 27000 | 901    | 894    | −0.78%     | 281    | 301    | +7.12%     |
| 42875 | 531    | 501    | −5.65%     | 121    | 121    |  0.00%     |



`NL` runs this:
```
cpu:     COORDINATION GROUPA=@mdatoms GROUPB=@mdatoms SWITCH={RATIONAL R_0=0.5 NN=6 MM=10 D_MAX=2.0} NLIST      NL_CUTOFF=3.5 NL_STRIDE=20
```
`LC` runs this:
```
cpucl:   COORDINATION GROUPA=@mdatoms GROUPB=@mdatoms SWITCH={RATIONAL R_0=0.5 NN=6 MM=10 D_MAX=2.0} NLISTCELLS NL_CUTOFF=2.0 NL_STRIDE=1
```

`**-v` is this thread performances, considering that the LC do not make the extra copy I am surprised by the improvement even if it is not expected. `NL` has a worse improvement, but the algorithm runs every 20 steps, where for `LC` at each step 
(me being lazy I made an AI calculate the % columns, the number of steps are correct, I double checked them)

With mpi looks less attractive, but I only did a single run for both the tries on my workstation

If this work for you, it will be the base of the "standard" NL accelerated by the linked cells algorithm. This is not necessary for that, a somehow working version already exists, but I believe that rebasing that on these modifications will enhance its performace a little more.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __v2.11__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
