### PR TITLE
PathMSDBase: drop four omp simd pragmas that cannot vectorize

### DIFF
--- a/src/colvar/PathMSDBase.cpp
+++ b/src/colvar/PathMSDBase.cpp
@@ -28,6 +28,8 @@
 #include "tools/RMSD.h"
 #include "tools/Tools.h"
 
+#include <algorithm>
+
 namespace PLMD {
 namespace colvar {
 
@@ -173,7 +175,8 @@ void PathMSDBase::calculate() {
   // resize the list to full
   if(imgVec.empty()) { // this is the signal that means: recalculate all
     imgVec.resize(nframes);
-    #pragma omp simd
+    // No `omp simd` here: ImagePath::property is a std::vector<double>, so this body performs a
+    // vector copy-assignment, i.e. it allocates. There is nothing for a SIMD unit to do.
     for(unsigned i=0; i<nframes; i++) {
       imgVec[i].property=indexvec[i];
       imgVec[i].index=i;
@@ -231,20 +234,14 @@ void PathMSDBase::calculate() {
       for(unsigned i=rank; i<imgVec.size(); i+=stride) {
         tmp_distances[i] = msdv[imgVec[i].index].calc_Rot(getPositions(), tmp_derivs, tmp_rotationRefClose[imgVec[i].index], true);
         plumed_assert(tmp_derivs.size()==nat);
-        #pragma omp simd
-        for(unsigned j=0; j<nat; j++) {
-          tmp_derivs2[i*nat+j]=tmp_derivs[j];
-        }
+        std::copy_n(tmp_derivs.begin(), nat, tmp_derivs2.begin()+i*nat);
       }
     } else {
       //approximate distance with saved rotation matrices
       for(unsigned i=rank; i<imgVec.size(); i+=stride) {
         tmp_distances[i] = msdv[imgVec[i].index].calculateWithCloseStructure(getPositions(), tmp_derivs, rotationPosClose, rotationRefClose[imgVec[i].index], drotationPosCloseDrr01, true);
         plumed_assert(tmp_derivs.size()==nat);
-        #pragma omp simd
-        for(unsigned j=0; j<nat; j++) {
-          tmp_derivs2[i*nat+j]=tmp_derivs[j];
-        }
+        std::copy_n(tmp_derivs.begin(), nat, tmp_derivs2.begin()+i*nat);
         if (debugClose) {
           double withclose = tmp_distances[i];
           RMSD opt;
@@ -263,10 +260,7 @@ void PathMSDBase::calculate() {
     for(unsigned i=rank; i<imgVec.size(); i+=stride) {
       tmp_distances[i]=msdv[imgVec[i].index].calculate(getPositions(),tmp_derivs,true);
       plumed_assert(tmp_derivs.size()==nat);
-      #pragma omp simd
-      for(unsigned j=0; j<nat; j++) {
-        tmp_derivs2[i*nat+j]=tmp_derivs[j];
-      }
+      std::copy_n(tmp_derivs.begin(), nat, tmp_derivs2.begin()+i*nat);
     }
   }
 


### PR DESCRIPTION
##### Description

Building PLUMED with clang and OpenMP emits this four times:

```
PathMSDBase.cpp:160:19: warning: loop not vectorized: the optimizer was unable to perform the
requested transformation; the transformation might be disabled or specified as part of an
unsupported transformation ordering [-Wpass-failed=transform-warning]
```

All four are attributed to `calculate()`'s opening line, which hides which loops are responsible.
Keeping one `#pragma omp simd` at a time and recompiling isolates them exactly:

| pragma | loop | warnings |
|:---|:---|:---|
| line 176 | `imgVec[i].property = indexvec[i]; imgVec[i].index = i;` | 1 |
| line 234 | `tmp_derivs2[i*nat+j] = tmp_derivs[j];` | 1 |
| line 244 | the same loop again | 1 |
| line 266 | the same loop again | 1 |
| line 335 | `derivs_s[i] += tmp*it.distder[i];` | 0 — vectorizes |
| line 340 | `derivs_z[i] += ...;` | 0 — vectorizes |

Neither failing case can be vectorized, and requesting it is misleading:

* Line 176 is not merely hard to vectorize, it is meaningless. `ImagePath::property` is a
  `std::vector<double>`, so `imgVec[i].property = indexvec[i]` is a vector copy-assignment that
  **allocates**. There is no SIMD work in that loop.
* The other three are the same contiguous copy of `Vector` elements, written out by hand.
  `std::copy_n` states the intent and lets the compiler emit a `memmove` rather than an element loop
  the vectorizer then declines to transform.

Fixing the source rather than silencing the diagnostic means the warning disappears for every
compiler, and a build that adds `-Werror` no longer fails here. Behaviour is unchanged: `std::copy_n`
over `[0, nat)` is exactly the loop it replaces, and the two pragmas that do vectorize are untouched.

Net change: 7 insertions, 13 deletions in one file.

##### Target release

I would like my code to appear in release **2.11** (master).

##### Type of contribution
- [x] changes to code or doc authored by PLUMED developers
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright
- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the
      author of the code I am modifying.
- [ ] the code I am contributing is not mine and I am making it available under LGPL

##### Tests
- [x] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on GitHub Actions.

No new regtest is added: this changes neither behaviour nor interface, so there is nothing new to
assert. The existing PathMSD regtests are the check, and they already encode the expected colvar and
derivative values. Locally, with the change applied, all seven that this build can run pass:

```
basic/rt35  rt37  rt39  rt39-mpi  rt57  rt58  rt59      7 passed, 0 failed
mapping/rt39, mapping/rt39-mpi                          skipped (mapping module off in that build)
```

Verified with clang 20.1.1:

```
clang++ -std=c++17 -O3 -fopenmp -march=skylake-avx512 -Wall -c colvar/PathMSDBase.cpp -I.
```

4 warnings before, 0 after. GCC is unaffected either way.
