### PR TITLE
Restore setNumOMPthreads in the GROMACS 2025 patch

### DIFF
--- a/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
+++ b/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
@@ -44,6 +44,7 @@
 #include "gromacs/domdec/domdec.h"
 #include "gromacs/domdec/domdec_struct.h"
 #include "gromacs/math/units.h"
+#include "gromacs/mdlib/gmx_omp_nthreads.h"
 #include "gromacs/mdrunutility/handlerestart.h"
 #include "gromacs/mdrunutility/multisim.h"
 #include "gromacs/mdtypes/commrec.h"
@@ -113,6 +114,15 @@ try : plumed_(std::make_unique<PLMD::Plumed>()),replex_(options.replex_)
             int res = 1;
             plumed_->cmd("setRestart", &res);
         }
+    }
+
+    if (plumedAPIversion_ > 5)
+    {
+        /* tell PLUMED how many OpenMP threads GROMACS is using, so that it can
+           parallelise its own work; without this PLMD::OpenMP::getNumThreads()
+           always reports 1 unless PLUMED_NUM_THREADS is set by hand */
+        int numOmpThreads = gmx_omp_nthreads_get(ModuleMultiThread::Default);
+        plumed_->cmd("setNumOMPthreads", &numOmpThreads);
     }
 
     if (isMultiSim(options.ms_))


### PR DESCRIPTION
Fixes #1407.

Up to `patches/gromacs-2024.3.diff` the GROMACS patch told PLUMED how many OpenMP threads
GROMACS was using (in the `/* PLUMED */` block of `src/gromacs/mdrun/runner.cpp`):

```cpp
int nth = gmx_omp_nthreads_get(ModuleMultiThread::Default);
plumed_cmd(plumedmain, "setNumOMPthreads", &nth);
```

When the 2025.0 patch was rewritten around the native PLUMED support that GROMACS 2025 ships,
that call was not carried over, so `PLMD::OpenMP::getNumThreads()` returns 1 for every GROMACS
2025 run and anything parallelised over OpenMP silently runs serially. As discussed in #1407,
setting `PLUMED_NUM_THREADS` by hand is not a workable substitute: the right number is not known
in advance on heterogeneous hardware, and it changes once GROMACS' dynamic load balancing
redistributes the work.

This restores the call in the `PlumedForceProvider` constructor, behind the same API-version gate
the 2024.3 patch used.

### Placement and safety

- `gmx_omp_nthreads_init()` is called in `runner.cpp` well before `mdModules_->initForceProviders()`,
  so the thread count is initialised by the time the force provider is constructed.
- `src/gromacs/applied_forces/{colvars,densityfitting,qmmm}` already include `gromacs/mdlib/`
  headers, so the added include does not violate GROMACS' module layering.

### Verification

- `plumedforceprovider.cpp.preplumed` is byte-identical to the GROMACS file at **v2025.0, v2025.1,
  v2025.2, v2025.3 and v2025.4**, so the hunk applies across the whole 2025 series. Confirmed by
  applying it to real v2025.0 and v2025.4 sources with the same flags `patch.sh` uses
  (`patch -u -l -b -F 5 -N`).
- Built GROMACS 2025.4 with this patch applied (clang 20.1.1, `-DGMX_USE_PLUMED=ON`, runtime mode)
  and ran `gmx mdrun -ntmpi 1 -ntomp N -plumed` with `PLUMED_NUM_THREADS` unset. `PLUMED.OUT`
  reports, with and without the restored block (same build tree, same kernel, only this hunk
  differing):

  | `-ntomp` | without the block | with the block |
  |---------:|------------------:|---------------:|
  | 1        | 1                 | 1              |
  | 4        | **1**             | 4              |
  | 8        | **1**             | 8              |

### Two related gaps, not addressed here

The same 2024.3 block contained two further items that are also absent from the 2025 patch:

1. `plumed_cmd(plumedmain, "setGpuDeviceId", &deviceId)` (gated on API > 9);
2. the warning that `-update gpu` combined with `-plumed` produces wrong results unless PLUMED
   only acts on neighbour-list-search and/or file-writing steps.

Both would need new fields plumbed through `PlumedOptions`, the way `replex_` and `ms_` already are.
Happy to open a separate issue or PR if you confirm these were dropped unintentionally rather than
deliberately.
