### PR TITLE
Feature/atomic distribution usability

### DIFF
--- a/regtest/tools/rt-make-AtomicDistribution/main.cpp
+++ b/regtest/tools/rt-make-AtomicDistribution/main.cpp
@@ -1,6 +1,8 @@
 #include "plumed/tools/AtomDistribution.h"
 #include "plumed/tools/Random.h"
 #include "plumed/tools/Vector.h"
+#include "plumed/tools/Tools.h"
+#include "plumed/tools/Pbc.h"
 #include <array>
 #include <fstream>
 #include <memory>
@@ -15,24 +17,49 @@ void atomsInBoxCheck(
   const std::vector<double> &box,
   const std::string_view header,
   std::ostream & ofs) {
-  Vector lowbound = atoms[0];
-  Vector upbound= atoms[0];
-  for (unsigned i =1; i < atoms.size(); ++i) {
-    for (unsigned j=0; j<3; ++j) {
-      if (atoms[i][j] < lowbound[j]) {
-        lowbound[j] = atoms[i][j];
-      }
-      if (atoms[i][j] > upbound[j]) {
-        upbound[j] = atoms[i][j];
+  Pbc mybox;
+  mybox.setBox(Tensor{
+    box[0],
+    box[1],
+    box[2],
+    box[3],
+    box[4],
+    box[5],
+    box[6],
+    box[7],
+    box[8]});
+  ofs << "Atoms are within box dimensions:\n";
+  if (!mybox.isOrthorombic()) {
+    bool inbox = true;
+    for (const auto& atom : atoms) {
+      auto scaled = mybox.realToScaled(atom);
+      inbox &= scaled[0]<1.0;
+      inbox &= scaled[1]<1.0;
+      inbox &= scaled[2]<1.0;
+      if (!inbox) {
+        break;
       }
     }
-  }
-  // box is orhtorombic an starts in 0,0,0:
-  //shifting lowbound and upbound to chek the box:
-  upbound-=lowbound;
-  ofs << "Atoms are within box dimensions:\n";
-  for (unsigned j=0; j<3; ++j) {
-    ofs <<header <<" all atoms in box along " <<xyz[j]<<" : "<< (upbound[j]<box[j*3+j]) << "\n";
+    ofs <<header <<" all atoms within the non orthorombic box: "<< inbox << "\n";
+  } else {
+    Vector lowbound = atoms[0];
+    Vector upbound= atoms[0];
+    for (unsigned i =1; i < atoms.size(); ++i) {
+      for (unsigned j=0; j<3; ++j) {
+        if (atoms[i][j] < lowbound[j]) {
+          lowbound[j] = atoms[i][j];
+        }
+        if (atoms[i][j] > upbound[j]) {
+          upbound[j] = atoms[i][j];
+        }
+      }
+    }
+    // box is orhtorombic an starts in 0,0,0:
+    //shifting lowbound and upbound to chek the box:
+    upbound-=lowbound;
+    for (unsigned j=0; j<3; ++j) {
+      ofs <<header <<" all atoms in box along " <<xyz[j]<<" : "<< (upbound[j]<box[j*3+j]) << "\n";
+    }
   }
 }
 
@@ -128,11 +155,7 @@ void scaleTrajCheck(std::string_view kind,
   std::vector<double> basebox(9);
   auto scaled= [&]() {
     std::unique_ptr<PLMD::AtomDistribution> d;
-    if (kind == "sphere-reply212") {
-      d = AtomDistribution::getAtomDistribution("sphere|reply 2 1 2");
-    } else {
       d = AtomDistribution::getAtomDistribution(kind);
-    }
     d->frame(baseatoms,basebox,0,rng);
 
     auto mod="scale "+ std::to_string(scale) + " ";
@@ -169,6 +192,81 @@ void scaleTrajCheck(std::string_view kind,
   }
 }
 
+void fixTrajCheck(std::string_view kind,
+                  std::ostream & ofs) {
+  std::stringstream ss;
+  ss << "[fixTrajCheck -" << kind << "-]:";
+  auto header = ss.str();
+  ofs << header << "\n";
+  //reinitialized each time for stability
+  Random rng;
+  rng.setSeed(12345);
+  std::vector<Vector> baseatoms(200);
+  std::vector<double> basebox(9);
+  // sphere generates a new configuration at each step
+  auto d = AtomDistribution::getAtomDistribution(std::string(kind)+"|fix");
+  d->frame(baseatoms,basebox,0,rng);
+  std::vector<Vector> atoms(200);
+  std::vector<double> box(9);
+  //generating the next frame
+  d->frame(atoms,box,0,rng);
+
+  ofs << header << "The atoms are fixed correctly:\t";
+  bool correct = true;
+  for(unsigned i =0; i< atoms.size() && correct; ++i) {
+    correct = (abs(baseatoms[i][0] - atoms[i][0]) < 1000*PLMD::epsilon)
+              &&
+              (abs(baseatoms[i][1] - atoms[i][1]) < 1000*PLMD::epsilon)&&
+              (abs(baseatoms[i][2] - atoms[i][2]) < 1000*PLMD::epsilon);
+
+  }
+  ofs << correct << "\n";
+}
+
+void forceBoxCheck(std::string_view kind, std::ostream & ofs) {
+  std::string header= "[forceBoxCheck -"+ std::string(kind) + "-]:";
+  ofs << header << "\n";
+  {
+    auto d = AtomDistribution::getAtomDistribution(std::string(kind)+"|box 1 2 3" );
+    //reinitialized each time for stability
+    Random rng;
+    std::vector<Vector> atoms(200);
+    std::vector<double> box(9);
+    d->frame(atoms,box,0,rng);
+    ofs << header << "The box is changed as asked (ortho): ";
+
+    bool success = (box[0] - 1.0)< 1000 * PLMD::epsilon &&
+                   box[1] <  1000 * PLMD::epsilon &&
+                   box[2] <  1000 * PLMD::epsilon &&
+                   box[3] <  1000 * PLMD::epsilon &&
+                   (box[4] - 2.0) <  1000 * PLMD::epsilon &&
+                   box[5] <  1000 * PLMD::epsilon &&
+                   box[6] <  1000 * PLMD::epsilon &&
+                   box[7] <  1000 * PLMD::epsilon &&
+                   (box[8] - 3.0) <  1000 * PLMD::epsilon;
+    ofs << success << "\n";
+  }
+  {
+    auto d = AtomDistribution::getAtomDistribution(std::string(kind)+"|box 1 2 3 4 5 6 7 8 9" );
+    //reinitialized each time for stability
+    Random rng;
+    std::vector<Vector> atoms(200);
+    std::vector<double> box(9);
+    d->frame(atoms,box,0,rng);
+    ofs << header << "The box is changed as asked (9 elements): ";
+
+    bool success = (box[0] - 1.0)< 1000 * PLMD::epsilon &&
+                   (box[1] - 2.0) <  1000 * PLMD::epsilon &&
+                   (box[2] - 3.0) <  1000 * PLMD::epsilon &&
+                   (box[3] - 4.0) <  1000 * PLMD::epsilon &&
+                   (box[4] - 5.0) <  1000 * PLMD::epsilon &&
+                   (box[5] - 6.0) <  1000 * PLMD::epsilon &&
+                   (box[6] - 7.0) <  1000 * PLMD::epsilon &&
+                   (box[7] - 8.0) <  1000 * PLMD::epsilon &&
+                   (box[8] - 9.0) <  1000 * PLMD::epsilon;
+    ofs << success << "\n";
+  }
+}
 int main() {
   std::ofstream ofs("output");
   ofs << std::boolalpha;
@@ -177,7 +275,11 @@ int main() {
          "cube",
          "sphere",
          "globs",
-         "sc"
+         "sc",
+         "fcc",
+         "bcc",
+         "ifcc",
+         "ibcc"
        }) {
     basecheck(kind,ofs);
     ofs << "\n";
@@ -196,8 +298,17 @@ int main() {
     scaleTrajCheck("sphere",num,ofs);
     scaleTrajCheck("sc",num,ofs);
     scaleTrajCheck("globs",num,ofs);
-    scaleTrajCheck("sphere-reply212",num,ofs);
+    scaleTrajCheck("sphere|reply 2 1 2",num,ofs);
     ofs << "\n";
   }
+  forceBoxCheck("sc",ofs);
+  forceBoxCheck("fcc",ofs);
+  //I actually do not know how to test wiggle in a sensible way
+  // cube, globs and sphere are generate a randm configuration at each step
+  fixTrajCheck("cube",ofs);
+  fixTrajCheck("globs",ofs);
+  fixTrajCheck("sphere",ofs);
+  fixTrajCheck("sphere|reply 1 1 2",ofs);
+  fixTrajCheck("ifcc|wiggle 0.5",ofs);
   return 0;
 }

--- a/regtest/tools/rt-make-AtomicDistribution/main.cpp
+++ b/regtest/tools/rt-make-AtomicDistribution/main.cpp
@@ -63,14 +63,15 @@ void replyTrajCheck(std::string_view kind,
   unsigned nat = atoms.size();
   const auto oldNat=nat;
 
-  std::unique_ptr<PLMD::AtomDistribution> rep= std::make_unique<repliedTrajectory>([&]() {
+  auto rep= [&]() {
     auto d = AtomDistribution::getAtomDistribution(kind);
     d->frame(atoms,basebox,0,rng);
-    return d;
+    auto mod="reply "+ std::to_string(num[0]) + " "
+             + std::to_string(num[1]) + " "
+             + std::to_string(num[2]);
+    return AtomDistribution::decorateAtomDistribution(std::move(d),mod);
   }
-  (),
-  num[0], num[1], num[2],
-  nat);
+  ();
 
   //this must return true
   ofs <<header<< " rep->overrideNat(nat)=" <<
@@ -125,20 +126,20 @@ void scaleTrajCheck(std::string_view kind,
   rng.setSeed(12345);
   std::vector<Vector> baseatoms(200);
   std::vector<double> basebox(9);
-  std::unique_ptr<PLMD::AtomDistribution> scaled= std::make_unique<scaledTrajectory>([&]() {
+  auto scaled= [&]() {
     std::unique_ptr<PLMD::AtomDistribution> d;
     if (kind == "sphere-reply212") {
-      d = std::make_unique<repliedTrajectory>(
-            AtomDistribution::getAtomDistribution("sphere"),
-            2,1,2,baseatoms.size()/(2*1*2));
+      d = AtomDistribution::getAtomDistribution("sphere|reply 2 1 2");
     } else {
       d = AtomDistribution::getAtomDistribution(kind);
     }
     d->frame(baseatoms,basebox,0,rng);
-    return d;
+
+    auto mod="scale "+ std::to_string(scale) + " ";
+    return
+      AtomDistribution::decorateAtomDistribution(std::move(d),mod);
   }
-  (),
-  scale);
+  ();
 
   std::vector<Vector> atoms(200);
   std::vector<double> box(9);
@@ -151,7 +152,8 @@ void scaleTrajCheck(std::string_view kind,
   ofs << header << "The atoms are scaled correctly:\t";
   bool correct = true;
   for(unsigned i =0; i< atoms.size() && correct; ++i) {
-    correct = (abs(scale*baseatoms[i][0] - atoms[i][0]) < 1000*PLMD::epsilon)&&
+    correct = (abs(scale*baseatoms[i][0] - atoms[i][0]) < 1000*PLMD::epsilon)
+              &&
               (abs(scale*baseatoms[i][1] - atoms[i][1]) < 1000*PLMD::epsilon)&&
               (abs(scale*baseatoms[i][2] - atoms[i][2]) < 1000*PLMD::epsilon);
 
@@ -161,7 +163,8 @@ void scaleTrajCheck(std::string_view kind,
   atomsInBoxCheck(atoms,box,header,ofs);
   ofs << "New box has the correct dimensions:\n";
   for (unsigned j=0; j<3; ++j) {
-    ofs <<header <<" correct box dimension " <<xyz[j]<<" : "
+    ofs <<header <<" correct box dimension " <<xyz[j]
+        <<" : "
         << ((scale*basebox[j*3+j] - box[j*3+j]) < 1000*PLMD::epsilon) << "\n";
   }
 }

--- a/regtest/tools/rt-make-AtomicDistribution/output.reference
+++ b/regtest/tools/rt-make-AtomicDistribution/output.reference
@@ -28,6 +28,26 @@ Atoms are within box dimensions:
 [baseCheck -sc-]: all atoms in box along y : true
 [baseCheck -sc-]: all atoms in box along z : true
 
+[baseCheck -fcc-]:
+Atoms are within box dimensions:
+[baseCheck -fcc-]: all atoms within the non orthorombic box: true
+
+[baseCheck -bcc-]:
+Atoms are within box dimensions:
+[baseCheck -bcc-]: all atoms within the non orthorombic box: true
+
+[baseCheck -ifcc-]:
+Atoms are within box dimensions:
+[baseCheck -ifcc-]: all atoms in box along x : true
+[baseCheck -ifcc-]: all atoms in box along y : true
+[baseCheck -ifcc-]: all atoms in box along z : true
+
+[baseCheck -ibcc-]:
+Atoms are within box dimensions:
+[baseCheck -ibcc-]: all atoms in box along x : true
+[baseCheck -ibcc-]: all atoms in box along y : true
+[baseCheck -ibcc-]: all atoms in box along z : true
+
 [replyTrajCheck -sphere 1, 2, 3-]:
 [replyTrajCheck -sphere 1, 2, 3-]: rep->overrideNat(nat)=true
 [replyTrajCheck -sphere 1, 2, 3-]: new number of atoms: ( should be 1200) : 1200
@@ -162,16 +182,16 @@ New box has the correct dimensions:
 [scaleTrajCheck -globs*0.5-]: correct box dimension x : true
 [scaleTrajCheck -globs*0.5-]: correct box dimension y : true
 [scaleTrajCheck -globs*0.5-]: correct box dimension z : true
-[scaleTrajCheck -sphere-reply212*0.5-]:
-[scaleTrajCheck -sphere-reply212*0.5-]:The atoms are scaled correctly:	true
+[scaleTrajCheck -sphere|reply 2 1 2*0.5-]:
+[scaleTrajCheck -sphere|reply 2 1 2*0.5-]:The atoms are scaled correctly:	true
 Atoms are within box dimensions:
-[scaleTrajCheck -sphere-reply212*0.5-]: all atoms in box along x : true
-[scaleTrajCheck -sphere-reply212*0.5-]: all atoms in box along y : true
-[scaleTrajCheck -sphere-reply212*0.5-]: all atoms in box along z : true
+[scaleTrajCheck -sphere|reply 2 1 2*0.5-]: all atoms in box along x : true
+[scaleTrajCheck -sphere|reply 2 1 2*0.5-]: all atoms in box along y : true
+[scaleTrajCheck -sphere|reply 2 1 2*0.5-]: all atoms in box along z : true
 New box has the correct dimensions:
-[scaleTrajCheck -sphere-reply212*0.5-]: correct box dimension x : true
-[scaleTrajCheck -sphere-reply212*0.5-]: correct box dimension y : true
-[scaleTrajCheck -sphere-reply212*0.5-]: correct box dimension z : true
+[scaleTrajCheck -sphere|reply 2 1 2*0.5-]: correct box dimension x : true
+[scaleTrajCheck -sphere|reply 2 1 2*0.5-]: correct box dimension y : true
+[scaleTrajCheck -sphere|reply 2 1 2*0.5-]: correct box dimension z : true
 
 [scaleTrajCheck -sphere*3-]:
 [scaleTrajCheck -sphere*3-]:The atoms are scaled correctly:	true
@@ -203,16 +223,16 @@ New box has the correct dimensions:
 [scaleTrajCheck -globs*3-]: correct box dimension x : true
 [scaleTrajCheck -globs*3-]: correct box dimension y : true
 [scaleTrajCheck -globs*3-]: correct box dimension z : true
-[scaleTrajCheck -sphere-reply212*3-]:
-[scaleTrajCheck -sphere-reply212*3-]:The atoms are scaled correctly:	true
+[scaleTrajCheck -sphere|reply 2 1 2*3-]:
+[scaleTrajCheck -sphere|reply 2 1 2*3-]:The atoms are scaled correctly:	true
 Atoms are within box dimensions:
-[scaleTrajCheck -sphere-reply212*3-]: all atoms in box along x : true
-[scaleTrajCheck -sphere-reply212*3-]: all atoms in box along y : true
-[scaleTrajCheck -sphere-reply212*3-]: all atoms in box along z : true
+[scaleTrajCheck -sphere|reply 2 1 2*3-]: all atoms in box along x : true
+[scaleTrajCheck -sphere|reply 2 1 2*3-]: all atoms in box along y : true
+[scaleTrajCheck -sphere|reply 2 1 2*3-]: all atoms in box along z : true
 New box has the correct dimensions:
-[scaleTrajCheck -sphere-reply212*3-]: correct box dimension x : true
-[scaleTrajCheck -sphere-reply212*3-]: correct box dimension y : true
-[scaleTrajCheck -sphere-reply212*3-]: correct box dimension z : true
+[scaleTrajCheck -sphere|reply 2 1 2*3-]: correct box dimension x : true
+[scaleTrajCheck -sphere|reply 2 1 2*3-]: correct box dimension y : true
+[scaleTrajCheck -sphere|reply 2 1 2*3-]: correct box dimension z : true
 
 [scaleTrajCheck -sphere*10-]:
 [scaleTrajCheck -sphere*10-]:The atoms are scaled correctly:	true
@@ -244,14 +264,30 @@ New box has the correct dimensions:
 [scaleTrajCheck -globs*10-]: correct box dimension x : true
 [scaleTrajCheck -globs*10-]: correct box dimension y : true
 [scaleTrajCheck -globs*10-]: correct box dimension z : true
-[scaleTrajCheck -sphere-reply212*10-]:
-[scaleTrajCheck -sphere-reply212*10-]:The atoms are scaled correctly:	true
+[scaleTrajCheck -sphere|reply 2 1 2*10-]:
+[scaleTrajCheck -sphere|reply 2 1 2*10-]:The atoms are scaled correctly:	true
 Atoms are within box dimensions:
-[scaleTrajCheck -sphere-reply212*10-]: all atoms in box along x : true
-[scaleTrajCheck -sphere-reply212*10-]: all atoms in box along y : true
-[scaleTrajCheck -sphere-reply212*10-]: all atoms in box along z : true
+[scaleTrajCheck -sphere|reply 2 1 2*10-]: all atoms in box along x : true
+[scaleTrajCheck -sphere|reply 2 1 2*10-]: all atoms in box along y : true
+[scaleTrajCheck -sphere|reply 2 1 2*10-]: all atoms in box along z : true
 New box has the correct dimensions:
-[scaleTrajCheck -sphere-reply212*10-]: correct box dimension x : true
-[scaleTrajCheck -sphere-reply212*10-]: correct box dimension y : true
-[scaleTrajCheck -sphere-reply212*10-]: correct box dimension z : true
+[scaleTrajCheck -sphere|reply 2 1 2*10-]: correct box dimension x : true
+[scaleTrajCheck -sphere|reply 2 1 2*10-]: correct box dimension y : true
+[scaleTrajCheck -sphere|reply 2 1 2*10-]: correct box dimension z : true
 
+[forceBoxCheck -sc-]:
+[forceBoxCheck -sc-]:The box is changed as asked (ortho): true
+[forceBoxCheck -sc-]:The box is changed as asked (9 elements): true
+[forceBoxCheck -fcc-]:
+[forceBoxCheck -fcc-]:The box is changed as asked (ortho): true
+[forceBoxCheck -fcc-]:The box is changed as asked (9 elements): true
+[fixTrajCheck -cube-]:
+[fixTrajCheck -cube-]:The atoms are fixed correctly:	true
+[fixTrajCheck -globs-]:
+[fixTrajCheck -globs-]:The atoms are fixed correctly:	true
+[fixTrajCheck -sphere-]:
+[fixTrajCheck -sphere-]:The atoms are fixed correctly:	true
+[fixTrajCheck -sphere|reply 1 1 2-]:
+[fixTrajCheck -sphere|reply 1 1 2-]:The atoms are fixed correctly:	true
+[fixTrajCheck -ifcc|wiggle 0.5-]:
+[fixTrajCheck -ifcc|wiggle 0.5-]:The atoms are fixed correctly:	true

--- a/regtest/tools/rt-make-CellLists/main.cpp
+++ b/regtest/tools/rt-make-CellLists/main.cpp
@@ -21,7 +21,6 @@
 #include <numeric>
 
 using namespace PLMD;
-using atomDst = std::unique_ptr<PLMD::AtomDistribution>;
 
 void test (PLMD::Communicator &comm);
 void testIndexes (PLMD::Communicator &comm);
@@ -364,17 +363,16 @@ void test (PLMD::Communicator &comm) {
   std::vector<Vector> atoms(5*5*5);
   std::vector<double> basebox(9);
   unsigned nat = atoms.size();
-  atomDst rep= std::make_unique<repliedTrajectory>([&]() {
+  auto rep= [&]() {
     auto d = AtomDistribution::getAtomDistribution("sc");
 //getting some base informations
     d->frame(atoms,basebox,0,rng);
-    return d;
+    auto mod="reply "+ std::to_string(replicas[0]) + " "
+             + std::to_string(replicas[1]) + " "
+             + std::to_string(replicas[2]);
+    return AtomDistribution::decorateAtomDistribution(std::move(d),mod);
   }
-  (),
-  replicas[0],
-  replicas[1],
-  replicas[2],
-  nat);
+  ();
   const unsigned startingnat=nat;
   rep->overrideNat(nat);
   const unsigned nrep = nat/startingnat;
@@ -434,17 +432,16 @@ void bench (PLMD::Communicator &comm) {
   std::vector<Vector> atoms(50000);
   std::vector<double> basebox(9);
   unsigned nat = atoms.size();
-  atomDst rep= std::make_unique<repliedTrajectory>([&]() {
+  auto rep= [&]() {
     auto d = AtomDistribution::getAtomDistribution("cube");
 //getting some base informations
     d->frame(atoms,basebox,0,rng);
-    return d;
+    auto mod="reply "+ std::to_string(replicas[0]) + " "
+             + std::to_string(replicas[1]) + " "
+             + std::to_string(replicas[2]);
+    return AtomDistribution::decorateAtomDistribution(std::move(d),mod);
   }
-  (),
-  replicas[0],
-  replicas[1],
-  replicas[2],
-  nat);
+  ();
   //const unsigned startingnat=nat;
   rep->overrideNat(nat);
   //const unsigned nrep = nat/startingnat;

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -378,7 +378,7 @@ void Benchmark::registerKeywords( Keywords& keys ) {
   keys.add("compulsory","--nsteps","2000","number of steps of MD to perform (-1 means forever)");
   keys.add("compulsory","--maxtime","-1","maximum number of seconds (-1 means forever)");
   keys.add("compulsory","--sleep","0","number of seconds of sleep, mimicking MD calculation");
-  keys.add("compulsory","--atom-distribution","line","the kind of possible atomic displacement at each step");
+  keys.add("compulsory","--atom-distribution","line|wiggle 0.5","the kind of possible atomic displacement at each step");
   // Maybe "--atom-distribution" can be more clear when calling --help if we use reset_style to "atoms"
   keys.add("optional","--dump-trajectory","dump the trajectory to this file");
   keys.addFlag("--domain-decomposition",false,"simulate domain decomposition, implies --shuffle");

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -354,41 +354,14 @@ public:
       return std::nullopt;
     }
 
-    bool doWiggle=false;
-    parseFlag("--wiggle",doWiggle);
-    if (doWiggle) {
+    if(std::string trajectoryModifications="";
+        parse("--modify-trajectory",trajectoryModifications)) {
+
+      log << "Using --modify-trajectory=" << trajectoryModifications << "\n";
       std::unique_ptr<AtomDistribution> tmp = std::move(*toret);
-      toret = std::make_unique<wiggleTrajectory>(std::move(tmp),0.1);
+      toret = AtomDistribution::decorateAtomDistribution(std::move(tmp),trajectoryModifications);
     }
 
-    double scale = -1;
-    parse("--scale",scale);
-    if (scale>0) {
-      std::unique_ptr<AtomDistribution> tmp = std::move(*toret);
-      toret = std::make_unique<scaledTrajectory>(std::move(tmp),
-              scale);
-    }
-    ///@todo: add a the possibility to add the pcbbox via CLI
-    /// this is necessary for some molfile plugins
-    int repeatX=0;
-    int repeatY=0;
-    int repeatZ=0;
-    parse("--repeatX",repeatX);
-    log << "Using --repeatX=" << repeatX << "\n";
-    parse("--repeatY",repeatY);
-    log << "Using --repeatY=" << repeatY << "\n";
-    parse("--repeatZ",repeatZ);
-    log << "Using --repeatZ=" << repeatZ << "\n";
-    if (repeatX<1 || repeatY<1 || repeatZ<1) {
-      log << "ERROR: repetitions of the trajectory must be >=1\n";
-      return std::nullopt;
-    }
-    if (repeatX*repeatY*repeatZ >1) {
-      return std::make_unique<repliedTrajectory>(std::move(*toret),
-             repeatX,
-             repeatY,
-             repeatZ);
-    }
     return toret;
   }
 };
@@ -410,16 +383,7 @@ void Benchmark::registerKeywords( Keywords& keys ) {
   keys.addFlag("--domain-decomposition",false,"simulate domain decomposition, implies --shuffle");
   keys.addFlag("--shuffled",false,"reshuffle atoms");
   TrajectoryParser::registerKeywords(keys);
-  keys.add("compulsory","--repeatX","1","number of time to align the read trajectory along the fist box component,"
-           " ingnored with a atomic distribution");
-  keys.add("compulsory","--repeatY","1","number of time to align the read trajectory along the second box component,"
-           " ingnored with a atomic distribution");
-  keys.add("compulsory","--repeatZ","1","number of time to align the read trajectory along the third box component,"
-           " ingnored with a atomic distribution");
-  //defaults to negative because we are parsing doubles
-  keys.add("compulsory","--scale","-1","multiplies atom positions and box dimensions by the specified positive number");
-  keys.addFlag("--wiggle",false, "Displaces each atom of the trajectory at each steps");
-
+  keys.add("optional","--modify-trajectory","apply some modifications to the trajectory used in the benchmark, can modify a parsed file");
 }
 
 Benchmark::Benchmark(const CLToolOptions& co ):

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -665,7 +665,8 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
         ofile << natoms << "\n"
               << cell[0] << " " << cell[1] << " " << cell[2] << " "
               << cell[3] << " " << cell[4] << " " << cell[5] << " "
-              << cell[6] << " " << cell[7] << " " << cell[8] << "\n";
+              << cell[6] << " " << cell[7] << " " << cell[8]
+              << "\n";
         for(unsigned i=0; i<natoms; ++i) {
           ofile << "X\t" << pos[i]<< "\n";
         }

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -31,6 +31,7 @@
 #include "tools/Random.h"
 #include "tools/TrajectoryParser.h"
 #include "tools/AtomDistribution.h"
+#include "tools/AtomDistributionFiles.h"
 
 #include <cstdio>
 #include <string>

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -353,6 +353,14 @@ public:
     if (!toret.has_value()) {
       return std::nullopt;
     }
+
+    bool doWiggle=false;
+    parseFlag("--wiggle",doWiggle);
+    if (doWiggle) {
+      std::unique_ptr<AtomDistribution> tmp = std::move(*toret);
+      toret = std::make_unique<wiggleTrajectory>(std::move(tmp),0.1);
+    }
+
     double scale = -1;
     parse("--scale",scale);
     if (scale>0) {
@@ -410,6 +418,8 @@ void Benchmark::registerKeywords( Keywords& keys ) {
            " ingnored with a atomic distribution");
   //defaults to negative because we are parsing doubles
   keys.add("compulsory","--scale","-1","multiplies atom positions and box dimensions by the specified positive number");
+  keys.addFlag("--wiggle",false, "Displaces each atom of the trajectory at each steps");
+
 }
 
 Benchmark::Benchmark(const CLToolOptions& co ):

--- a/src/cltools/Benchmark.cpp
+++ b/src/cltools/Benchmark.cpp
@@ -381,6 +381,7 @@ void Benchmark::registerKeywords( Keywords& keys ) {
   keys.add("compulsory","--atom-distribution","line|wiggle 0.5","the kind of possible atomic displacement at each step");
   // Maybe "--atom-distribution" can be more clear when calling --help if we use reset_style to "atoms"
   keys.add("optional","--dump-trajectory","dump the trajectory to this file");
+  keys.addFlag("--ad-help",false,"print a small help text for the atom distributions");
   keys.addFlag("--domain-decomposition",false,"simulate domain decomposition, implies --shuffle");
   keys.addFlag("--shuffled",false,"reshuffle atoms");
   TrajectoryParser::registerKeywords(keys);
@@ -414,6 +415,41 @@ int Benchmark::main(FILE* in, FILE*out,Communicator& pc) {
   } else {
     log.link(log_dev_null.get());
   }
+
+  bool printADHelp=false;
+  parseFlag("--ad-help",printADHelp);
+  if (printADHelp) {
+    log << "Documentation for the atomic distributions:\n";
+    log << "\nThese are the basic atomic distributions:\n";
+    auto distrs = AtomDistribution::getDistributionDocumentation();
+    for(const auto& d:distrs) {
+      log.printf("%8s - %s\n\n",d.id.c_str(),d.doc.c_str());
+    }
+    auto modifiers = AtomDistribution::getDecoratorsDocumentation();
+
+    log << "\nThese are the modifiers that can be applied to any atomic distributions:\n";
+    for(const auto& d:modifiers) {
+      log.printf("%8s - %s\n\n",d.id.c_str(),d.doc.c_str());
+    }
+    log << R"==(
+To use these distributions in the benchmark you can simple the cli option --atom-distribution
+like:
+  --atom-distribution="sc", with no extra modifiers
+  --atom-distribution="line|wiggle 0.5", use the pipe for modify the base distribution
+  --atom-distribution="ifcc|scale 2.3|reply 2 1 1", do not add spaces before or after the pipes
+
+As an extra tool you can append more modificators with --modify-trajectory,
+it is not necessary since you can use --atom-distribution, but can be applied
+to a trajectory read from a file, for example "box" can be used for adding
+the pbcs to certain file parsers.
+Remember that --modify-trajectory accepts only  modifiers, with the
+same syntax of --atom-distribution
+  --modify-trajectory="box 5 5 5"
+  --modify-trajectory="box 0 1 1 1 1 0 1 0 1|reply 4 2 6"
+)==";
+    return 0;
+  }
+
   log.setLinePrefix("BENCH:  ");
   log <<"Welcome to PLUMED benchmark\n";
   std::vector<Kernel> kernels;

--- a/src/tools/AtomDistribution.cpp
+++ b/src/tools/AtomDistribution.cpp
@@ -691,6 +691,75 @@ or
   }
 };
 
+/// A decorator for fixing the state of the trajectory
+class fixedTrajectory: public AtomDistribution {
+  std::unique_ptr<AtomDistribution> distribution;
+  std::array<double,9> fixedBox= {0.0,0.0,0.0,
+                                  0.0,0.0,0.0,
+                                  0.0,0.0,0.0
+                                 };
+  std::vector<Vector> positions= {};
+  unsigned stride=0;
+  bool generate=true;
+public:
+  static constexpr auto id="fix";
+  static constexpr auto doc=R"=(Fixes the trajectory for stride steps, or forever if stride is 0
+usage:
+ "fix stride(optional)")=";
+
+  static std::unique_ptr<AtomDistribution> decorate(
+    std::unique_ptr<AtomDistribution>&& d,
+    std::string_view cmd) {
+    unpackedLine lines;
+    Tools::getWordsSimple(lines,cmd);
+    plumed_assert(lines.size() <= 2) << id << " supports only one optional parameter for the stride";
+
+    if (lines.size()==2) {
+      unsigned newStride=0;
+      Tools::convert(std::string(lines[1]), newStride);
+      return std::make_unique<fixedTrajectory>(std::move(d),newStride);
+    }
+    //the default value is specified in the header
+    return std::make_unique<fixedTrajectory>(std::move(d));
+  }
+  fixedTrajectory(std::unique_ptr<AtomDistribution>&& d,
+                  unsigned newStride=0):
+    distribution(std::move(d)),
+    stride(newStride)
+  {}
+
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned step,
+             Random& rng) override {
+    generate = (!generate && stride>0) ?
+               step%stride==0
+               : generate;
+    if (generate) {
+      positions.resize(posToUpdate.size());
+      distribution->frame(
+        make_view(positions),
+        View<double,9>(fixedBox.data()),
+        step,rng);
+      generate=false;
+    }
+    plumed_assert(positions.size() == posToUpdate.size()) << "fixed atom distributions: the expected number of atoms  changed";
+    std::copy(positions.begin(),positions.end(),posToUpdate.begin());
+    box[0] = fixedBox[0];
+    box[1] = fixedBox[1];
+    box[2] = fixedBox[2];
+    box[3] = fixedBox[3];
+    box[4] = fixedBox[4];
+    box[5] = fixedBox[5];
+    box[6] = fixedBox[6];
+    box[7] = fixedBox[7];
+    box[8] = fixedBox[8];
+  }
+
+  bool overrideNat(unsigned& natoms) override {
+    return distribution->overrideNat(natoms);
+  }
+};
 //****************************Helpers and managements***************************
 
 
@@ -753,7 +822,8 @@ using decoratorDistribuitions = std::variant<
                                 repliedTrajectory,
                                 scaledTrajectory,
                                 wiggleTrajectory,
-                                forceBoxTrajectory>;
+                                forceBoxTrajectory,
+                                fixedTrajectory>;
 
 template <size_t I=0>
 std::optional<std::unique_ptr<AtomDistribution>> getAD(std::string_view atomicDistr) {

--- a/src/tools/AtomDistribution.cpp
+++ b/src/tools/AtomDistribution.cpp
@@ -22,123 +22,16 @@
 #include "AtomDistribution.h"
 #include "Exception.h"
 #include "View.h"
+#include "Tools.h"
 #include <cassert>
-#include <memory>
 #include <variant>
 #include <optional>
 #include <functional>
 
+
 namespace PLMD {
 
 using unpackedLine=gch::small_vector<std::string_view>;
-
-namespace ADHelpers {
-//add a new base distribution here, and the compiler will automagically
-//set up the parser for you
-using baseDistributions = std::variant<
-                          theLine,
-                          uniformCube,
-                          uniformSphere,
-                          twoGlobs,
-                          tiledSimpleCubic,
-                          tiledBodyCenteredCubic,
-                          tiledFaceCenteredCubic,
-                          inscribedBodyCenteredCubic,
-                          inscribedFaceCenteredCubic>;
-//add new decorators here:
-using decoratorDistribuitions = std::variant<
-                                repliedTrajectory,
-                                scaledTrajectory,
-                                wiggleTrajectory,
-                                forceBoxTrajectory>;
-
-template <size_t I=0>
-std::optional<std::unique_ptr<AtomDistribution>> getAD(std::string_view atomicDistr) {
-  if constexpr ( I < std::variant_size_v<baseDistributions>) {
-    using myAD=typename std::variant_alternative_t<I,baseDistributions>;
-    if (atomicDistr==myAD::id) {
-      return std::make_unique<myAD>();
-    }
-    return getAD<I+1>(atomicDistr);
-  }
-  return std::nullopt;
-}
-
-template <size_t I=0>
-std::string getBaseList(std::string init="") {
-  if constexpr ( I < std::variant_size_v<baseDistributions>) {
-    using myAD=typename std::variant_alternative_t<I,baseDistributions>;
-    return init + "\"" + myAD::id + "\""+ getBaseList<I+1>(", ");
-  }
-  return "";
-}
-
-template <size_t I=0>
-std::string getDecoratorList(std::string init="") {
-  if constexpr ( I < std::variant_size_v<decoratorDistribuitions>) {
-    using myAD=typename std::variant_alternative_t<I,decoratorDistribuitions>;
-    return init + "\"" + myAD::id + "\""+ getDecoratorList<I+1>(", ");
-  }
-  return "";
-}
-
-using parser=std::function<std::unique_ptr<AtomDistribution>(std::unique_ptr<AtomDistribution>&& d,
-             std::string_view cmd)>;
-
-template <size_t I=0>
-std::optional<parser> getDecorator( std::string_view decoratorDistr) {
-  if constexpr ( I < std::variant_size_v<decoratorDistribuitions>) {
-    auto name=decoratorDistr.substr(0,decoratorDistr.find(' '));
-    using myAD=typename std::variant_alternative_t<I,decoratorDistribuitions>;
-    if (name==myAD::id) {
-      return myAD::decorate;
-    }
-    return getDecorator<I+1>(decoratorDistr);
-  }
-  return std::nullopt;
-}
-} // namespace ADHelpers
-
-std::unique_ptr<AtomDistribution> AtomDistribution::getAtomDistribution(std::string_view atomicDistr) {
-  auto pipePos = atomicDistr.find("|");
-  auto base=atomicDistr.substr(0,pipePos);
-  std::unique_ptr<AtomDistribution> distribution;
-  if(auto d = ADHelpers::getAD(base); d) {
-    distribution = std::move(*d);
-  } else {
-    plumed_error() << "The atomic distribution can be only "<<ADHelpers::getBaseList()
-                   << ", but the input was \""
-                   << base <<'"';
-  }
-  if (pipePos != std::string_view::npos) {
-    return decorateAtomDistribution(std::move(distribution),
-                                    atomicDistr.substr(pipePos+1));
-  }
-  return distribution;
-}
-
-
-std::unique_ptr<AtomDistribution> AtomDistribution::decorateAtomDistribution(
-  std::unique_ptr<AtomDistribution> && ad,
-  std::string_view decoratorDistr) {
-  unpackedLine lines;
-  Tools::getWordsSimple(lines,decoratorDistr,"|");
-  std::unique_ptr<AtomDistribution> distribution=std::move(ad);
-  for(auto i=0u; i < lines.size(); ++i) {
-    auto decorator=ADHelpers::getDecorator(lines[i]);
-    if (decorator) {
-      auto tmp=std::move(distribution);
-      distribution = (*decorator)(std::move(tmp),lines[i]);
-    } else {
-
-      plumed_error() << "The atomic distribution decorators be only "<<ADHelpers::getDecoratorList()
-                     << ", but the input was \""
-                     << lines[i] <<'"';
-    }
-
-  }
-  return distribution;
-}
 
 void AtomDistribution::frame(std::vector<Vector>& posToUpdate,
                              std::vector<double>& box,
@@ -160,7 +53,7 @@ public:
   //assuming rmin=0
   explicit UniformSphericalVector(const double rmax):
     rCub (rmax*rmax*rmax/*-rminCub*/) {}
-  PLMD::Vector operator()(Random& rng) {
+  PLMD::Vector operator()(Random& rng) const {
     double rho = std::cbrt (/*rminCub + */rng.RandU01()*rCub);
     double theta =std::acos (2.0*rng.RandU01() -1.0);
     double phi = 2.0 * PLMD::pi * rng.RandU01();
@@ -171,117 +64,131 @@ public:
   }
 };
 
-void theLine::frame(View<Vector> posToUpdate,
-                    View<double,9> box,
-                    unsigned step,
-                    Random& rng) {
-  auto nat = posToUpdate.size();
-  UniformSphericalVector usv(0.5);
+///A wiggly line of atoms
+struct theLine:public AtomDistribution {
+  static constexpr auto id="line";
+  static constexpr auto doc="A line of atoms, that wiggles randomly at each step";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned step,
+             Random& rng) override {
+    auto nat = posToUpdate.size();
+    UniformSphericalVector usv(0.5);
 
-  for (unsigned i=0; i<nat; ++i) {
-    posToUpdate[i] = Vector(i, 0, 0) + usv(rng);
+    for (unsigned i=0; i<nat; ++i) {
+      posToUpdate[i] = Vector(i, 0, 0) + usv(rng);
+    }
+    box[0]=nat;
+    box[1]=0.0;
+    box[2]=0.0;
+    box[3]=0.0;
+    box[4]=1.75;
+    box[5]=0.0;
+    box[6]=0.0;
+    box[7]=0.0;
+    box[8]=1.75;
   }
-  box[0]=nat;
-  box[1]=0.0;
-  box[2]=0.0;
-  box[3]=0.0;
-  box[4]=1.75;
-  box[5]=0.0;
-  box[6]=0.0;
-  box[7]=0.0;
-  box[8]=1.75;
-}
+};
 
-void uniformSphere::frame(View<Vector> posToUpdate,
-                          View<double,9> box,
-                          unsigned /*step*/,
-                          Random& rng) {
+///Atom randomly distribuited in a sphere
+struct uniformSphere:public AtomDistribution {
+  static constexpr auto id="sphere";
+  static constexpr auto doc="Atoms are displaced uniformly in a sphere, the desity is ccirca 1/unit^3";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned /*step*/,
+             Random& rng) override {
+    //giving more or less a cubic udm of volume for each atom: V=nat
+    const double rmax= std::cbrt ((3.0/(4.0*PLMD::pi)) * posToUpdate.size());
 
-  //giving more or less a cubic udm of volume for each atom: V=nat
-  const double rmax= std::cbrt ((3.0/(4.0*PLMD::pi)) * posToUpdate.size());
+    UniformSphericalVector usv(rmax);
+    auto s=posToUpdate.begin();
+    auto e=posToUpdate.end();
+    //I am using the iterators:this is slightly faster,
+    // enough to overcome the cost of the vtable that I added
+    for (unsigned i=0; s!=e; ++s,++i) {
+      *s = usv (rng);
+    }
 
-  UniformSphericalVector usv(rmax);
-  auto s=posToUpdate.begin();
-  auto e=posToUpdate.end();
-  //I am using the iterators:this is slightly faster,
-  // enough to overcome the cost of the vtable that I added
-  for (unsigned i=0; s!=e; ++s,++i) {
-    *s = usv (rng);
+    box[0]=2.0*rmax;
+    box[1]=0.0;
+    box[2]=0.0;
+    box[3]=0.0;
+    box[4]=2.0*rmax;
+    box[5]=0.0;
+    box[6]=0.0;
+    box[7]=0.0;
+    box[8]=2.0*rmax;
   }
+};
 
-  box[0]=2.0*rmax;
-  box[1]=0.0;
-  box[2]=0.0;
-  box[3]=0.0;
-  box[4]=2.0*rmax;
-  box[5]=0.0;
-  box[6]=0.0;
-  box[7]=0.0;
-  box[8]=2.0*rmax;
+///Atom randomly distribuited between two not overlapping a spheres
+struct twoGlobs: public AtomDistribution {
+  static constexpr auto id="globs";
+  static constexpr auto doc="Two spheres of uniformly distribuited atosm";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned /*step*/,
+             Random&rng) override {
+    //I am using two unigform spheres and 2V=n
+    const double rmax= std::cbrt ((3.0/(8.0*PLMD::pi)) * posToUpdate.size());
 
-}
-
-void twoGlobs::frame(View<Vector> posToUpdate,
-                     View<double,9> box,
-                     unsigned /*step*/,
-                     Random&rng) {
-  //I am using two unigform spheres and 2V=n
-  const double rmax= std::cbrt ((3.0/(8.0*PLMD::pi)) * posToUpdate.size());
-
-  UniformSphericalVector usv(rmax);
-  const std::array<const Vector,2> centers{
-    PLMD::Vector{0.0,0.0,0.0},
+    UniformSphericalVector usv(rmax);
+    const std::array<const Vector,2> centers{
+      PLMD::Vector{0.0,0.0,0.0},
 //so they do not overlap
-    PLMD::Vector{2.0*rmax,2.0*rmax,2.0*rmax}
-  };
-  std::generate(posToUpdate.begin(),posToUpdate.end(),[&]() {
-    //RandInt is only declared
-    // return usv (rng) + centers[rng.RandInt(1)];
-    return usv (rng) + centers[rng.RandU01()>0.5];
-  });
+      PLMD::Vector{2.0*rmax,2.0*rmax,2.0*rmax}
+    };
+    std::generate(posToUpdate.begin(),posToUpdate.end(),[&]() {
+      //RandInt is only declared
+      // return usv (rng) + centers[rng.RandInt(1)];
+      return usv (rng) + centers[rng.RandU01()>0.5];
+    });
 
-  box[0]=4.0 *rmax;
-  box[1]=0.0;
-  box[2]=0.0;
-  box[3]=0.0;
-  box[4]=4.0 *rmax;
-  box[5]=0.0;
-  box[6]=0.0;
-  box[7]=0.0;
-  box[8]=4.0 *rmax;
-}
-
-void uniformCube::frame(View<Vector> posToUpdate,
-                        View<double,9> box,
-                        unsigned /*step*/,
-                        Random& rng) {
-  //giving more or less a cubic udm of volume for each atom: V = nat
-  const double rmax = std::cbrt(static_cast<double>(posToUpdate.size()));
-
-
-
-  // std::generate(posToUpdate.begin(),posToUpdate.end(),[&]() {
-  //   return Vector (rndR(rng),rndR(rng),rndR(rng));
-  // });
-  auto s=posToUpdate.begin();
-  auto e=posToUpdate.end();
-  //I am using the iterators:this is slightly faster,
-  // enough to overcome the cost of the vtable that I added
-  for (unsigned i=0; s!=e; ++s,++i) {
-    *s = Vector (rng.RandU01()*rmax,rng.RandU01()*rmax,rng.RandU01()*rmax);
+    box[0]=4.0 *rmax;
+    box[1]=0.0;
+    box[2]=0.0;
+    box[3]=0.0;
+    box[4]=4.0 *rmax;
+    box[5]=0.0;
+    box[6]=0.0;
+    box[7]=0.0;
+    box[8]=4.0 *rmax;
   }
-  //+0.05 to avoid overlap
-  box[0]=rmax+0.05;
-  box[1]=0.0;
-  box[2]=0.0;
-  box[3]=0.0;
-  box[4]=rmax+0.05;
-  box[5]=0.0;
-  box[6]=0.0;
-  box[7]=0.0;
-  box[8]=rmax+0.05;
+};
 
-}
+struct uniformCube:public AtomDistribution {
+  static constexpr auto id="cube";
+  static constexpr auto doc="Randomly displaced atoms in a cube, the density is circa 1/unit^3";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned /*step*/,
+             Random& rng) override {
+    //giving more or less a cubic udm of volume for each atom: V = nat
+    const double rmax = std::cbrt(static_cast<double>(posToUpdate.size()));
+
+    // std::generate(posToUpdate.begin(),posToUpdate.end(),[&]() {
+    //   return Vector (rndR(rng),rndR(rng),rndR(rng));
+    // });
+    auto s=posToUpdate.begin();
+    auto e=posToUpdate.end();
+    //I am using the iterators:this is slightly faster,
+    // enough to overcome the cost of the vtable that I added
+    for (unsigned i=0; s!=e; ++s,++i) {
+      *s = Vector (rng.RandU01()*rmax,rng.RandU01()*rmax,rng.RandU01()*rmax);
+    }
+    //+0.05 to avoid overlap
+    box[0]=rmax+0.05;
+    box[1]=0.0;
+    box[2]=0.0;
+    box[3]=0.0;
+    box[4]=rmax+0.05;
+    box[5]=0.0;
+    box[6]=0.0;
+    box[7]=0.0;
+    box[8]=rmax+0.05;
+  }
+};
 
 /// A simple correction to getting (in ceil mode) the correct nearest perfect cube
 unsigned ceiledPerfectCube(const unsigned N) {
@@ -296,312 +203,275 @@ unsigned ceiledPerfectCube(const unsigned N) {
   return x+1;
 }
 
-void tiledSimpleCubic::frame(View<Vector> posToUpdate,
-                             View<double,9> box,
-                             unsigned /*step*/,
-                             Random& rng) {
-  //Tiling the space in this way will not tests 100% the pbc, but
-  //I do not think that write a spacefilling curve, like Hilbert, Peano or Morton
-  //could be a good idea, in this case
+struct tiledSimpleCubic:public AtomDistribution {
+  static constexpr auto id="sc";
+  static constexpr auto doc="Simple Cubic";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned /*step*/,
+             Random& rng) override {
+    //Tiling the space in this way will not tests 100% the pbc, but
+    //I do not think that write a spacefilling curve, like Hilbert, Peano or Morton
+    //could be a good idea, in this case
 
-  const unsigned rmax =ceiledPerfectCube(posToUpdate.size());
+    const unsigned rmax =ceiledPerfectCube(posToUpdate.size());
 
-  auto s=posToUpdate.begin();
-  auto e=posToUpdate.end();
-  //I am using the iterators:this is slightly faster,
-  // enough to overcome the cost of the vtable that I added
-  for (unsigned k=0; k<rmax&&s!=e; ++k) {
-    for (unsigned j=0; j<rmax&&s!=e; ++j) {
-      for (unsigned i=0; i<rmax&&s!=e; ++i) {
-        *s = Vector (i,j,k);
-        ++s;
+    auto s=posToUpdate.begin();
+    auto e=posToUpdate.end();
+    //I am using the iterators:this is slightly faster,
+    // enough to overcome the cost of the vtable that I added
+    for (unsigned k=0; k<rmax&&s!=e; ++k) {
+      for (unsigned j=0; j<rmax&&s!=e; ++j) {
+        for (unsigned i=0; i<rmax&&s!=e; ++i) {
+          *s = Vector (i,j,k);
+          ++s;
+        }
       }
     }
+    box[0]=rmax;
+    box[1]=0.0;
+    box[2]=0.0;
+    box[3]=0.0;
+    box[4]=rmax;
+    box[5]=0.0;
+    box[6]=0.0;
+    box[7]=0.0;
+    box[8]=rmax;
   }
-  box[0]=rmax;
-  box[1]=0.0;
-  box[2]=0.0;
-  box[3]=0.0;
-  box[4]=rmax;
-  box[5]=0.0;
-  box[6]=0.0;
-  box[7]=0.0;
-  box[8]=rmax;
+};
 
-}
+/// This FCC is contained in a orthogonal cubic box
+///
+/// Fun facts: full cubes at 4, 32, 108, 256, 500 atoms and so on.
+///
+/// At certain sizes above the ones above (36, 504), you get
+/// good (100) slabs quite separated on th z axis
+struct inscribedFaceCenteredCubic:public AtomDistribution {
+  static constexpr auto id="ifcc";
+  static constexpr auto doc="FCC, but in a cubic box";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned /*step*/,
+             Random& rng) override {
+    //Here we are exploiting a litte trick:
+    // if you remove the even or odd atoms from a simple cubic built with our algorithm,
+    //you get an fcc boxed in a cube
+    const unsigned rmax = [&] {
+      auto x = ceiledPerfectCube(2*posToUpdate.size());
+      //rmax needs to be even for this trick to work
+      if ( x%2==0) {
+        return x;
+      } else {
+        return x+1;
+      }
 
-void inscribedFaceCenteredCubic::frame(View<Vector> posToUpdate,
-                                       View<double,9> box,
-                                       unsigned /*step*/,
-                                       Random& rng) {
-  //Here we are exploiting a litte trick:
-  // if you remove the even or odd atoms from a simple cubic built with our algorithm,
-  //you get an fcc boxed in a cube
-  const unsigned rmax = [&] {
-    auto x = ceiledPerfectCube(2*posToUpdate.size());
-    //rmax needs to be even for this trick to work
-    if ( x%2==0) {
-      return x;
-    } else {
-      return x+1;
-    }
+    }();
 
-  }();
-
-  auto s=posToUpdate.begin();
-  auto e=posToUpdate.end();
-  //I am using the iterators:this is slightly faster,
-  // enough to overcome the cost of the vtable that I added
-  for (unsigned k=0; k<rmax&&s!=e; ++k) {
-    for (unsigned j=0; j<rmax&&s!=e; ++j) {
-      //we choose to show only the atoms with even index: (i+j+k)%2
-      //Like this we skip steps and lots of divisions
-      for (unsigned i=(j+k)%2; i<rmax&&s!=e; i+=2) {
-        *s = 0.5*Vector (i,j,k);
-        ++s;
+    auto s=posToUpdate.begin();
+    auto e=posToUpdate.end();
+    //I am using the iterators:this is slightly faster,
+    // enough to overcome the cost of the vtable that I added
+    for (unsigned k=0; k<rmax&&s!=e; ++k) {
+      for (unsigned j=0; j<rmax&&s!=e; ++j) {
+        //we choose to show only the atoms with even index: (i+j+k)%2
+        //Like this we skip steps and lots of divisions
+        for (unsigned i=(j+k)%2; i<rmax&&s!=e; i+=2) {
+          *s = 0.5*Vector (i,j,k);
+          ++s;
+        }
       }
     }
+    box[0]=0.5*rmax;
+    box[1]=0.0;
+    box[2]=0.0;
+    box[3]=0.0;
+    box[4]=0.5*rmax;
+    box[5]=0.0;
+    box[6]=0.0;
+    box[7]=0.0;
+    box[8]=0.5*rmax;
   }
-  box[0]=0.5*rmax;
-  box[1]=0.0;
-  box[2]=0.0;
-  box[3]=0.0;
-  box[4]=0.5*rmax;
-  box[5]=0.0;
-  box[6]=0.0;
-  box[7]=0.0;
-  box[8]=0.5*rmax;
+};
 
-}
+/// This FCC is contained in a "standard" FCC box
+struct tiledFaceCenteredCubic:public AtomDistribution {
+  static constexpr auto id="fcc";
+  static constexpr auto doc="Face Centered Cubic";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned /*step*/,
+             Random& rng) override {
 
-void tiledFaceCenteredCubic::frame(View<Vector> posToUpdate,
-                                   View<double,9> box,
-                                   unsigned /*step*/,
-                                   Random& rng) {
+    const unsigned rmax =ceiledPerfectCube(posToUpdate.size());
 
-  const unsigned rmax =ceiledPerfectCube(posToUpdate.size());
-
-  auto s=posToUpdate.begin();
-  auto e=posToUpdate.end();
+    auto s=posToUpdate.begin();
+    auto e=posToUpdate.end();
 #define X PLMD::Versors::xp<double>
 #define Y PLMD::Versors::yp<double>
 #define Z PLMD::Versors::zp<double>
-  const auto a=sqrt(2)*0.5*(X+Y);
-  const auto b=sqrt(2)*0.5*(X+Z);
-  const auto c=sqrt(2)*0.5*(Y+Z);
+    const auto a=sqrt(2)*0.5*(X+Y);
+    const auto b=sqrt(2)*0.5*(X+Z);
+    const auto c=sqrt(2)*0.5*(Y+Z);
 #undef X
 #undef Y
 #undef Z
-  //I am using the iterators:this is slightly faster,
-  // enough to overcome the cost of the vtable that I added
-  for (unsigned k=0; k<rmax&&s!=e; ++k) {
-    for (unsigned j=0; j<rmax&&s!=e; ++j) {
-      for (unsigned i=0; i<rmax&&s!=e; ++i) {
-        *s = i*a
-             +j*b
-             +k*c;
-        ++s;
+    //I am using the iterators:this is slightly faster,
+    // enough to overcome the cost of the vtable that I added
+    for (unsigned k=0; k<rmax&&s!=e; ++k) {
+      for (unsigned j=0; j<rmax&&s!=e; ++j) {
+        for (unsigned i=0; i<rmax&&s!=e; ++i) {
+          *s = i*a
+               +j*b
+               +k*c;
+          ++s;
+        }
       }
     }
+
+    box.subview<0,3>() = a*rmax;
+    box.subview<3,3>() = b*rmax;
+    box.subview<6,3>() = c*rmax;
   }
+};
 
-  box.subview<0,3>() = a*rmax;
-  box.subview<3,3>() = b*rmax;
-  box.subview<6,3>() = c*rmax;
+/// This BCC is contained in a "standard" FCC box
+struct tiledBodyCenteredCubic:public AtomDistribution {
+  static constexpr auto id="bcc";
+  static constexpr auto doc="Body Centered Cubic";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned /*step*/,
+             Random& rng) override {
+    //For the base functionality of this see the comment in the tiledSimpleCubic
 
-}
+    const unsigned rmax =ceiledPerfectCube(posToUpdate.size());
 
-void tiledBodyCenteredCubic::frame(View<Vector> posToUpdate,
-                                   View<double,9> box,
-                                   unsigned /*step*/,
-                                   Random& rng) {
-  //For the base functionality of this see the comment in the tiledSimpleCubic
-
-  const unsigned rmax =ceiledPerfectCube(posToUpdate.size());
-
-  auto s=posToUpdate.begin();
-  auto e=posToUpdate.end();
+    auto s=posToUpdate.begin();
+    auto e=posToUpdate.end();
 #define X PLMD::Versors::xp<double>
 #define Y PLMD::Versors::yp<double>
 #define Z PLMD::Versors::zp<double>
-  const auto a=0.5*(-X+Y+Z);
-  const auto b=0.5*( X-Y+Z);
-  const auto c=0.5*( X+Y-Z);
+    const auto a=0.5*(-X+Y+Z);
+    const auto b=0.5*( X-Y+Z);
+    const auto c=0.5*( X+Y-Z);
 #undef X
 #undef Y
 #undef Z
-  //I am using the iterators:this is slightly faster,
-  // enough to overcome the cost of the vtable that I added
-  for (unsigned k=0; k<rmax&&s!=e; ++k) {
-    for (unsigned j=0; j<rmax&&s!=e; ++j) {
-      for (unsigned i=0; i<rmax&&s!=e; ++i) {
-        *s = i*a
-             +j*b
-             +k*c;
-        ++s;
+    //I am using the iterators:this is slightly faster,
+    // enough to overcome the cost of the vtable that I added
+    for (unsigned k=0; k<rmax&&s!=e; ++k) {
+      for (unsigned j=0; j<rmax&&s!=e; ++j) {
+        for (unsigned i=0; i<rmax&&s!=e; ++i) {
+          *s = i*a
+               +j*b
+               +k*c;
+          ++s;
+        }
       }
     }
+
+    box.subview<0,3>() = a*rmax;
+    box.subview<3,3>() = b*rmax;
+    box.subview<6,3>() = c*rmax;
   }
+};
 
-  box.subview<0,3>() = a*rmax;
-  box.subview<3,3>() = b*rmax;
-  box.subview<6,3>() = c*rmax;
+/// This BCC is contained in a orthogonal cubic box
+struct inscribedBodyCenteredCubic:public AtomDistribution {
+  static constexpr auto id="ibcc";
+  static constexpr auto doc="BCC, but in a cubic box";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned /*step*/,
+             Random& rng) override {
+    //Here we are exploiting a litte trick:
+    // if you remove the even or odd atoms from a simple cubic built with our algorithm,
+    //you get an bcc boxed in a cube
+    const unsigned rmax = [&] {
+      //we take one atoms every 4
+      auto x = ceiledPerfectCube(4*posToUpdate.size());
+      //rmax needs to be even for this trick to work
+      if ( x%2==0) {
+        return x;
+      } else {
+        return x+1;
+      }
 
-}
+    }();
 
-void inscribedBodyCenteredCubic::frame(View<Vector> posToUpdate,
-                                       View<double,9> box,
-                                       unsigned /*step*/,
-                                       Random& rng) {
-  //Here we are exploiting a litte trick:
-  // if you remove the even or odd atoms from a simple cubic built with our algorithm,
-  //you get an bcc boxed in a cube
-  const unsigned rmax = [&] {
-    //we take one atoms every 4
-    auto x = ceiledPerfectCube(4*posToUpdate.size());
-    //rmax needs to be even for this trick to work
-    if ( x%2==0) {
-      return x;
-    } else {
-      return x+1;
-    }
-
-  }();
-
-  auto s=posToUpdate.begin();
-  auto e=posToUpdate.end();
-  //I am using the iterators:this is slightly faster,
-  // enough to overcome the cost of the vtable that I added
-  for (unsigned k=0; k<rmax&&s!=e; ++k) {
-    //we alternate on the z axis the choice between atoms with both i and j even or odd
-    //The +=2 skips an extra check in the inner body
-    for (unsigned j=k%2; j<rmax&&s!=e; j+=2) {
-      for (unsigned i=k%2; i<rmax&&s!=e; i+=2) {
-        *s = 0.5*Vector (i,j,k);
-        ++s;
+    auto s=posToUpdate.begin();
+    auto e=posToUpdate.end();
+    //I am using the iterators:this is slightly faster,
+    // enough to overcome the cost of the vtable that I added
+    for (unsigned k=0; k<rmax&&s!=e; ++k) {
+      //we alternate on the z axis the choice between atoms with both i and j even or odd
+      //The +=2 skips an extra check in the inner body
+      for (unsigned j=k%2; j<rmax&&s!=e; j+=2) {
+        for (unsigned i=k%2; i<rmax&&s!=e; i+=2) {
+          *s = 0.5*Vector (i,j,k);
+          ++s;
+        }
       }
     }
+    box[0]=0.5*rmax;
+    box[1]=0.0;
+    box[2]=0.0;
+    box[3]=0.0;
+    box[4]=0.5*rmax;
+    box[5]=0.0;
+    box[6]=0.0;
+    box[7]=0.0;
+    box[8]=0.5*rmax;
   }
-  box[0]=0.5*rmax;
-  box[1]=0.0;
-  box[2]=0.0;
-  box[3]=0.0;
-  box[4]=0.5*rmax;
-  box[5]=0.0;
-  box[6]=0.0;
-  box[7]=0.0;
-  box[8]=0.5*rmax;
+};
 
+
+///a decorator for replicating the atomic distribution
+class repliedTrajectory: public AtomDistribution {
+  std::unique_ptr<AtomDistribution> distribution;
+  unsigned rX=1;
+  unsigned rY=1;
+  unsigned rZ=1;
+public:
+  static constexpr auto id="reply";
+  static constexpr auto doc=R"=(replicate the box by the given in all the directions:
+usage (must be used with 3 paramenters):
+ reply x y z
+)=";
+
+  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
+    std::string_view cmd) {
+  unpackedLine lines;
+  Tools::getWordsSimple(lines,cmd);
+  unsigned repeatX;
+  unsigned repeatY;
+  unsigned repeatZ;
+  plumed_assert(lines.size() ==4) << id << " supports exacly three inputs: x y z";
+
+  Tools::convert(std::string(lines[1]),repeatX);
+  Tools::convert(std::string(lines[2]),repeatY);
+  Tools::convert(std::string(lines[3]),repeatZ);
+  return std::make_unique<repliedTrajectory>(std::move(d),
+         repeatX,
+         repeatY,
+         repeatZ);
 }
 
-void fileTraj::rewind() {
-  auto errormessage=parser.rewind();
-  if (errormessage) {
-    // A workarounf for not implemented rewind is to dump the trajectory in an xyz and then read that
-    plumed_error()<<*errormessage;
-  }
-  //the extra false prevents an infinite loop in case of unexpected consecutice EOFs after a rewind
-  step(false);
-}
-
-//read the next step
-void fileTraj::step(bool doRewind) {
-  read=false;
-  long long int mystep=0;
-  double timeStep;
-  std::optional<std::string> errormessage;
-  if (masses.empty()) {
-    errormessage=parser.readHeader(
-                   mystep,
-                   timeStep
-                 );
-    if (errormessage) {
-      plumed_error()<<*errormessage;
-    }
-    const size_t natoms = parser.nOfAtoms();
-
-    masses.assign(natoms,0.0);
-    charges.assign(natoms,0.0);
-    coordinates.assign(natoms,Vector(0.0,0.0,0.0));
-    cell.assign(9,0.0);
-    errormessage=parser.readAtoms(1,
-                                  dont_read_pbc,
-                                  false,
-                                  0,
-                                  0,
-                                  mystep,
-                                  masses.data(),
-                                  charges.data(),
-                                  &coordinates[0][0],
-                                  cell.data()
-                                 );
-  } else {
-    errormessage=parser.readFrame(1,
-                                  dont_read_pbc,
-                                  false,
-                                  0,
-                                  0,
-                                  mystep,
-                                  timeStep,
-                                  masses.data(),
-                                  charges.data(),
-                                  &coordinates[0][0],
-                                  cell.data()
-                                 );
-  }
-
-  if (errormessage) {
-    if (*errormessage =="EOF" && doRewind) {
-      rewind();
-    } else {
-      plumed_error()<<*errormessage;
-    }
-  }
-}
-
-void fileTraj::frame(View<Vector> posToUpdate,
-                     View<double,9> box,
-                     unsigned /*step*/,
-                     Random& /*rng*/) {
-  if (read) {
-    step();
-  }
-  read=true;
-  std::copy(coordinates.begin(),coordinates.end(),posToUpdate.begin());
-  std::copy(cell.begin(),cell.end(),box.begin());
-}
-
-fileTraj::fileTraj(std::string_view fmt,
-                   std::string_view fname,
-                   bool useMolfile,
-                   int command_line_natoms) {
-  parser.init(fmt,
-              fname,
-              useMolfile,
-              command_line_natoms);
-  step();
-}
-
-bool fileTraj::overrideNat(unsigned& natoms) {
-  natoms = masses.size();
-  return true;
-}
-
-//Replicate
-repliedTrajectory::repliedTrajectory(std::unique_ptr<AtomDistribution>&& d,
-                                     const unsigned repeatX,
-                                     const unsigned repeatY,
-                                     const unsigned repeatZ,
-                                     const unsigned nat):
+  repliedTrajectory(std::unique_ptr<AtomDistribution>&& d,
+                    const unsigned repeatX,
+                    const unsigned repeatY,
+                    const unsigned repeatZ) :
   distribution(std::move(d)),
   rX(repeatX),
   rY(repeatY),
   rZ(repeatZ)
 {}
 
-void repliedTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
-                              unsigned step,
-                              Random& rng) {
+///Generates the inner trajectory of `(nat)/(rX*rY*rZ)`, where `nat` is the dimension of the vector view, then it replicate the atoms in the various directions
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned step,
+             Random& rng) override {
   plumed_assert((posToUpdate.size() % (rX*rY*rZ)==0));
   const auto nat = posToUpdate.size()/(rX*rY*rZ);
   auto coordinates=posToUpdate.subview(0,nat);
@@ -644,43 +514,50 @@ void repliedTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
   box[8]*=rZ;
 }
 
-bool repliedTrajectory::overrideNat(unsigned& natoms) {
+///See the documentation the AtomDistribution
+  bool overrideNat(unsigned& natoms) override {
   distribution->overrideNat(natoms);
   natoms *= (rX*rY*rZ);
   return true;
 }
+};
 
-std::unique_ptr<AtomDistribution> repliedTrajectory::decorate(std::unique_ptr<AtomDistribution>&& d,
+///a decorator for scaling the atomic positions
+class scaledTrajectory: public AtomDistribution {
+  std::unique_ptr<AtomDistribution> distribution;
+  double multiplier;
+public:
+  static constexpr auto id="scale";
+  static constexpr auto doc=R"=(scales the atoms by a certain amount
+usage:
+ scale (optional: mults=2.0)
+)=";
+
+  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
     std::string_view cmd) {
   unpackedLine lines;
   Tools::getWordsSimple(lines,cmd);
-  unsigned repeatX;
-  unsigned repeatY;
-  unsigned repeatZ;
-  plumed_assert(lines.size() ==4) << id << " supports exacly three inputs: x y z";
+  plumed_assert(lines.size() <=2) << id << " supports maximum one input";
+  if (lines.size()==2) {
+    double mult=2.0;
+    Tools::convert(std::string(lines[1]), mult);
+    return std::make_unique<scaledTrajectory>(std::move(d),mult);
+  }
 
-  Tools::convert(std::string(lines[1]),repeatX);
-  Tools::convert(std::string(lines[2]),repeatY);
-  Tools::convert(std::string(lines[3]),repeatZ);
-  return std::make_unique<repliedTrajectory>(std::move(d),
-         repeatX,
-         repeatY,
-         repeatZ);
+  //the default value is specified in the header
+  return std::make_unique<scaledTrajectory>(std::move(d));
 }
 
-//Scale
-scaledTrajectory::scaledTrajectory(std::unique_ptr<AtomDistribution>&& d,
-                                   const double mult):
+  scaledTrajectory(std::unique_ptr<AtomDistribution>&& d,
+		   double mult=2.0):
   distribution(std::move(d)),
   multiplier(mult)
 {}
 
-bool scaledTrajectory::overrideNat(unsigned& natoms) {
-  return distribution->overrideNat(natoms);
-}
-void scaledTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
-                             unsigned step,
-                             Random& rng) {
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned step,
+             Random& rng) override {
   distribution->frame(posToUpdate,box,step,rng);
 
   for (auto& p:posToUpdate) {
@@ -692,42 +569,25 @@ void scaledTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
   }
 }
 
-std::unique_ptr<AtomDistribution> scaledTrajectory::decorate(std::unique_ptr<AtomDistribution>&& d,
-    std::string_view cmd) {
-  unpackedLine lines;
-  Tools::getWordsSimple(lines,cmd);
-  plumed_assert(lines.size() <=2) << id << " supports maximum one input";
-  if (lines.size()==2) {
-    double mult=2.0;
-    Tools::convert(std::string(lines[1]), mult);
-    return std::make_unique<scaledTrajectory>(std::move(d),mult);
-  }
-  //the default value is specified in the header
-  return std::make_unique<scaledTrajectory>(std::move(d));
-}
-
-//Wiggle
-wiggleTrajectory::wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,
-                                   const double amount):
-  distribution(std::move(d)),
-  radius(amount)
-{}
-
-bool wiggleTrajectory::overrideNat(unsigned& natoms) {
+	bool overrideNat(unsigned& natoms) override {
   return distribution->overrideNat(natoms);
 }
-void wiggleTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
-                             unsigned step,
-                             Random& rng) {
-  distribution->frame(posToUpdate,box,step,rng);
+};
 
-  UniformSphericalVector usv(radius);
-  for (auto& v: posToUpdate) {
-    v+= usv(rng);
-  }
-}
 
-std::unique_ptr<AtomDistribution> wiggleTrajectory::decorate(std::unique_ptr<AtomDistribution>&& d,
+
+/// A decorator for displacing the atoms from the generated underline distribution
+class wiggleTrajectory: public AtomDistribution {
+  std::unique_ptr<AtomDistribution> distribution;
+  double radius;
+public:
+  static constexpr auto id="wiggle";
+  static constexpr auto doc=R"=(displaces all the atoms by a certain amunt
+usage:
+ wiggle (optional: sphere radius=0.1)
+)=";
+  static std::unique_ptr<AtomDistribution> decorate(
+		std::unique_ptr<AtomDistribution>&& d,
     std::string_view cmd) {
   unpackedLine lines;
   Tools::getWordsSimple(lines,cmd);
@@ -741,56 +601,309 @@ std::unique_ptr<AtomDistribution> wiggleTrajectory::decorate(std::unique_ptr<Ato
   return std::make_unique<wiggleTrajectory>(std::move(d));
 }
 
-//ForceBox
-forceBoxTrajectory::forceBoxTrajectory(std::unique_ptr<AtomDistribution>&& d,
-                                       std::array<double,9> mybox):
+  wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,
+		   double amount=0.1) :
   distribution(std::move(d)),
-  fixedbox(mybox)
+  radius(amount)
 {}
 
-bool forceBoxTrajectory::overrideNat(unsigned& natoms) {
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned step,
+             Random& rng) override {
+  distribution->frame(posToUpdate,box,step,rng);
+
+  UniformSphericalVector usv(radius);
+  for (auto& v: posToUpdate) {
+    v+= usv(rng);
+  }
+}
+  bool overrideNat(unsigned& natoms) override {
   return distribution->overrideNat(natoms);
 }
-void forceBoxTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
-                               unsigned step,
-                               Random& rng) {
-  distribution->frame(posToUpdate,box,step,rng);
-  box[0] = fixedbox[0];
-  box[1] = fixedbox[1];
-  box[2] = fixedbox[2];
-  box[3] = fixedbox[3];
-  box[4] = fixedbox[4];
-  box[5] = fixedbox[5];
-  box[6] = fixedbox[6];
-  box[7] = fixedbox[7];
-  box[8] = fixedbox[8];
+};
+
+
+
+/// A decorator for forcing a box in the trajectory
+class forceBoxTrajectory: public AtomDistribution {
+  std::unique_ptr<AtomDistribution> distribution;
+  std::array<double,9> fixedbox;
+public:
+  static constexpr auto id="box";
+  static constexpr auto doc=R"=(Forces a box on the atom distribution
+usage:
+ "box xx yy zz"
+or
+ "box xx xy xy yx yy yz zx zy zz")=";
+
+  static std::unique_ptr<AtomDistribution> decorate(
+    std::unique_ptr<AtomDistribution>&& d,
+    std::string_view cmd) {
+    unpackedLine lines;
+    Tools::getWordsSimple(lines,cmd);
+    plumed_assert(lines.size() == 4 || lines.size() == 10) << id << " supports either 3 or 9 numbers as input";
+    std::array<double,9> newBox= {0.0,0.0,0.0,
+                                  0.0,0.0,0.0,
+                                  0.0,0.0,0.0
+                                 };
+    if (lines.size()==4) {
+      Tools::convert(std::string(lines[1]), newBox[0]);
+      Tools::convert(std::string(lines[2]), newBox[4]);
+      Tools::convert(std::string(lines[3]), newBox[8]);
+    } else {// we now is 9
+      Tools::convert(std::string(lines[1]), newBox[0]);
+      Tools::convert(std::string(lines[2]), newBox[1]);
+      Tools::convert(std::string(lines[3]), newBox[2]);
+      Tools::convert(std::string(lines[4]), newBox[3]);
+      Tools::convert(std::string(lines[5]), newBox[4]);
+      Tools::convert(std::string(lines[6]), newBox[5]);
+      Tools::convert(std::string(lines[7]), newBox[6]);
+      Tools::convert(std::string(lines[8]), newBox[7]);
+      Tools::convert(std::string(lines[9]), newBox[8]);
+    }
+    //the default value is specified in the header
+    return std::make_unique<forceBoxTrajectory>(std::move(d),newBox);
+  }
+  forceBoxTrajectory(std::unique_ptr<AtomDistribution>&& d,
+                     std::array<double,9> mybox):
+    distribution(std::move(d)),
+    fixedbox(mybox)
+  {}
+
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned step,
+             Random& rng) override {
+    distribution->frame(posToUpdate,box,step,rng);
+    box[0] = fixedbox[0];
+    box[1] = fixedbox[1];
+    box[2] = fixedbox[2];
+    box[3] = fixedbox[3];
+    box[4] = fixedbox[4];
+    box[5] = fixedbox[5];
+    box[6] = fixedbox[6];
+    box[7] = fixedbox[7];
+    box[8] = fixedbox[8];
+  }
+
+  bool overrideNat(unsigned& natoms) override {
+    return distribution->overrideNat(natoms);
+  }
+};
+
+//****************************Helpers and managements***************************
+
+
+namespace ADHelpers {
+//How to use this:
+//
+//The following variants act as "registers" for the distributions and the decorators
+//
+//To register a new distribution, siply write the struct in the file above
+//then add it to the rigth list
+//
+//Distributions and decorators must have a declared
+//`constexpr auto id="name"` and `constexpr auto doc="documentation"` members,
+//to be correcly listed and parsed
+//
+//To work a distribution simply needs to have a frame method, and no constructor.
+//
+//To add a complex distribution that needs a constructor you need to
+//do some more work like the file one, in its own source AtomDistributionFiles.cpp/h.
+//It is still compatible with the decorators.
+//
+//The decorators needs some more work:
+//a decorator needs to store the unique_ptr of the distribution that modifies
+//a decorator may need to store some extra settings
+//a decorator needs a static method "decorate"
+//  that accepts a rvalue unique_ptr of the distribution that it will modify,
+//  and a string of data to be parsed,
+//  this method will return a unique_ptr with the modified distribution.
+//  Note that the decorator will be the new owner of the original distribution pointer
+//  and that the command string will contain the declared id of the decorator ("id settings")
+//a decorator will needd to override the overrideNat method, ideally only like this:
+//```
+//bool forceBoxTrajectory::overrideNat(unsigned& natoms) {
+//  return distribution->overrideNat(natoms);
+//}
+//```
+//  To propagate the changes in the number of atoms by all the decorators
+//  applied to a distribution, it can be more complex (like in "reply")
+//a decorator must overload the frame method, and call the one of the
+//  stored distribution and eventually modify the results of it
+//
+//Note that as time of writing this, there is no check implemented to verify
+// if two distributuin have the same id
+
+//add a new base distribution here, and the compiler will automagically
+//set up the parser and the documentation for you with some template shenanigans
+using baseDistributions = std::variant<
+                          theLine,
+                          uniformCube,
+                          uniformSphere,
+                          twoGlobs,
+                          tiledSimpleCubic,
+                          tiledBodyCenteredCubic,
+                          tiledFaceCenteredCubic,
+                          inscribedBodyCenteredCubic,
+                          inscribedFaceCenteredCubic>;
+
+//add new decorators here:
+using decoratorDistribuitions = std::variant<
+                                repliedTrajectory,
+                                scaledTrajectory,
+                                wiggleTrajectory,
+                                forceBoxTrajectory>;
+
+template <size_t I=0>
+std::optional<std::unique_ptr<AtomDistribution>> getAD(std::string_view atomicDistr) {
+  if constexpr ( I < std::variant_size_v<baseDistributions>) {
+    using myAD=typename std::variant_alternative_t<I,baseDistributions>;
+    if (atomicDistr==myAD::id) {
+      return std::make_unique<myAD>();
+    }
+    return getAD<I+1>(atomicDistr);
+  }
+  return std::nullopt;
 }
 
-std::unique_ptr<AtomDistribution> forceBoxTrajectory::decorate(std::unique_ptr<AtomDistribution>&& d,
-    std::string_view cmd) {
-  unpackedLine lines;
-  Tools::getWordsSimple(lines,cmd);
-  plumed_assert(lines.size() == 4 || lines.size() == 10) << id << " supports either 3 or 9 numbers as input";
-  std::array<double,9> newBox= {0.0,0.0,0.0,
-                                0.0,0.0,0.0,
-                                0.0,0.0,0.0
-                               };
-  if (lines.size()==4) {
-    Tools::convert(std::string(lines[1]), newBox[0]);
-    Tools::convert(std::string(lines[2]), newBox[4]);
-    Tools::convert(std::string(lines[3]), newBox[8]);
-  } else {// we now is 9
-    Tools::convert(std::string(lines[1]), newBox[0]);
-    Tools::convert(std::string(lines[2]), newBox[1]);
-    Tools::convert(std::string(lines[3]), newBox[2]);
-    Tools::convert(std::string(lines[4]), newBox[3]);
-    Tools::convert(std::string(lines[5]), newBox[4]);
-    Tools::convert(std::string(lines[6]), newBox[5]);
-    Tools::convert(std::string(lines[7]), newBox[6]);
-    Tools::convert(std::string(lines[8]), newBox[7]);
-    Tools::convert(std::string(lines[9]), newBox[8]);
+using parser=std::function<std::unique_ptr<AtomDistribution>(std::unique_ptr<AtomDistribution>&& d,
+             std::string_view cmd)>;
+
+template <size_t I=0>
+std::optional<parser> getDecorator( std::string_view decoratorDistr) {
+  if constexpr ( I < std::variant_size_v<decoratorDistribuitions>) {
+    auto name=decoratorDistr.substr(0,decoratorDistr.find(' '));
+    using myAD=typename std::variant_alternative_t<I,decoratorDistribuitions>;
+    if (name==myAD::id) {
+      return myAD::decorate;
+    }
+    return getDecorator<I+1>(decoratorDistr);
   }
-  //the default value is specified in the header
-  return std::make_unique<forceBoxTrajectory>(std::move(d),newBox);
+  return std::nullopt;
 }
+
+template <size_t I=0>
+void getDistributionList(std::vector<std::string>& list) {
+  if constexpr ( I < std::variant_size_v<baseDistributions>) {
+    using myAD=typename std::variant_alternative_t<I,baseDistributions>;
+    list.push_back(myAD::id);
+    getDistributionList<I+1>(list);
+  }
+}
+
+template <size_t I=0>
+void getDistributionDocumentation( std::vector<AtomDistribution::documentation>& list) {
+  if constexpr ( I < std::variant_size_v<baseDistributions>) {
+    using myAD=typename std::variant_alternative_t<I,baseDistributions>;
+    list.push_back({myAD::id,myAD::doc});
+    getDistributionDocumentation<I+1>(list);
+  }
+}
+
+template <size_t I=0>
+void getDecoratorList(std::vector<std::string>& list) {
+  if constexpr ( I < std::variant_size_v<decoratorDistribuitions>) {
+    using myAD=typename std::variant_alternative_t<I,decoratorDistribuitions>;
+    list.push_back(myAD::id);
+    getDecoratorList<I+1>(list);
+  }
+}
+
+template <size_t I=0>
+void getDecoratorDocumentation(std::vector<AtomDistribution::documentation>& list) {
+  if constexpr ( I < std::variant_size_v<decoratorDistribuitions>) {
+    using myAD=typename std::variant_alternative_t<I,decoratorDistribuitions>;
+    list.push_back({myAD::id,myAD::doc});
+    getDecoratorDocumentation<I+1>(list);
+  }
+}
+
+std::string getDistributionList_forError() {
+  auto list = AtomDistribution::getDistributionList();
+  std::string toRet="";
+  std::string pre="\"";
+  for (const auto & distr:list) {
+    toRet += pre+distr+ "\"";
+    pre=", \"";
+  }
+  return toRet;
+}
+
+std::string getDecoratorList_forError() {
+  auto list = AtomDistribution::getDecoratorsList();
+  std::string toRet="";
+  std::string pre="\"";
+  for (const auto& distr:list) {
+    toRet += pre+distr+ "\"";
+    pre=", \"";
+  }
+  return toRet;
+}
+} // namespace ADHelpers
+
+std::unique_ptr<AtomDistribution> AtomDistribution::getAtomDistribution(std::string_view atomicDistr) {
+  auto pipePos = atomicDistr.find("|");
+  auto base=atomicDistr.substr(0,pipePos);
+  std::unique_ptr<AtomDistribution> distribution;
+  if(auto d = ADHelpers::getAD(base); d) {
+    distribution = std::move(*d);
+  } else {
+    plumed_error() << "The atomic distribution can be only "<<ADHelpers::getDistributionList_forError()
+                   << ", but the input was \""
+                   << base <<'"';
+  }
+  if (pipePos != std::string_view::npos) {
+    return decorateAtomDistribution(std::move(distribution),
+                                    atomicDistr.substr(pipePos+1));
+  }
+  return distribution;
+}
+
+std::unique_ptr<AtomDistribution> AtomDistribution::decorateAtomDistribution(
+  std::unique_ptr<AtomDistribution> && ad,
+  std::string_view decoratorDistr) {
+  unpackedLine lines;
+  Tools::getWordsSimple(lines,decoratorDistr,"|");
+  std::unique_ptr<AtomDistribution> distribution=std::move(ad);
+  for(auto i=0u; i < lines.size(); ++i) {
+    auto decorator=ADHelpers::getDecorator(lines[i]);
+    if (decorator) {
+      auto tmp=std::move(distribution);
+      distribution = (*decorator)(std::move(tmp),lines[i]);
+    } else {
+
+      plumed_error() << "The atomic distribution decorators be only "<<ADHelpers::getDecoratorList_forError()
+                     << ", but the input was \""
+                     << lines[i] <<'"';
+    }
+
+  }
+  return distribution;
+}
+
+std::vector<std::string> AtomDistribution::getDistributionList() {
+  std::vector<std::string> list;
+  ADHelpers::getDistributionList(list);
+  return list;
+}
+std::vector<AtomDistribution::documentation> AtomDistribution::getDistributionDocumentation() {
+  std::vector<documentation> list;
+  ADHelpers::getDistributionDocumentation(list);
+  return list;
+}
+
+std::vector<std::string> AtomDistribution::getDecoratorsList() {
+  std::vector<std::string> list;
+  ADHelpers::getDecoratorList(list);
+  return list;
+}
+
+std::vector<AtomDistribution::documentation> AtomDistribution::getDecoratorsDocumentation() {
+  std::vector<documentation> list;
+  ADHelpers::getDecoratorDocumentation(list);
+  return list;
+}
+
 } //namespace PLMD

--- a/src/tools/AtomDistribution.cpp
+++ b/src/tools/AtomDistribution.cpp
@@ -584,4 +584,24 @@ void scaledTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
     b*=multiplier;
   }
 }
+
+wiggleTrajectory::wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,
+                                   const double amount):
+  distribution(std::move(d)),
+  radius(amount)
+{}
+
+bool wiggleTrajectory::overrideNat(unsigned& natoms) {
+  return distribution->overrideNat(natoms);
+}
+void wiggleTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
+                             unsigned step,
+                             Random& rng) {
+  distribution->frame(posToUpdate,box,step,rng);
+
+  UniformSphericalVector usv(radius);
+  for (auto& v: posToUpdate) {
+    v+= usv(rng);
+  }
+}
 } //namespace PLMD

--- a/src/tools/AtomDistribution.cpp
+++ b/src/tools/AtomDistribution.cpp
@@ -70,13 +70,12 @@ struct theLine:public AtomDistribution {
   static constexpr auto doc="A line of atoms, that wiggles randomly at each step";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
-             unsigned step,
-             Random& rng) override {
+             unsigned /*step*/,
+             Random& /*rng*/) override {
     auto nat = posToUpdate.size();
-    UniformSphericalVector usv(0.5);
 
     for (unsigned i=0; i<nat; ++i) {
-      posToUpdate[i] = Vector(i, 0, 0) + usv(rng);
+      posToUpdate[i] = Vector(i, 0, 0);
     }
     box[0]=nat;
     box[1]=0.0;

--- a/src/tools/AtomDistribution.cpp
+++ b/src/tools/AtomDistribution.cpp
@@ -20,38 +20,124 @@
    along with plumed.  If not, see <http://www.gnu.org/licenses/>.
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
 #include "AtomDistribution.h"
+#include "Exception.h"
 #include "View.h"
 #include <cassert>
+#include <memory>
+#include <variant>
+#include <optional>
+#include <functional>
 
 namespace PLMD {
 
+using unpackedLine=gch::small_vector<std::string_view>;
+
+namespace ADHelpers {
+//add a new base distribution here, and the compiler will automagically
+//set up the parser for you
+using baseDistributions = std::variant<
+                          theLine,
+                          uniformCube,
+                          uniformSphere,
+                          twoGlobs,
+                          tiledSimpleCubic,
+                          tiledBodyCenteredCubic,
+                          tiledFaceCenteredCubic,
+                          inscribedBodyCenteredCubic,
+                          inscribedFaceCenteredCubic>;
+//add new decorators here:
+using decoratorDistribuitions = std::variant<
+                                repliedTrajectory,
+                                scaledTrajectory,
+                                wiggleTrajectory>;
+
+template <size_t I=0>
+std::optional<std::unique_ptr<AtomDistribution>> getAD(std::string_view atomicDistr) {
+  if constexpr ( I < std::variant_size_v<baseDistributions>) {
+    using myAD=typename std::variant_alternative_t<I,baseDistributions>;
+    if (atomicDistr==myAD::id) {
+      return std::make_unique<myAD>();
+    }
+    return getAD<I+1>(atomicDistr);
+  }
+  return std::nullopt;
+}
+
+template <size_t I=0>
+std::string getBaseList(std::string init="") {
+  if constexpr ( I < std::variant_size_v<baseDistributions>) {
+    using myAD=typename std::variant_alternative_t<I,baseDistributions>;
+    return init + "\"" + myAD::id + "\""+ getBaseList<I+1>(", ");
+  }
+  return "";
+}
+
+template <size_t I=0>
+std::string getDecoratorList(std::string init="") {
+  if constexpr ( I < std::variant_size_v<decoratorDistribuitions>) {
+    using myAD=typename std::variant_alternative_t<I,decoratorDistribuitions>;
+    return init + "\"" + myAD::id + "\""+ getDecoratorList<I+1>(", ");
+  }
+  return "";
+}
+
+using parser=std::function<std::unique_ptr<AtomDistribution>(std::unique_ptr<AtomDistribution>&& d,
+             std::string_view cmd)>;
+
+template <size_t I=0>
+std::optional<parser> getDecorator( std::string_view decoratorDistr) {
+  if constexpr ( I < std::variant_size_v<decoratorDistribuitions>) {
+    auto name=decoratorDistr.substr(0,decoratorDistr.find(' '));
+    using myAD=typename std::variant_alternative_t<I,decoratorDistribuitions>;
+    if (name==myAD::id) {
+      return myAD::decorate;
+    }
+    return getDecorator<I+1>(decoratorDistr);
+  }
+  return std::nullopt;
+}
+} // namespace ADHelpers
+
 std::unique_ptr<AtomDistribution> AtomDistribution::getAtomDistribution(std::string_view atomicDistr) {
+  auto pipePos = atomicDistr.find("|");
+  auto base=atomicDistr.substr(0,pipePos);
   std::unique_ptr<AtomDistribution> distribution;
-  if(atomicDistr == "line") {
-    distribution = std::make_unique<theLine>();
-  } else if (atomicDistr == "cube") {
-    distribution = std::make_unique<uniformCube>();
-  } else if (atomicDistr == "sphere") {
-    distribution = std::make_unique<uniformSphere>();
-  } else if (atomicDistr == "globs") {
-    distribution = std::make_unique<twoGlobs>();
-  } else if (atomicDistr == "sc") {
-    distribution = std::make_unique<tiledSimpleCubic>();
-  } else if (atomicDistr == "ibcc") {
-    distribution = std::make_unique<inscribedBodyCenteredCubic>();
-  } else if (atomicDistr == "bcc") {
-    distribution = std::make_unique<tiledBodyCenteredCubic>();
-  } else if (atomicDistr == "ifcc") {
-    distribution = std::make_unique<inscribedFaceCenteredCubic>();
-  } else if (atomicDistr == "fcc") {
-    distribution = std::make_unique<tiledFaceCenteredCubic>();
+  if(auto d = ADHelpers::getAD(base); d) {
+    distribution = std::move(*d);
   } else {
-    plumed_error() << R"(The atomic distribution can be only "line", "cube", "sphere", "globs", "sc", "ibcc", "bcc", "ifcc",and "fcc", the input was ")"
-                   << atomicDistr <<'"';
+    plumed_error() << "The atomic distribution can be only "<<ADHelpers::getBaseList()
+                   << ", but the input was \""
+                   << base <<'"';
+  }
+  if (pipePos != std::string_view::npos) {
+    return decorateAtomDistribution(std::move(distribution),
+                                    atomicDistr.substr(pipePos+1));
   }
   return distribution;
 }
 
+
+std::unique_ptr<AtomDistribution> AtomDistribution::decorateAtomDistribution(
+  std::unique_ptr<AtomDistribution> && ad,
+  std::string_view decoratorDistr) {
+  unpackedLine lines;
+  Tools::getWordsSimple(lines,decoratorDistr,"|");
+  std::unique_ptr<AtomDistribution> distribution=std::move(ad);
+  for(auto i=0u; i < lines.size(); ++i) {
+    auto decorator=ADHelpers::getDecorator(lines[i]);
+    if (decorator) {
+      auto tmp=std::move(distribution);
+      distribution = (*decorator)(std::move(tmp),lines[i]);
+    } else {
+
+      plumed_error() << "The atomic distribution decorators be only "<<ADHelpers::getDecoratorList()
+                     << ", but the input was \""
+                     << lines[i] <<'"';
+    }
+
+  }
+  return distribution;
+}
 
 void AtomDistribution::frame(std::vector<Vector>& posToUpdate,
                              std::vector<double>& box,
@@ -562,6 +648,24 @@ bool repliedTrajectory::overrideNat(unsigned& natoms) {
   return true;
 }
 
+std::unique_ptr<AtomDistribution> repliedTrajectory::decorate(std::unique_ptr<AtomDistribution>&& d,
+    std::string_view cmd) {
+  unpackedLine lines;
+  Tools::getWordsSimple(lines,cmd);
+  unsigned repeatX;
+  unsigned repeatY;
+  unsigned repeatZ;
+  plumed_assert(lines.size() ==4) << id << " supports exacly three inputs: x y z";
+
+  Tools::convert(std::string(lines[1]),repeatX);
+  Tools::convert(std::string(lines[2]),repeatY);
+  Tools::convert(std::string(lines[3]),repeatZ);
+  return std::make_unique<repliedTrajectory>(std::move(d),
+         repeatX,
+         repeatY,
+         repeatZ);
+}
+
 scaledTrajectory::scaledTrajectory(std::unique_ptr<AtomDistribution>&& d,
                                    const double mult):
   distribution(std::move(d)),
@@ -585,6 +689,20 @@ void scaledTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
   }
 }
 
+std::unique_ptr<AtomDistribution> scaledTrajectory::decorate(std::unique_ptr<AtomDistribution>&& d,
+    std::string_view cmd) {
+  unpackedLine lines;
+  Tools::getWordsSimple(lines,cmd);
+  plumed_assert(lines.size() <=2) << id << " supports maximum one input";
+  if (lines.size()==2) {
+    double mult=2.0;
+    Tools::convert(std::string(lines[1]), mult);
+    return std::make_unique<scaledTrajectory>(std::move(d),mult);
+  }
+  //the default value is specified in the header
+  return std::make_unique<scaledTrajectory>(std::move(d));
+}
+
 wiggleTrajectory::wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,
                                    const double amount):
   distribution(std::move(d)),
@@ -603,5 +721,19 @@ void wiggleTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
   for (auto& v: posToUpdate) {
     v+= usv(rng);
   }
+}
+
+std::unique_ptr<AtomDistribution> wiggleTrajectory::decorate(std::unique_ptr<AtomDistribution>&& d,
+    std::string_view cmd) {
+  unpackedLine lines;
+  Tools::getWordsSimple(lines,cmd);
+  plumed_assert(lines.size() <=2) << id << " supports maximum one input";
+  if (lines.size()==2) {
+    double displacement=0.1;
+    Tools::convert(std::string(lines[1]), displacement);
+    return std::make_unique<wiggleTrajectory>(std::move(d),displacement);
+  }
+  //the default value is specified in the header
+  return std::make_unique<wiggleTrajectory>(std::move(d));
 }
 } //namespace PLMD

--- a/src/tools/AtomDistribution.cpp
+++ b/src/tools/AtomDistribution.cpp
@@ -49,7 +49,8 @@ using baseDistributions = std::variant<
 using decoratorDistribuitions = std::variant<
                                 repliedTrajectory,
                                 scaledTrajectory,
-                                wiggleTrajectory>;
+                                wiggleTrajectory,
+                                forceBoxTrajectory>;
 
 template <size_t I=0>
 std::optional<std::unique_ptr<AtomDistribution>> getAD(std::string_view atomicDistr) {
@@ -586,6 +587,7 @@ bool fileTraj::overrideNat(unsigned& natoms) {
   return true;
 }
 
+//Replicate
 repliedTrajectory::repliedTrajectory(std::unique_ptr<AtomDistribution>&& d,
                                      const unsigned repeatX,
                                      const unsigned repeatY,
@@ -666,6 +668,7 @@ std::unique_ptr<AtomDistribution> repliedTrajectory::decorate(std::unique_ptr<At
          repeatZ);
 }
 
+//Scale
 scaledTrajectory::scaledTrajectory(std::unique_ptr<AtomDistribution>&& d,
                                    const double mult):
   distribution(std::move(d)),
@@ -703,6 +706,7 @@ std::unique_ptr<AtomDistribution> scaledTrajectory::decorate(std::unique_ptr<Ato
   return std::make_unique<scaledTrajectory>(std::move(d));
 }
 
+//Wiggle
 wiggleTrajectory::wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,
                                    const double amount):
   distribution(std::move(d)),
@@ -735,5 +739,58 @@ std::unique_ptr<AtomDistribution> wiggleTrajectory::decorate(std::unique_ptr<Ato
   }
   //the default value is specified in the header
   return std::make_unique<wiggleTrajectory>(std::move(d));
+}
+
+//ForceBox
+forceBoxTrajectory::forceBoxTrajectory(std::unique_ptr<AtomDistribution>&& d,
+                                       std::array<double,9> mybox):
+  distribution(std::move(d)),
+  fixedbox(mybox)
+{}
+
+bool forceBoxTrajectory::overrideNat(unsigned& natoms) {
+  return distribution->overrideNat(natoms);
+}
+void forceBoxTrajectory::frame(View<Vector> posToUpdate, View<double,9> box,
+                               unsigned step,
+                               Random& rng) {
+  distribution->frame(posToUpdate,box,step,rng);
+  box[0] = fixedbox[0];
+  box[1] = fixedbox[1];
+  box[2] = fixedbox[2];
+  box[3] = fixedbox[3];
+  box[4] = fixedbox[4];
+  box[5] = fixedbox[5];
+  box[6] = fixedbox[6];
+  box[7] = fixedbox[7];
+  box[8] = fixedbox[8];
+}
+
+std::unique_ptr<AtomDistribution> forceBoxTrajectory::decorate(std::unique_ptr<AtomDistribution>&& d,
+    std::string_view cmd) {
+  unpackedLine lines;
+  Tools::getWordsSimple(lines,cmd);
+  plumed_assert(lines.size() == 4 || lines.size() == 10) << id << " supports either 3 or 9 numbers as input";
+  std::array<double,9> newBox= {0.0,0.0,0.0,
+                                0.0,0.0,0.0,
+                                0.0,0.0,0.0
+                               };
+  if (lines.size()==4) {
+    Tools::convert(std::string(lines[1]), newBox[0]);
+    Tools::convert(std::string(lines[2]), newBox[4]);
+    Tools::convert(std::string(lines[3]), newBox[8]);
+  } else {// we now is 9
+    Tools::convert(std::string(lines[1]), newBox[0]);
+    Tools::convert(std::string(lines[2]), newBox[1]);
+    Tools::convert(std::string(lines[3]), newBox[2]);
+    Tools::convert(std::string(lines[4]), newBox[3]);
+    Tools::convert(std::string(lines[5]), newBox[4]);
+    Tools::convert(std::string(lines[6]), newBox[5]);
+    Tools::convert(std::string(lines[7]), newBox[6]);
+    Tools::convert(std::string(lines[8]), newBox[7]);
+    Tools::convert(std::string(lines[9]), newBox[8]);
+  }
+  //the default value is specified in the header
+  return std::make_unique<forceBoxTrajectory>(std::move(d),newBox);
 }
 } //namespace PLMD

--- a/src/tools/AtomDistribution.cpp
+++ b/src/tools/AtomDistribution.cpp
@@ -434,91 +434,90 @@ class repliedTrajectory: public AtomDistribution {
 public:
   static constexpr auto id="reply";
   static constexpr auto doc=R"=(replicate the box by the given in all the directions:
-usage (must be used with 3 paramenters):
- reply x y z
-)=";
+usage:
+  reply x y z)=";
 
   static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
-    std::string_view cmd) {
-  unpackedLine lines;
-  Tools::getWordsSimple(lines,cmd);
-  unsigned repeatX;
-  unsigned repeatY;
-  unsigned repeatZ;
-  plumed_assert(lines.size() ==4) << id << " supports exacly three inputs: x y z";
+      std::string_view cmd) {
+    unpackedLine lines;
+    Tools::getWordsSimple(lines,cmd);
+    unsigned repeatX;
+    unsigned repeatY;
+    unsigned repeatZ;
+    plumed_assert(lines.size() ==4) << id << " supports exacly three inputs: x y z";
 
-  Tools::convert(std::string(lines[1]),repeatX);
-  Tools::convert(std::string(lines[2]),repeatY);
-  Tools::convert(std::string(lines[3]),repeatZ);
-  return std::make_unique<repliedTrajectory>(std::move(d),
-         repeatX,
-         repeatY,
-         repeatZ);
-}
+    Tools::convert(std::string(lines[1]),repeatX);
+    Tools::convert(std::string(lines[2]),repeatY);
+    Tools::convert(std::string(lines[3]),repeatZ);
+    return std::make_unique<repliedTrajectory>(std::move(d),
+           repeatX,
+           repeatY,
+           repeatZ);
+  }
 
   repliedTrajectory(std::unique_ptr<AtomDistribution>&& d,
                     const unsigned repeatX,
                     const unsigned repeatY,
                     const unsigned repeatZ) :
-  distribution(std::move(d)),
-  rX(repeatX),
-  rY(repeatY),
-  rZ(repeatZ)
-{}
+    distribution(std::move(d)),
+    rX(repeatX),
+    rY(repeatY),
+    rZ(repeatZ)
+  {}
 
 ///Generates the inner trajectory of `(nat)/(rX*rY*rZ)`, where `nat` is the dimension of the vector view, then it replicate the atoms in the various directions
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned step,
              Random& rng) override {
-  plumed_assert((posToUpdate.size() % (rX*rY*rZ)==0));
-  const auto nat = posToUpdate.size()/(rX*rY*rZ);
-  auto coordinates=posToUpdate.subview(0,nat);
-  distribution->frame(coordinates,box,step,rng);
+    plumed_assert((posToUpdate.size() % (rX*rY*rZ)==0));
+    const auto nat = posToUpdate.size()/(rX*rY*rZ);
+    auto coordinates=posToUpdate.subview(0,nat);
+    distribution->frame(coordinates,box,step,rng);
 
-  // repetitions
-  auto p = posToUpdate.begin()+nat;
+    // repetitions
+    auto p = posToUpdate.begin()+nat;
 
-  assert((rX*rY*rZ)*nat == posToUpdate.size());
+    assert((rX*rY*rZ)*nat == posToUpdate.size());
 
-  Vector boxX(box[0],box[1],box[2]);
-  Vector boxY(box[3],box[4],box[5]);
-  Vector boxZ(box[6],box[7],box[8]);
-  for (unsigned x=0; x<rX; ++x) {
-    for (unsigned y=0; y<rY; ++y) {
-      for (unsigned z=0; z<rZ; ++z) {
-        if(x==0&&y==0&&z==0) {
-          continue;
-        }
-        for (unsigned i=0; i<nat; ++i) {
-          *p=coordinates[i]
-             + x * boxX
-             + y * boxY
-             + z * boxZ;
-          ++p;
+    Vector boxX(box[0],box[1],box[2]);
+    Vector boxY(box[3],box[4],box[5]);
+    Vector boxZ(box[6],box[7],box[8]);
+    for (unsigned x=0; x<rX; ++x) {
+      for (unsigned y=0; y<rY; ++y) {
+        for (unsigned z=0; z<rZ; ++z) {
+          if(x==0&&y==0&&z==0) {
+            continue;
+          }
+          for (unsigned i=0; i<nat; ++i) {
+            *p=coordinates[i]
+               + x * boxX
+               + y * boxY
+               + z * boxZ;
+            ++p;
+          }
         }
       }
     }
+    box[0]*=rX;
+    box[1]*=rX;
+    box[2]*=rX;
+
+    box[3]*=rY;
+    box[4]*=rY;
+    box[5]*=rY;
+
+    box[6]*=rZ;
+    box[7]*=rZ;
+    box[8]*=rZ;
   }
-  box[0]*=rX;
-  box[1]*=rX;
-  box[2]*=rX;
-
-  box[3]*=rY;
-  box[4]*=rY;
-  box[5]*=rY;
-
-  box[6]*=rZ;
-  box[7]*=rZ;
-  box[8]*=rZ;
-}
 
 ///See the documentation the AtomDistribution
   bool overrideNat(unsigned& natoms) override {
-  distribution->overrideNat(natoms);
-  natoms *= (rX*rY*rZ);
-  return true;
-}
+    distribution->overrideNat(natoms);
+    natoms *= (rX*rY*rZ);
+    return true;
+  }
 };
 
 ///a decorator for scaling the atomic positions
@@ -529,48 +528,47 @@ public:
   static constexpr auto id="scale";
   static constexpr auto doc=R"=(scales the atoms by a certain amount
 usage:
- scale (optional: mults=2.0)
-)=";
+  scale (optional: mults=2.0))=";
 
   static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
-    std::string_view cmd) {
-  unpackedLine lines;
-  Tools::getWordsSimple(lines,cmd);
-  plumed_assert(lines.size() <=2) << id << " supports maximum one input";
-  if (lines.size()==2) {
-    double mult=2.0;
-    Tools::convert(std::string(lines[1]), mult);
-    return std::make_unique<scaledTrajectory>(std::move(d),mult);
+      std::string_view cmd) {
+    unpackedLine lines;
+    Tools::getWordsSimple(lines,cmd);
+    plumed_assert(lines.size() <=2) << id << " supports maximum one input";
+    if (lines.size()==2) {
+      double mult=2.0;
+      Tools::convert(std::string(lines[1]), mult);
+      return std::make_unique<scaledTrajectory>(std::move(d),mult);
+    }
+
+    //the default value is specified in the header
+    return std::make_unique<scaledTrajectory>(std::move(d));
   }
 
-  //the default value is specified in the header
-  return std::make_unique<scaledTrajectory>(std::move(d));
-}
-
   scaledTrajectory(std::unique_ptr<AtomDistribution>&& d,
-		   double mult=2.0):
-  distribution(std::move(d)),
-  multiplier(mult)
-{}
+                   double mult=2.0):
+    distribution(std::move(d)),
+    multiplier(mult)
+  {}
 
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned step,
              Random& rng) override {
-  distribution->frame(posToUpdate,box,step,rng);
+    distribution->frame(posToUpdate,box,step,rng);
 
-  for (auto& p:posToUpdate) {
-    p*=multiplier;
+    for (auto& p:posToUpdate) {
+      p*=multiplier;
+    }
+
+    for (auto& b:box) {
+      b*=multiplier;
+    }
   }
 
-  for (auto& b:box) {
-    b*=multiplier;
+  bool overrideNat(unsigned& natoms) override {
+    return distribution->overrideNat(natoms);
   }
-}
-
-	bool overrideNat(unsigned& natoms) override {
-  return distribution->overrideNat(natoms);
-}
 };
 
 
@@ -581,45 +579,44 @@ class wiggleTrajectory: public AtomDistribution {
   double radius;
 public:
   static constexpr auto id="wiggle";
-  static constexpr auto doc=R"=(displaces all the atoms by a certain amunt
+  static constexpr auto doc=R"=(displaces all the atoms by a certain amount
 usage:
- wiggle (optional: sphere radius=0.1)
-)=";
+  wiggle (optional: sphere radius=0.1))=";
   static std::unique_ptr<AtomDistribution> decorate(
-		std::unique_ptr<AtomDistribution>&& d,
+    std::unique_ptr<AtomDistribution>&& d,
     std::string_view cmd) {
-  unpackedLine lines;
-  Tools::getWordsSimple(lines,cmd);
-  plumed_assert(lines.size() <=2) << id << " supports maximum one input";
-  if (lines.size()==2) {
-    double displacement=0.1;
-    Tools::convert(std::string(lines[1]), displacement);
-    return std::make_unique<wiggleTrajectory>(std::move(d),displacement);
+    unpackedLine lines;
+    Tools::getWordsSimple(lines,cmd);
+    plumed_assert(lines.size() <=2) << id << " supports maximum one input";
+    if (lines.size()==2) {
+      double displacement=0.1;
+      Tools::convert(std::string(lines[1]), displacement);
+      return std::make_unique<wiggleTrajectory>(std::move(d),displacement);
+    }
+    //the default value is specified in the header
+    return std::make_unique<wiggleTrajectory>(std::move(d));
   }
-  //the default value is specified in the header
-  return std::make_unique<wiggleTrajectory>(std::move(d));
-}
 
   wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,
-		   double amount=0.1) :
-  distribution(std::move(d)),
-  radius(amount)
-{}
+                   double amount=0.1) :
+    distribution(std::move(d)),
+    radius(amount)
+  {}
 
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned step,
              Random& rng) override {
-  distribution->frame(posToUpdate,box,step,rng);
+    distribution->frame(posToUpdate,box,step,rng);
 
-  UniformSphericalVector usv(radius);
-  for (auto& v: posToUpdate) {
-    v+= usv(rng);
+    UniformSphericalVector usv(radius);
+    for (auto& v: posToUpdate) {
+      v+= usv(rng);
+    }
   }
-}
   bool overrideNat(unsigned& natoms) override {
-  return distribution->overrideNat(natoms);
-}
+    return distribution->overrideNat(natoms);
+  }
 };
 
 
@@ -632,9 +629,9 @@ public:
   static constexpr auto id="box";
   static constexpr auto doc=R"=(Forces a box on the atom distribution
 usage:
- "box xx yy zz"
-or
- "box xx xy xy yx yy yz zx zy zz")=";
+  box xx yy zz
+ or
+  box xx xy xy yx yy yz zx zy zz)=";
 
   static std::unique_ptr<AtomDistribution> decorate(
     std::unique_ptr<AtomDistribution>&& d,
@@ -705,7 +702,7 @@ public:
   static constexpr auto id="fix";
   static constexpr auto doc=R"=(Fixes the trajectory for stride steps, or forever if stride is 0
 usage:
- "fix stride(optional)")=";
+  fix (optional stride=0))=";
 
   static std::unique_ptr<AtomDistribution> decorate(
     std::unique_ptr<AtomDistribution>&& d,

--- a/src/tools/AtomDistribution.h
+++ b/src/tools/AtomDistribution.h
@@ -233,5 +233,22 @@ public:
              Random& rng) override;
   bool overrideNat(unsigned& natoms) override;
 };
+
+/// A decorator for forcing a box in the trajectory
+class forceBoxTrajectory: public AtomDistribution {
+  std::unique_ptr<AtomDistribution> distribution;
+  std::array<double,9> fixedbox;
+public:
+  static constexpr auto id="box";
+  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
+      std::string_view cmd);
+  forceBoxTrajectory(std::unique_ptr<AtomDistribution>&& d,
+                     std::array<double,9> mybox);
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned step,
+             Random& rng) override;
+  bool overrideNat(unsigned& natoms) override;
+};
 } //namespace PLMD
 #endif // __PLUMED_tools_AtomDistribution_h

--- a/src/tools/AtomDistribution.h
+++ b/src/tools/AtomDistribution.h
@@ -197,5 +197,18 @@ public:
              Random& rng) override;
   bool overrideNat(unsigned& natoms) override;
 };
+
+/// A decorator for displacing the atoms from the generated underline distribution
+class wiggleTrajectory: public AtomDistribution {
+  std::unique_ptr<AtomDistribution> distribution;
+  double radius;
+public:
+  wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,  double amount=0.5);
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned step,
+             Random& rng) override;
+  bool overrideNat(unsigned& natoms) override;
+};
 } //namespace PLMD
 #endif // __PLUMED_tools_AtomDistribution_h

--- a/src/tools/AtomDistribution.h
+++ b/src/tools/AtomDistribution.h
@@ -28,6 +28,7 @@
 #include "Random.h"
 #include "TrajectoryParser.h"
 
+#include <memory>
 #include <vector>
 namespace PLMD {
 ///tested in regtest/tools/rt-make-AtomicDistribution
@@ -59,10 +60,14 @@ struct AtomDistribution {
     return false;
   }
   static std::unique_ptr<AtomDistribution> getAtomDistribution(std::string_view atomicDistr);
+  static std::unique_ptr<AtomDistribution> decorateAtomDistribution(
+    std::unique_ptr<AtomDistribution> && ad,
+    std::string_view decoratorsDistr);
 };
 
 ///A wiggly line of atoms
 struct theLine:public AtomDistribution {
+  static constexpr auto id="line";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned step,
@@ -71,6 +76,7 @@ struct theLine:public AtomDistribution {
 
 ///Atom randomly distribuited in a sphere
 struct uniformSphere:public AtomDistribution {
+  static constexpr auto id="sphere";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned /*step*/,
@@ -79,6 +85,7 @@ struct uniformSphere:public AtomDistribution {
 
 ///Atom randomly distribuited between two not overlapping a spheres
 struct twoGlobs: public AtomDistribution {
+  static constexpr auto id="globs";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned /*step*/,
@@ -86,6 +93,7 @@ struct twoGlobs: public AtomDistribution {
 };
 
 struct uniformCube:public AtomDistribution {
+  static constexpr auto id="cube";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned /*step*/,
@@ -93,6 +101,7 @@ struct uniformCube:public AtomDistribution {
 };
 
 struct tiledSimpleCubic:public AtomDistribution {
+  static constexpr auto id="sc";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned /*step*/,
@@ -106,6 +115,7 @@ struct tiledSimpleCubic:public AtomDistribution {
 /// At certain sizes above the ones above (36, 504), you get
 /// good (100) slabs quite separated on th z axis
 struct inscribedFaceCenteredCubic:public AtomDistribution {
+  static constexpr auto id="ifcc";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned /*step*/,
@@ -114,6 +124,7 @@ struct inscribedFaceCenteredCubic:public AtomDistribution {
 
 /// This FCC is contained in a "standard" FCC box
 struct tiledFaceCenteredCubic:public AtomDistribution {
+  static constexpr auto id="fcc";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned /*step*/,
@@ -122,6 +133,7 @@ struct tiledFaceCenteredCubic:public AtomDistribution {
 
 /// This BCC is contained in a orthogonal cubic box
 struct inscribedBodyCenteredCubic:public AtomDistribution {
+  static constexpr auto id="ibcc";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned /*step*/,
@@ -130,6 +142,7 @@ struct inscribedBodyCenteredCubic:public AtomDistribution {
 
 /// This BCC is contained in a "standard" FCC box
 struct tiledBodyCenteredCubic:public AtomDistribution {
+  static constexpr auto id="bcc";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned /*step*/,
@@ -151,6 +164,7 @@ class fileTraj:public AtomDistribution {
   //read the next step
   void step(bool doRewind=true);
 public:
+  static constexpr auto id="file";
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned /*step*/,
@@ -170,6 +184,9 @@ class repliedTrajectory: public AtomDistribution {
   unsigned rY=1;
   unsigned rZ=1;
 public:
+  static constexpr auto id="reply";
+  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
+      std::string_view cmd);
   repliedTrajectory(std::unique_ptr<AtomDistribution>&& d,
                     const unsigned repeatX,
                     const unsigned repeatY,
@@ -190,7 +207,10 @@ class scaledTrajectory: public AtomDistribution {
   std::unique_ptr<AtomDistribution> distribution;
   double multiplier;
 public:
-  scaledTrajectory(std::unique_ptr<AtomDistribution>&& d,  double mult);
+  static constexpr auto id="scale";
+  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
+      std::string_view cmd);
+  scaledTrajectory(std::unique_ptr<AtomDistribution>&& d,  double mult=2.0);
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned step,
@@ -203,7 +223,10 @@ class wiggleTrajectory: public AtomDistribution {
   std::unique_ptr<AtomDistribution> distribution;
   double radius;
 public:
-  wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,  double amount=0.5);
+  static constexpr auto id="wiggle";
+  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
+      std::string_view cmd);
+  wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,  double amount=0.1);
   void frame(View<Vector> posToUpdate,
              View<double,9> box,
              unsigned step,

--- a/src/tools/AtomDistribution.h
+++ b/src/tools/AtomDistribution.h
@@ -24,12 +24,13 @@
 
 #include "Vector.h"
 #include "View.h"
-#include "Tools.h"
 #include "Random.h"
-#include "TrajectoryParser.h"
 
+#include <string_view>
 #include <memory>
 #include <vector>
+#include <tuple>
+
 namespace PLMD {
 ///tested in regtest/tools/rt-make-AtomicDistribution
 ///Acts as a template for any distribution
@@ -59,196 +60,20 @@ struct AtomDistribution {
   virtual bool overrideNat(unsigned& ) {
     return false;
   }
+
+  struct documentation {
+    std::string id;
+    std::string doc;
+  };
   static std::unique_ptr<AtomDistribution> getAtomDistribution(std::string_view atomicDistr);
   static std::unique_ptr<AtomDistribution> decorateAtomDistribution(
     std::unique_ptr<AtomDistribution> && ad,
     std::string_view decoratorsDistr);
+  static std::vector<std::string> getDistributionList();
+  static std::vector<documentation> getDistributionDocumentation();
+  static std::vector<std::string> getDecoratorsList();
+  static std::vector<documentation> getDecoratorsDocumentation();
 };
 
-///A wiggly line of atoms
-struct theLine:public AtomDistribution {
-  static constexpr auto id="line";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned step,
-             Random& rng) override;
-};
-
-///Atom randomly distribuited in a sphere
-struct uniformSphere:public AtomDistribution {
-  static constexpr auto id="sphere";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned /*step*/,
-             Random& rng) override;
-};
-
-///Atom randomly distribuited between two not overlapping a spheres
-struct twoGlobs: public AtomDistribution {
-  static constexpr auto id="globs";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned /*step*/,
-             Random&rng) override;
-};
-
-struct uniformCube:public AtomDistribution {
-  static constexpr auto id="cube";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned /*step*/,
-             Random& rng) override;
-};
-
-struct tiledSimpleCubic:public AtomDistribution {
-  static constexpr auto id="sc";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned /*step*/,
-             Random& rng) override;
-};
-
-/// This FCC is contained in a orthogonal cubic box
-///
-/// Fun facts: full cubes at 4, 32, 108, 256, 500 atoms and so on.
-///
-/// At certain sizes above the ones above (36, 504), you get
-/// good (100) slabs quite separated on th z axis
-struct inscribedFaceCenteredCubic:public AtomDistribution {
-  static constexpr auto id="ifcc";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned /*step*/,
-             Random& rng) override;
-};
-
-/// This FCC is contained in a "standard" FCC box
-struct tiledFaceCenteredCubic:public AtomDistribution {
-  static constexpr auto id="fcc";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned /*step*/,
-             Random& rng) override;
-};
-
-/// This BCC is contained in a orthogonal cubic box
-struct inscribedBodyCenteredCubic:public AtomDistribution {
-  static constexpr auto id="ibcc";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned /*step*/,
-             Random& rng) override;
-};
-
-/// This BCC is contained in a "standard" FCC box
-struct tiledBodyCenteredCubic:public AtomDistribution {
-  static constexpr auto id="bcc";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned /*step*/,
-             Random& rng) override;
-};
-
-/// atomic distribution from a trajectory file
-class fileTraj:public AtomDistribution {
-  TrajectoryParser parser;
-  std::vector<double> masses{};
-  std::vector<double> charges{};
-  std::vector<Vector> coordinates{};
-  std::vector<double> cell{0.0,0.0,0.0,
-        0.0,0.0,0.0,
-        0.0,0.0,0.0};
-  bool read=false;
-  bool dont_read_pbc=false;
-  void rewind();
-  //read the next step
-  void step(bool doRewind=true);
-public:
-  static constexpr auto id="file";
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned /*step*/,
-             Random& /*rng*/) override;
-
-  fileTraj(std::string_view fmt,
-           std::string_view fname,
-           bool useMolfile,
-           int command_line_natoms);
-  bool overrideNat(unsigned& natoms) override;
-};
-
-///a decorator for replicate the atomic distribution
-class repliedTrajectory: public AtomDistribution {
-  std::unique_ptr<AtomDistribution> distribution;
-  unsigned rX=1;
-  unsigned rY=1;
-  unsigned rZ=1;
-public:
-  static constexpr auto id="reply";
-  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
-      std::string_view cmd);
-  repliedTrajectory(std::unique_ptr<AtomDistribution>&& d,
-                    const unsigned repeatX,
-                    const unsigned repeatY,
-                    const unsigned repeatZ,
-                    // not used, here for legacy purpose
-                    const unsigned=1 /*nat*/);
-///Generates the inner trajectory of `(nat)/(rX*rY*rZ)`, where `nat` is the dimension of the vector view, then it replicate the atoms in the various directions
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned step,
-             Random& rng) override;
-///See the documentation the AtomDistribution
-  bool overrideNat(unsigned& natoms) override;
-};
-
-///a decorator for scaling the atomic positions
-class scaledTrajectory: public AtomDistribution {
-  std::unique_ptr<AtomDistribution> distribution;
-  double multiplier;
-public:
-  static constexpr auto id="scale";
-  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
-      std::string_view cmd);
-  scaledTrajectory(std::unique_ptr<AtomDistribution>&& d,  double mult=2.0);
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned step,
-             Random& rng) override;
-  bool overrideNat(unsigned& natoms) override;
-};
-
-/// A decorator for displacing the atoms from the generated underline distribution
-class wiggleTrajectory: public AtomDistribution {
-  std::unique_ptr<AtomDistribution> distribution;
-  double radius;
-public:
-  static constexpr auto id="wiggle";
-  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
-      std::string_view cmd);
-  wiggleTrajectory(std::unique_ptr<AtomDistribution>&& d,  double amount=0.1);
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned step,
-             Random& rng) override;
-  bool overrideNat(unsigned& natoms) override;
-};
-
-/// A decorator for forcing a box in the trajectory
-class forceBoxTrajectory: public AtomDistribution {
-  std::unique_ptr<AtomDistribution> distribution;
-  std::array<double,9> fixedbox;
-public:
-  static constexpr auto id="box";
-  static std::unique_ptr<AtomDistribution> decorate(std::unique_ptr<AtomDistribution>&& d,
-      std::string_view cmd);
-  forceBoxTrajectory(std::unique_ptr<AtomDistribution>&& d,
-                     std::array<double,9> mybox);
-  void frame(View<Vector> posToUpdate,
-             View<double,9> box,
-             unsigned step,
-             Random& rng) override;
-  bool overrideNat(unsigned& natoms) override;
-};
 } //namespace PLMD
 #endif // __PLUMED_tools_AtomDistribution_h

--- a/src/tools/AtomDistributionFiles.cpp
+++ b/src/tools/AtomDistributionFiles.cpp
@@ -1,0 +1,120 @@
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+   Copyright (c) 2026 The plumed team
+   (see the PEOPLE file at the root of the distribution for a list of names)
+
+   See http://www.plumed.org for more information.
+
+   This file is part of plumed, version 2.
+
+   plumed is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   plumed is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with plumed.  If not, see <http://www.gnu.org/licenses/>.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#include "AtomDistributionFiles.h"
+#include "View.h"
+
+namespace PLMD {
+
+void fileTraj::rewind() {
+  auto errormessage=parser.rewind();
+  if (errormessage) {
+    // A workarounf for not implemented rewind is to dump the trajectory in an xyz and then read that
+    plumed_error()<<*errormessage;
+  }
+  //the extra false prevents an infinite loop in case of unexpected consecutice EOFs after a rewind
+  step(false);
+}
+
+//read the next step
+void fileTraj::step(bool doRewind) {
+  read=false;
+  long long int mystep=0;
+  double timeStep;
+  std::optional<std::string> errormessage;
+  if (masses.empty()) {
+    errormessage=parser.readHeader(
+                   mystep,
+                   timeStep
+                 );
+    if (errormessage) {
+      plumed_error()<<*errormessage;
+    }
+    const size_t natoms = parser.nOfAtoms();
+
+    masses.assign(natoms,0.0);
+    charges.assign(natoms,0.0);
+    coordinates.assign(natoms,Vector(0.0,0.0,0.0));
+    cell.assign(9,0.0);
+    errormessage=parser.readAtoms(1,
+                                  dont_read_pbc,
+                                  false,
+                                  0,
+                                  0,
+                                  mystep,
+                                  masses.data(),
+                                  charges.data(),
+                                  &coordinates[0][0],
+                                  cell.data()
+                                 );
+  } else {
+    errormessage=parser.readFrame(1,
+                                  dont_read_pbc,
+                                  false,
+                                  0,
+                                  0,
+                                  mystep,
+                                  timeStep,
+                                  masses.data(),
+                                  charges.data(),
+                                  &coordinates[0][0],
+                                  cell.data()
+                                 );
+  }
+
+  if (errormessage) {
+    if (*errormessage =="EOF" && doRewind) {
+      rewind();
+    } else {
+      plumed_error()<<*errormessage;
+    }
+  }
+}
+
+void fileTraj::frame(View<Vector> posToUpdate,
+                     View<double,9> box,
+                     unsigned /*step*/,
+                     Random& /*rng*/) {
+  if (read) {
+    step();
+  }
+  read=true;
+  std::copy(coordinates.begin(),coordinates.end(),posToUpdate.begin());
+  std::copy(cell.begin(),cell.end(),box.begin());
+}
+
+fileTraj::fileTraj(std::string_view fmt,
+                   std::string_view fname,
+                   bool useMolfile,
+                   int command_line_natoms) {
+  parser.init(fmt,
+              fname,
+              useMolfile,
+              command_line_natoms);
+  step();
+}
+
+bool fileTraj::overrideNat(unsigned& natoms) {
+  natoms = masses.size();
+  return true;
+}
+
+} //namespace PLMD

--- a/src/tools/AtomDistributionFiles.h
+++ b/src/tools/AtomDistributionFiles.h
@@ -1,0 +1,64 @@
+/* +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+   Copyright (c) 2026 The plumed team
+   (see the PEOPLE file at the root of the distribution for a list of names)
+
+   See http://www.plumed.org for more information.
+
+   This file is part of plumed, version 2.
+
+   plumed is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   plumed is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with plumed.  If not, see <http://www.gnu.org/licenses/>.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ */
+#ifndef __PLUMED_tools_AtomDistributionFiles_h
+#define __PLUMED_tools_AtomDistributionFiles_h
+#include "AtomDistribution.h"
+
+#include "Vector.h"
+#include "View.h"
+#include "Random.h"
+#include "TrajectoryParser.h"
+
+#include <string_view>
+#include <vector>
+
+namespace PLMD {
+
+/// atomic distribution from a trajectory file
+class fileTraj:public AtomDistribution {
+  TrajectoryParser parser;
+  std::vector<double> masses{};
+  std::vector<double> charges{};
+  std::vector<Vector> coordinates{};
+  std::vector<double> cell{0.0,0.0,0.0,
+        0.0,0.0,0.0,
+        0.0,0.0,0.0};
+  bool read=false;
+  bool dont_read_pbc=false;
+  void rewind();
+  //read the next step
+  void step(bool doRewind=true);
+public:
+  static constexpr auto id="file";
+  void frame(View<Vector> posToUpdate,
+             View<double,9> box,
+             unsigned /*step*/,
+             Random& /*rng*/) override;
+
+  fileTraj(std::string_view fmt,
+           std::string_view fname,
+           bool useMolfile,
+           int command_line_natoms);
+  bool overrideNat(unsigned& natoms) override;
+};
+} //namespace PLMD
+#endif // __PLUMED_tools_AtomDistributionFiles_h


### PR DESCRIPTION
<!--
  Feel free to delete not relevant sections below
-->

##### Description

<!-- describe here your pull request -->
I added a few new modificators for the atomic distributions:
fix that fixes the state of a distribution, can be strided (useful with cube, sphere, globs)
box that forces the box for the simulations, useful with some file reades that do not read the box correcly
wiggle that wiggles the atoms, useful with line, fcc, sc, bcc and variants

I compacted some of the option from the benchmark in the the --atom-distribution.

I added an extra --modify-trajectory to modify also a loaded file, and 
--ad-help that shows:

```
Documentation for the atomic distributions:

These are the basic atomic distributions:
    line - A line of atoms, that wiggles randomly at each step

    cube - Randomly displaced atoms in a cube, the density is circa 1/unit^3

  sphere - Atoms are displaced uniformly in a sphere, the desity is ccirca 1/unit^3

   globs - Two spheres of uniformly distribuited atosm

      sc - Simple Cubic

     bcc - Body Centered Cubic

     fcc - Face Centered Cubic

    ibcc - BCC, but in a cubic box

    ifcc - FCC, but in a cubic box


These are the modifiers that can be applied to any atomic distributions:
   reply - replicate the box by the given in all the directions:
usage:
  reply x y z

   scale - scales the atoms by a certain amount
usage:
  scale (optional: mults=2.0)

  wiggle - displaces all the atoms by a certain amount
usage:
  wiggle (optional: sphere radius=0.1)

     box - Forces a box on the atom distribution
usage:
  box xx yy zz
 or
  box xx xy xy yx yy yz zx zy zz

     fix - Fixes the trajectory for stride steps, or forever if stride is 0
usage:
  fix (optional stride=0)


To use these distributions in the benchmark you can simple the cli option --atom-distribution
like:
  --atom-distribution="sc", with no extra modifiers
  --atom-distribution="line|wiggle 0.5", use the pipe for modify the base distribution
  --atom-distribution="ifcc|scale 2.3|reply 2 1 1", do not add spaces before or after the pipes

As an extra tool you can append more modificators with --modify-trajectory,
it is not necessary since you can use --atom-distribution, but can be applied
to a trajectory read from a file, for example "box" can be used for adding
the pbcs to certain file parsers.
Remember that --modify-trajectory accepts only  modifiers, with the
same syntax of --atom-distribution
  --modify-trajectory="box 5 5 5"
  --modify-trajectory="box 0 1 1 1 1 0 1 0 1|reply 4 2 6"
```

The way AtomDistribution.cpp is organized acan be applied to other similar functionalities that have a register and are contained in a single cpp file, like the switching functions


##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release __V2.11__

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
