### PR TITLE
Fix for histogram shortcut for when used for reweighting

### DIFF
--- a/src/gridtools/Histogram.cpp
+++ b/src/gridtools/Histogram.cpp
@@ -240,6 +240,9 @@ Histogram::Histogram( const ActionOptions& ao ):
     readInputLine( getShortcutLabel() + "_wsum: COMBINE ARG=" + lw + " PERIODIC=NO");
     readInputLine( getShortcutLabel() + "_weight: CUSTOM ARG=" + getShortcutLabel() + "_wsum FUNC=exp(x) PERIODIC=NO");
   } else {
+    if( lw.length()>0 ) {
+      error("set NORMALIZATION=true/false when using LOGWEIGHTS as otherwise the weights are ignored. Alternatively, learn to use the new syntax for histograms with KDE/ACCUMULATE to have more control over what PLUMED is calculating");
+    }
     readInputLine( getShortcutLabel() + "_weight: ONES SIZE=1" );
   }
 


### PR DESCRIPTION
##### Description

This PR "fixes" a bug with the HISTOGRAM shortcut in version 2.10.

The histogram shortcut ignores the input to the LOGWEIGHTS keyword if you don't also use the NORMALISATION keyword. I have thus added an error to crash the shortcut if you use LOGWEIGHTS but not NORMALISATION. This at least prevents users from getting wrong results with HISTOGRAM.  It hopefully also encourages them to learn to use the new syntax with ACCUMULATE/KDE, which ultimately gives them more control over what they are doing.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.10 to fix the bug

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
