### PR TITLE
Fixed bug in histogram that causes LOGWEIGHTS to be ignored if NORMALISATION not present

### DIFF
--- a/src/gridtools/Histogram.cpp
+++ b/src/gridtools/Histogram.cpp
@@ -30,6 +30,13 @@
 /*
 Accumulate the average probability density along a few CVs from a trajectory.
 
+!!! caution ""
+
+    We recommend not using this shortcut action and instead using a combination of [KDE](KDE.md) and
+    [ACCUMULATE](ACCUMULATE.md) actions. This newer syntax will give you much more control over the
+    calculation. HISTOGRAM works by calling these two underlying actions as you can see if you expand the shortcuts
+    in the documentation that follows.
+
 When using this shortcut it is supposed that you have some collective variable $\zeta$ that
 gives a reasonable description of some physical or chemical phenomenon.  As an example of what we
 mean by this suppose you wish to examine the following SN2 reaction:
@@ -54,6 +61,9 @@ of the histogram to the free energy can be achieved by using the method [CONVERT
 
 We calculate histograms within PLUMED using a method known as [kernel density estimation](https://en.wikipedia.org/wiki/Kernel_density_estimation).
 This shortcut action thus uses the [KDE](KDE.md) and [ACCUMULATE](ACCUMULATE.md) actions to build up the time average of the histogram.
+__You will have much more control over what PLUMED is computing if you take some time to learn to use the new syntax with [KDE](KDE.md) and
+[ACCUMULATE](ACCUMULATE.md) and if you stop using the HISTOGRAM shortcut action.__
+
 
 In PLUMED the value of $\zeta$ at each discrete instant in time in the trajectory is accumulated.  A kernel, $K(\zeta-\zeta(t'),\sigma)$,
 centered at the current value, $\zeta(t)$, of this quantity is generated with a bandwidth $\sigma$, which
@@ -258,6 +268,9 @@ Histogram::Histogram( const ActionOptions& ao ):
     readInputLine( getShortcutLabel() + "_wsum: COMBINE ARG=" + lw + " PERIODIC=NO");
     readInputLine( getShortcutLabel() + "_weight: CUSTOM ARG=" + getShortcutLabel() + "_wsum FUNC=exp(x) PERIODIC=NO");
   } else {
+    if( lw.length()>0 ) {
+      error("set NORMALIZATION=true/false when using LOGWEIGHTS as otherwise the weights are ignored. Alternatively, learn to use the new syntax for histograms with KDE/ACCUMULATE to have more control over what PLUMED is calculating");
+    }
     readInputLine( getShortcutLabel() + "_weight: ONES SIZE=1" );
   }
 


### PR DESCRIPTION
##### Description

HISTOGRAM now crashes if you use LOGWEIGHTS without NORMALISATION.  I have also added material to the documentation for this action that recommends users to use the new syntax with KDE and ACCUMULATE instead of HISTOGRAM.  This new syntax gives them more control over what PLUMED is calculating.

I have also added documentation here to tell users to use the new syntax instead of this old action.  

Note the c++ code I have added here is the same as PR #1410 but on master and with additional documentation added in the manual

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.11

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
