### PR TITLE
Control log file name via environment variable

### DIFF
--- a/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
+++ b/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
@@ -130,7 +130,10 @@ try : plumed_(std::make_unique<PLMD::Plumed>()),replex_(options.replex_)
 
     plumed_->cmd("setNatoms", options.natoms_);
     plumed_->cmd("setMDEngine", "gromacs");
-    plumed_->cmd("setLogFile", "PLUMED.OUT");
+    if (const char* logFile = getenv("PLUMED_LOG_FILE"))
+        plumed_->cmd("setLogFile", logFile);
+    else
+        plumed_->cmd("setLogFile", "PLUMED.OUT");
 
     plumed_->cmd("setTimestep", &options.simulationTimeStep_);
     plumed_->cmd("init", nullptr);

--- a/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
+++ b/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
@@ -130,10 +130,11 @@ try : plumed_(std::make_unique<PLMD::Plumed>()),replex_(options.replex_)
 
     plumed_->cmd("setNatoms", options.natoms_);
     plumed_->cmd("setMDEngine", "gromacs");
-    if (const char* logFile = getenv("PLUMED_LOG_FILE"))
-        plumed_->cmd("setLogFile", logFile);
-    else
-        plumed_->cmd("setLogFile", "PLUMED.OUT");
+    {
+        const char* logFileEnv = getenv("PLUMED_LOG_FILE");
+        const std::string logFile = (logFileEnv && logFileEnv[0] != '\0') ? logFileEnv : "PLUMED.OUT";
+        plumed_->cmd("setLogFile", logFile.c_str());
+    }
 
     plumed_->cmd("setTimestep", &options.simulationTimeStep_);
     plumed_->cmd("init", nullptr);


### PR DESCRIPTION
Using `PLUMED_LOG_FILE` environment variable to control the log file name instead of being hardcoded to `PLUMED.OUT`

##### Description

Quick & Dirty way to control the log file name instead of being hardcoded to `PLUMED.OUT` is to use PLUMED_LOG_FILE env variable.
If the variable is set, use it, otherwise, use the default value.

##### Type of contribution

- [X] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

- [ ] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

##### Tests

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).
