### PR TITLE
Fix ENERGY CV gromacs2024/25 + fix ENERGY CV with multi MPI and negative float to double (v2.10, any MD engine)

### DIFF
--- a/CHANGES/v2.10.md
+++ b/CHANGES/v2.10.md
@@ -93,5 +93,9 @@ Before switching to version 2.10, users are invited to carefully read the follow
     ENERGY printed as NaN with GROMACS in mixed precision because `log10` was applied to the raw value.
   - Enabled ENERGY (and energy biasing) with the native GROMACS 2025 ForceProvider interface:
     request energy/virial in the MD loop and apply energy biases after `F_EPOT` is accumulated.
+  - Fixed an out-of-bounds write when a force is applied on ENERGY and the atoms are scattered
+    over the domains. The forces of the MD code were rescaled over the total number of atoms
+    rather than over the atoms that are local to the rank, which corrupted the heap and made
+    OPES multithermal and the well-tempered ensemble crash on more than one MPI rank.
   - Documentation: ENERGY does include the GROMACS long tail (`DispCorr`) corrections, contrary
     to what the manual stated. See [issue 567](https://github.com/plumed/plumed2/issues/567).

--- a/CHANGES/v2.10.md
+++ b/CHANGES/v2.10.md
@@ -93,3 +93,5 @@ Before switching to version 2.10, users are invited to carefully read the follow
     ENERGY printed as NaN with GROMACS in mixed precision because `log10` was applied to the raw value.
   - Enabled ENERGY (and energy biasing) with the native GROMACS 2025 ForceProvider interface:
     request energy/virial in the MD loop and apply energy biases after `F_EPOT` is accumulated.
+  - Documentation: ENERGY does include the GROMACS long tail (`DispCorr`) corrections, contrary
+    to what the manual stated. See [issue 567](https://github.com/plumed/plumed2/issues/567).

--- a/CHANGES/v2.10.md
+++ b/CHANGES/v2.10.md
@@ -91,3 +91,5 @@ Before switching to version 2.10, users are invited to carefully read the follow
     where PLUMED needs it (ENERGY CV, OPES multithermal, well-tempered ensemble). See [issue 1205](https://github.com/plumed/plumed2/issues/1205).
   - Fixed conversion of negative (and zero) float scalars from mixed-precision MD codes.
     ENERGY printed as NaN with GROMACS in mixed precision because `log10` was applied to the raw value.
+  - Enabled ENERGY (and energy biasing) with the native GROMACS 2025 ForceProvider interface:
+    request energy/virial in the MD loop and apply energy biases after `F_EPOT` is accumulated.

--- a/CHANGES/v2.10.md
+++ b/CHANGES/v2.10.md
@@ -85,3 +85,9 @@ Before switching to version 2.10, users are invited to carefully read the follow
   - Added check that the neighbor list does not fill RAM. Can be removed with `export PLUMED_IGNORE_NL_MEMORY_ERROR=1`
   - Fixed a bug with [CONVERT_TO_FES](CONVERT_TO_FES.md) and `MINTOZERO`
   - Fixed issue with roundoff of timestep when using GROMACS in single precision
+
+## Version 2.10.2 (in progress)
+  - Fixed the GROMACS 2024 patch so that the potential energy is computed on every step
+    where PLUMED needs it (ENERGY CV, OPES multithermal, well-tempered ensemble). See [issue 1205](https://github.com/plumed/plumed2/issues/1205).
+  - Fixed conversion of negative (and zero) float scalars from mixed-precision MD codes.
+    ENERGY printed as NaN with GROMACS in mixed precision because `log10` was applied to the raw value.

--- a/patches/gromacs-2024.3.diff/src/gromacs/mdrun/md.cpp
+++ b/patches/gromacs-2024.3.diff/src/gromacs/mdrun/md.cpp
@@ -1326,6 +1326,14 @@ void gmx::LegacySimulator::do_md()
         force_flags = (GMX_FORCE_STATECHANGED | ((inputrecDynamicBox(ir)) ? GMX_FORCE_DYNAMICBOX : 0)
                        | GMX_FORCE_ALLFORCES | (bCalcVir ? GMX_FORCE_VIRIAL : 0)
                        | (bCalcEner ? GMX_FORCE_ENERGY : 0) | (computeDHDL ? GMX_FORCE_DHDL : 0));
+        /* PLUMED */
+        if (plumedswitch && plumedNeedsEnergy)
+        {
+            /* GROMACS >= 2024 snapshots force_flags into stepWork below.
+               Keep computing energy/virial if PLUMED needed them last step. */
+            force_flags |= GMX_FORCE_ENERGY | GMX_FORCE_VIRIAL;
+        }
+        /* END PLUMED */
         if (simulationWork.useMts && !do_per_step(step, ir->nstfout))
         {
             // TODO: merge this with stepWork.useOnlyMtsCombinedForceBuffer
@@ -1372,7 +1380,7 @@ void gmx::LegacySimulator::do_md()
         {
             // Reset graph on search step (due to changing neighbour list etc)
             // or virial step (due to changing shifts and box).
-            if (bNS || bCalcVir)
+            if (bNS || bCalcVir || plumedNeedsEnergy)
             {
                 fr_->mdGraph[MdGraphEvenOrOddStep::EvenStep]->reset();
                 fr_->mdGraph[MdGraphEvenOrOddStep::OddStep]->reset();
@@ -1381,7 +1389,7 @@ void gmx::LegacySimulator::do_md()
             {
                 mdGraph->setUsedGraphLastStep(usedMdGpuGraphLastStep);
                 bool canUseMdGpuGraphThisStep =
-                        !bNS && !bCalcVir && !doTemperatureScaling && !doParrinelloRahman && !bGStat
+                        !bNS && !bCalcVir && !plumedNeedsEnergy && !doTemperatureScaling && !doParrinelloRahman && !bGStat
                         && !needHalfStepKineticEnergy && !do_per_step(step, ir->nstxout)
                         && !do_per_step(step, ir->nstxout_compressed)
                         && !do_per_step(step, ir->nstvout) && !do_per_step(step, ir->nstfout)
@@ -1471,7 +1479,21 @@ void gmx::LegacySimulator::do_md()
                   if(pversion>3) plumed_cmd(plumedmain,"doCheckPoint",&checkp);
                   plumed_cmd(plumedmain,"setForces",&f.view().force()[0][0]);
                   plumed_cmd(plumedmain,"isEnergyNeeded",&plumedNeedsEnergy);
-                  if(plumedNeedsEnergy) force_flags |= GMX_FORCE_ENERGY | GMX_FORCE_VIRIAL;
+                  if(plumedNeedsEnergy) {
+                    /* GROMACS >= 2024 ignores force_flags at the do_force call:
+                       stepWork was already built above, so rebuild it here. */
+                    force_flags |= GMX_FORCE_ENERGY | GMX_FORCE_VIRIAL;
+                    runScheduleWork_->stepWork = setupStepWorkload(
+                            legacyForceFlags | GMX_FORCE_ENERGY | GMX_FORCE_VIRIAL,
+                            ir->mtsLevels,
+                            step,
+                            runScheduleWork_->domainWork,
+                            simulationWork);
+                    if(!runScheduleWork_->stepWork.computeEnergy)
+                    {
+                      gmx_fatal(FARGS, "PLUMED needs the potential energy but GROMACS is not computing it this step");
+                    }
+                  }
                   clear_mat(plumed_vir);
                   plumed_cmd(plumedmain,"setVirial",&plumed_vir[0][0]);
                 }

--- a/patches/gromacs-2025.0.config
+++ b/patches/gromacs-2025.0.config
@@ -9,7 +9,13 @@ function plumed_patch_info(){
 cat << EOF
 A basic PLUMED interface is already present in GROMACS
 
-This patch previes extra features to be implemented in the official PLUMED integration in the next GROMACS version
+This patch provides extra features to be implemented in the official PLUMED
+integration in the next GROMACS version, including:
+
+- multiple walkers (GREX)
+- OpenMP thread count passed to PLUMED
+- ENERGY CV and energy biasing (OPES multithermal, well-tempered ensemble):
+  the native GROMACS module does not compute or pass the potential energy.
 
 Patching must be done in the gromacs root directory  _before_ the cmake command is invoked.
 

--- a/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
+++ b/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
@@ -278,9 +278,11 @@ try
     if (!energyWasComputed || potentialEnergy == nullptr)
     {
         GMX_THROW(NotImplementedError(
-                "The PLUMED input needs the potential energy, but this run is using a part of "
-                "GROMACS that cannot request it (energy minimization, shell relaxation or "
-                "mdrun -rerun). Energy-dependent PLUMED input is only supported in plain MD."));
+                "The PLUMED input needs the potential energy, but this run uses the GROMACS "
+                "modular simulator, which cannot be asked for it before the step is scheduled. "
+                "The modular simulator is the default for the md-vv integrator. Set the "
+                "environment variable GMX_DISABLE_MODULAR_SIMULATOR=1 to use the legacy "
+                "simulator, which supports energy-dependent PLUMED input."));
     }
 
     plumed_->cmd("setEnergy", potentialEnergy);

--- a/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
+++ b/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.cpp
@@ -44,6 +44,7 @@
 #include "gromacs/domdec/domdec.h"
 #include "gromacs/domdec/domdec_struct.h"
 #include "gromacs/math/units.h"
+#include "gromacs/math/vec.h"
 #include "gromacs/mdlib/gmx_omp_nthreads.h"
 #include "gromacs/mdrunutility/handlerestart.h"
 #include "gromacs/mdrunutility/multisim.h"
@@ -187,35 +188,114 @@ try
     plumed_->cmd("setCharges", forceProviderInput.chargeA_.data());
     plumed_->cmd("setBox", &forceProviderInput.box_[0][0]);
 
-    plumed_->cmd("prepareCalc", nullptr);
+    if (preparedStep_ == lstep)
+    {
+        // requestsPotentialEnergy() already ran the first half of prepareCalc.
+        plumed_->cmd("shareData", nullptr);
+    }
+    else
+    {
+        plumed_->cmd("prepareCalc", nullptr);
+        plumedNeedsEnergy_ = 0;
+        plumed_->cmd("isEnergyNeeded", &plumedNeedsEnergy_);
+    }
+    preparedStep_.reset();
 
-    int plumedWantsToStop = 0;
-    plumed_->cmd("setStopFlag", &plumedWantsToStop);
+    plumedWantsToStop_ = 0;
+    plumed_->cmd("setStopFlag", &plumedWantsToStop_);
+
+    // ENERGY biasing rescales the total MD force, which is only complete once
+    // the potential energy has been accumulated: finish in applyAfterPotentialEnergy().
+    if (plumedNeedsEnergy_)
+    {
+        return;
+    }
 
     real* fOut = &(forceProviderOutput->forceWithVirial_.force_.data()->as_vec()[0]);
     plumed_->cmd("setForces", fOut);
 
-    matrix plumed_vir;
-    clear_mat(plumed_vir);
-    plumed_->cmd("setVirial", &plumed_vir[0][0]);
+    clear_mat(plumedVir_);
+    plumed_->cmd("setVirial", &plumedVir_[0][0]);
 
-    // end setup: these instructions in the original patch are BEFORE do_force()
-    // in the original patch do_force() was called HERE
-
-    // Do the work
     plumed_->cmd("performCalc", nullptr);
 
-    if(replex_) {
-        double bias=0.0;
-        plumed_->cmd("getBias",&bias);
-        if(bias!=0.0) {
+    checkReplicaExchangeBias();
+
+    msmul(plumedVir_, 0.5, plumedVir_);
+    forceProviderOutput->forceWithVirial_.addVirialContribution(plumedVir_);
+}
+catch (const std::exception& ex)
+{
+    GMX_THROW(InternalError(
+            std::string("An error occurred while PLUMED was calculating the forces\n:") + ex.what()));
+}
+
+bool PlumedForceProvider::requestsPotentialEnergy(int64_t step)
+try
+{
+    /* Whether PLUMED needs the energy depends on which actions are active on this
+       step, which is only known after prepareDependencies(). That is the first half
+       of prepareCalc(); calculateForces() runs the second half (shareData()) once
+       the positions are available. */
+    long int lstep = step;
+    plumed_->cmd("setStepLong", &lstep);
+    plumed_->cmd("prepareDependencies", nullptr);
+    plumedNeedsEnergy_ = 0;
+    plumed_->cmd("isEnergyNeeded", &plumedNeedsEnergy_);
+    preparedStep_ = step;
+    return plumedNeedsEnergy_ != 0;
+}
+catch (const std::exception& ex)
+{
+    GMX_THROW(InternalError(
+            std::string("An error occurred while PLUMED was preparing the step\n:") + ex.what()));
+}
+
+void PlumedForceProvider::checkReplicaExchangeBias()
+{
+    if (replex_)
+    {
+        double bias = 0.0;
+        plumed_->cmd("getBias", &bias);
+        if (bias != 0.0)
+        {
             GMX_THROW(NotImplementedError("The PLUMED patch is still not compatible"
-                " with the replica exchange if PLUMED computes biases"));
+                                          " with the replica exchange if PLUMED computes biases"));
         }
     }
+}
 
-    msmul(plumed_vir, 0.5, plumed_vir);
-    forceProviderOutput->forceWithVirial_.addVirialContribution(plumed_vir);
+void PlumedForceProvider::applyAfterPotentialEnergy(bool          energyWasComputed,
+                                                    real*         potentialEnergy,
+                                                    ArrayRef<RVec> force,
+                                                    tensor        virial)
+try
+{
+    if (!plumedNeedsEnergy_)
+    {
+        return;
+    }
+    if (!energyWasComputed || potentialEnergy == nullptr)
+    {
+        GMX_THROW(NotImplementedError(
+                "The PLUMED input needs the potential energy, but this run is using a part of "
+                "GROMACS that cannot request it (energy minimization, shell relaxation or "
+                "mdrun -rerun). Energy-dependent PLUMED input is only supported in plain MD."));
+    }
+
+    plumed_->cmd("setEnergy", potentialEnergy);
+    if (!force.empty())
+    {
+        plumed_->cmd("setForces", &(force.data()->as_vec()[0]));
+    }
+    // Match the legacy GROMACS patch: pass 2*virial into PLUMED, then replace.
+    msmul(virial, 2.0, plumedVir_);
+    plumed_->cmd("setVirial", &plumedVir_[0][0]);
+    plumed_->cmd("performCalc", nullptr);
+
+    checkReplicaExchangeBias();
+
+    msmul(plumedVir_, 0.5, virial);
 }
 catch (const std::exception& ex)
 {

--- a/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.h
+++ b/patches/gromacs-2025.0.diff/src/gromacs/applied_forces/plumed/plumedforceprovider.h
@@ -42,6 +42,7 @@
 #define GMX_APPLIED_FORCES_PLUMEDFORCEPROVIDER_H
 
 #include <memory>
+#include <optional>
 
 #include "gromacs/mdtypes/iforceprovider.h"
 
@@ -75,11 +76,23 @@ public:
      */
     void calculateForces(const ForceProviderInput& forceProviderInput,
                          ForceProviderOutput*      forceProviderOutput) override;
+    bool requestsPotentialEnergy(int64_t step) override;
+    void applyAfterPotentialEnergy(bool energyWasComputed,
+                                   real* potentialEnergy,
+                                   ArrayRef<RVec> force,
+                                   tensor virial) override;
 
 private:
+    void checkReplicaExchangeBias();
+
     std::unique_ptr<PLMD::Plumed> plumed_;
     int                           plumedAPIversion_;
-    bool replex_;
+    bool                          replex_;
+    int                           plumedNeedsEnergy_ = 0;
+    int                           plumedWantsToStop_ = 0;
+    matrix                        plumedVir_         = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
+    //! Step for which requestsPotentialEnergy() already prepared the dependencies, if any.
+    std::optional<int64_t> preparedStep_;
 };
 
 } // namespace gmx

--- a/patches/gromacs-2025.0.diff/src/gromacs/mdlib/sim_util.cpp
+++ b/patches/gromacs-2025.0.diff/src/gromacs/mdlib/sim_util.cpp
@@ -1,0 +1,2659 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 1991- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+#include "gmxpre.h"
+
+#include "config.h"
+
+#include <cinttypes>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <array>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "gromacs/applied_forces/awh/awh.h"
+#include "gromacs/domdec/dlbtiming.h"
+#include "gromacs/domdec/domdec.h"
+#include "gromacs/domdec/domdec_struct.h"
+#include "gromacs/domdec/gpuhaloexchange.h"
+#include "gromacs/domdec/haloexchange.h"
+#include "gromacs/domdec/partition.h"
+#include "gromacs/essentialdynamics/edsam.h"
+#include "gromacs/ewald/pme.h"
+#include "gromacs/ewald/pme_coordinate_receiver_gpu.h"
+#include "gromacs/ewald/pme_pp.h"
+#include "gromacs/ewald/pme_pp_comm_gpu.h"
+#include "gromacs/gmxlib/network.h"
+#include "gromacs/gmxlib/nonbonded/nb_free_energy.h"
+#include "gromacs/gmxlib/nonbonded/nonbonded.h"
+#include "gromacs/gmxlib/nrnb.h"
+#include "gromacs/gpu_utils/devicebuffer_datatype.h"
+#include "gromacs/gpu_utils/gpu_utils.h"
+#include "gromacs/imd/imd.h"
+#include "gromacs/listed_forces/disre.h"
+#include "gromacs/listed_forces/listed_forces.h"
+#include "gromacs/listed_forces/listed_forces_gpu.h"
+#include "gromacs/listed_forces/orires.h"
+#include "gromacs/math/arrayrefwithpadding.h"
+#include "gromacs/math/functions.h"
+#include "gromacs/math/units.h"
+#include "gromacs/math/vec.h"
+#include "gromacs/math/vecdump.h"
+#include "gromacs/math/vectypes.h"
+#include "gromacs/mdlib/calcmu.h"
+#include "gromacs/mdlib/calcvir.h"
+#include "gromacs/mdlib/constr.h"
+#include "gromacs/mdlib/dispersioncorrection.h"
+#include "gromacs/mdlib/enerdata_utils.h"
+#include "gromacs/mdlib/force.h"
+#include "gromacs/mdlib/force_flags.h"
+#include "gromacs/mdlib/forcerec.h"
+#include "gromacs/mdlib/gmx_omp_nthreads.h"
+#include "gromacs/mdlib/update.h"
+#include "gromacs/mdlib/vsite.h"
+#include "gromacs/mdlib/wall.h"
+#include "gromacs/mdlib/wholemoleculetransform.h"
+#include "gromacs/mdrunutility/mdmodulesnotifiers.h"
+#include "gromacs/mdtypes/commrec.h"
+#include "gromacs/mdtypes/enerdata.h"
+#include "gromacs/mdtypes/forcebuffers.h"
+#include "gromacs/mdtypes/forceoutput.h"
+#include "gromacs/mdtypes/forcerec.h"
+#include "gromacs/mdtypes/iforceprovider.h"
+#include "gromacs/mdtypes/inputrec.h"
+#include "gromacs/mdtypes/locality.h"
+#include "gromacs/mdtypes/md_enums.h"
+#include "gromacs/mdtypes/mdatom.h"
+#include "gromacs/mdtypes/multipletimestepping.h"
+#include "gromacs/mdtypes/simulation_workload.h"
+#include "gromacs/mdtypes/state.h"
+#include "gromacs/mdtypes/state_propagator_data_gpu.h"
+#include "gromacs/nbnxm/atomdata.h"
+#include "gromacs/nbnxm/gpu_data_mgmt.h"
+#include "gromacs/nbnxm/nbnxm.h"
+#include "gromacs/nbnxm/nbnxm_gpu.h"
+#include "gromacs/pbcutil/ishift.h"
+#include "gromacs/pbcutil/pbc.h"
+#include "gromacs/pulling/pull.h"
+#include "gromacs/pulling/pull_rotation.h"
+#include "gromacs/timing/cyclecounter.h"
+#include "gromacs/timing/gpu_timing.h"
+#include "gromacs/timing/wallcycle.h"
+#include "gromacs/timing/wallcyclereporting.h"
+#include "gromacs/timing/walltime_accounting.h"
+#include "gromacs/topology/ifunc.h"
+#include "gromacs/topology/topology.h"
+#include "gromacs/utility/arrayref.h"
+#include "gromacs/utility/basedefinitions.h"
+#include "gromacs/utility/booltype.h"
+#include "gromacs/utility/cstringutil.h"
+#include "gromacs/utility/enumerationhelpers.h"
+#include "gromacs/utility/exceptions.h"
+#include "gromacs/utility/fatalerror.h"
+#include "gromacs/utility/fixedcapacityvector.h"
+#include "gromacs/utility/gmxassert.h"
+#include "gromacs/utility/gmxmpi.h"
+#include "gromacs/utility/logger.h"
+#include "gromacs/utility/range.h"
+#include "gromacs/utility/real.h"
+#include "gromacs/utility/smalloc.h"
+#include "gromacs/utility/strconvert.h"
+#include "gromacs/utility/stringutil.h"
+#include "gromacs/utility/sysinfo.h"
+
+#include "gpuforcereduction.h"
+
+class GpuEventSynchronizer;
+struct gmx_edsam;
+struct gmx_enfrot;
+struct gmx_multisim_t;
+struct gmx_pme_t;
+struct interaction_const_t;
+struct pull_t;
+
+namespace gmx
+{
+
+// TODO: this environment variable allows us to verify before release
+// that on less common architectures the total cost of polling is not larger than
+// a blocking wait (so polling does not introduce overhead when the static
+// PME-first ordering would suffice).
+static const bool c_disableAlternatingWait = (getenv("GMX_DISABLE_ALTERNATING_GPU_WAIT") != nullptr);
+
+static void sum_forces(ArrayRef<RVec> f, ArrayRef<const RVec> forceToAdd)
+{
+    GMX_ASSERT(f.size() >= forceToAdd.size(), "Accumulation buffer should be sufficiently large");
+    const int end = forceToAdd.size();
+
+    int gmx_unused nt = gmx_omp_nthreads_get(ModuleMultiThread::Default);
+#pragma omp parallel for num_threads(nt) schedule(static)
+    for (int i = 0; i < end; i++)
+    {
+        rvec_inc(f[i], forceToAdd[i]);
+    }
+}
+
+static void calc_virial(int                         start,
+                        int                         homenr,
+                        const rvec                  x[],
+                        const ForceWithShiftForces& forceWithShiftForces,
+                        tensor                      vir_part,
+                        const matrix                box,
+                        t_nrnb*                     nrnb,
+                        const t_forcerec*           fr,
+                        PbcType                     pbcType)
+{
+    /* The short-range virial from surrounding boxes */
+    const rvec* fshift          = as_rvec_array(forceWithShiftForces.shiftForces().data());
+    const rvec* shiftVecPointer = as_rvec_array(fr->shift_vec.data());
+    calc_vir(c_numShiftVectors, shiftVecPointer, fshift, vir_part, pbcType == PbcType::Screw, box);
+    inc_nrnb(nrnb, eNR_VIRIAL, c_numShiftVectors);
+
+    /* Calculate partial virial, for local atoms only, based on short range.
+     * Total virial is computed in global_stat, called from do_md
+     */
+    const rvec* f = as_rvec_array(forceWithShiftForces.force().data());
+    f_calc_vir(start, start + homenr, x, f, vir_part, box);
+    inc_nrnb(nrnb, eNR_VIRIAL, homenr);
+
+    if (debug)
+    {
+        pr_rvecs(debug, 0, "vir_part", vir_part, DIM);
+    }
+}
+
+static void pull_potential_wrapper(const t_commrec*     cr,
+                                   const t_inputrec&    ir,
+                                   const matrix         box,
+                                   ArrayRef<const RVec> x,
+                                   const t_mdatoms*     mdatoms,
+                                   gmx_enerdata_t*      enerd,
+                                   pull_t*              pull_work,
+                                   const real*          lambda,
+                                   double               t,
+                                   gmx_wallcycle*       wcycle)
+{
+    t_pbc pbc;
+    real  dvdl;
+
+    /* Calculate the center of mass forces, this requires communication,
+     * which is why pull_potential is called close to other communication.
+     */
+    wallcycle_start(wcycle, WallCycleCounter::PullPot);
+    set_pbc(&pbc, ir.pbcType, box);
+    dvdl = 0;
+    enerd->term[F_COM_PULL] +=
+            pull_potential(pull_work,
+                           mdatoms->massT,
+                           pbc,
+                           cr,
+                           t,
+                           lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Restraint)],
+                           x,
+                           &dvdl);
+    enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Restraint] += dvdl;
+    wallcycle_stop(wcycle, WallCycleCounter::PullPot);
+}
+
+static void pme_receive_force_ener(t_forcerec*      fr,
+                                   const t_commrec* cr,
+                                   ForceWithVirial* forceWithVirial,
+                                   gmx_enerdata_t*  enerd,
+                                   bool             useGpuPmePpComms,
+                                   bool             receivePmeForceToGpu,
+                                   gmx_wallcycle*   wcycle)
+{
+    real  e_q, e_lj, dvdl_q, dvdl_lj;
+    float cycles_ppdpme, cycles_seppme;
+
+    cycles_ppdpme = wallcycle_stop(wcycle, WallCycleCounter::PpDuringPme);
+    dd_cycles_add(cr->dd, cycles_ppdpme, ddCyclPPduringPME);
+
+    /* In case of node-splitting, the PP nodes receive the long-range
+     * forces, virial and energy from the PME nodes here.
+     */
+    wallcycle_start(wcycle, WallCycleCounter::PpPmeWaitRecvF);
+    dvdl_q  = 0;
+    dvdl_lj = 0;
+    gmx_pme_receive_f(fr->pmePpCommGpu.get(),
+                      cr,
+                      forceWithVirial,
+                      &e_q,
+                      &e_lj,
+                      &dvdl_q,
+                      &dvdl_lj,
+                      useGpuPmePpComms,
+                      receivePmeForceToGpu,
+                      &cycles_seppme);
+    enerd->term[F_COUL_RECIP] += e_q;
+    enerd->term[F_LJ_RECIP] += e_lj;
+    enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Coul] += dvdl_q;
+    enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Vdw] += dvdl_lj;
+
+    if (wcycle)
+    {
+        dd_cycles_add(cr->dd, cycles_seppme, ddCyclPME);
+    }
+    wallcycle_stop(wcycle, WallCycleCounter::PpPmeWaitRecvF);
+}
+
+static void print_large_forces(FILE*                fp,
+                               const t_mdatoms*     md,
+                               const t_commrec*     cr,
+                               int64_t              step,
+                               real                 forceTolerance,
+                               ArrayRef<const RVec> x,
+                               ArrayRef<const RVec> f)
+{
+    real  force2Tolerance = square(forceTolerance);
+    Index numNonFinite    = 0;
+    for (int i = 0; i < md->homenr; i++)
+    {
+        real force2    = norm2(f[i]);
+        bool nonFinite = !std::isfinite(force2);
+        if (force2 >= force2Tolerance || nonFinite)
+        {
+            fprintf(fp,
+                    "step %" PRId64 " atom %6d  x %8.3f %8.3f %8.3f  force %12.5e\n",
+                    step,
+                    ddglatnr(cr->dd, i),
+                    x[i][XX],
+                    x[i][YY],
+                    x[i][ZZ],
+                    std::sqrt(force2));
+        }
+        if (nonFinite)
+        {
+            numNonFinite++;
+        }
+    }
+    if (numNonFinite > 0)
+    {
+        /* Note that with MPI this fatal call on one rank might interrupt
+         * the printing on other ranks. But we can only avoid that with
+         * an expensive MPI barrier that we would need at each step.
+         */
+        gmx_fatal(FARGS, "At step %" PRId64 " detected non-finite forces on %td atoms", step, numNonFinite);
+    }
+}
+
+//! When necessary, spreads forces on vsites and computes the virial for \p forceOutputs->forceWithShiftForces()
+static void postProcessForceWithShiftForces(t_nrnb*              nrnb,
+                                            gmx_wallcycle*       wcycle,
+                                            const matrix         box,
+                                            ArrayRef<const RVec> x,
+                                            ForceOutputs*        forceOutputs,
+                                            tensor               vir_force,
+                                            const t_mdatoms&     mdatoms,
+                                            const t_forcerec&    fr,
+                                            VirtualSitesHandler* vsite,
+                                            const StepWorkload&  stepWork)
+{
+    ForceWithShiftForces& forceWithShiftForces = forceOutputs->forceWithShiftForces();
+
+    /* If we have NoVirSum forces, but we do not calculate the virial,
+     * we later sum the forceWithShiftForces buffer together with
+     * the noVirSum buffer and spread the combined vsite forces at once.
+     */
+    if (vsite && (!forceOutputs->haveForceWithVirial() || stepWork.computeVirial))
+    {
+        using VirialHandling = VirtualSitesHandler::VirialHandling;
+
+        auto                 f      = forceWithShiftForces.force();
+        auto                 fshift = forceWithShiftForces.shiftForces();
+        const VirialHandling virialHandling =
+                (stepWork.computeVirial ? VirialHandling::Pbc : VirialHandling::None);
+        vsite->spreadForces(x, f, virialHandling, fshift, nullptr, nrnb, box, wcycle);
+        forceWithShiftForces.haveSpreadVsiteForces() = true;
+    }
+
+    if (stepWork.computeVirial)
+    {
+        /* Calculation of the virial must be done after vsites! */
+        calc_virial(
+                0, mdatoms.homenr, as_rvec_array(x.data()), forceWithShiftForces, vir_force, box, nrnb, &fr, fr.pbcType);
+    }
+}
+
+//! Spread, compute virial for and sum forces, when necessary
+static void postProcessForces(const t_commrec*     cr,
+                              int64_t              step,
+                              t_nrnb*              nrnb,
+                              gmx_wallcycle*       wcycle,
+                              const matrix         box,
+                              ArrayRef<const RVec> x,
+                              ForceOutputs*        forceOutputs,
+                              tensor               vir_force,
+                              const t_mdatoms*     mdatoms,
+                              const t_forcerec*    fr,
+                              VirtualSitesHandler* vsite,
+                              const StepWorkload&  stepWork)
+{
+    // Extract the final output force buffer, which is also the buffer for forces with shift forces
+    ArrayRef<RVec> f = forceOutputs->forceWithShiftForces().force();
+
+    if (forceOutputs->haveForceWithVirial())
+    {
+        auto& forceWithVirial = forceOutputs->forceWithVirial();
+
+        if (vsite)
+        {
+            /* Spread the mesh force on virtual sites to the other particles...
+             * This is parallellized. MPI communication is performed
+             * if the constructing atoms aren't local.
+             */
+            GMX_ASSERT(!stepWork.computeVirial || f.data() != forceWithVirial.force_.data(),
+                       "We need separate force buffers for shift and virial forces when "
+                       "computing the virial");
+            GMX_ASSERT(!stepWork.computeVirial
+                               || forceOutputs->forceWithShiftForces().haveSpreadVsiteForces(),
+                       "We should spread the force with shift forces separately when computing "
+                       "the virial");
+            const VirtualSitesHandler::VirialHandling virialHandling =
+                    (stepWork.computeVirial ? VirtualSitesHandler::VirialHandling::NonLinear
+                                            : VirtualSitesHandler::VirialHandling::None);
+            matrix virial = { { 0 } };
+            vsite->spreadForces(x, forceWithVirial.force_, virialHandling, {}, virial, nrnb, box, wcycle);
+            forceWithVirial.addVirialContribution(virial);
+        }
+
+        if (stepWork.computeVirial)
+        {
+            /* Now add the forces, this is local */
+            sum_forces(f, forceWithVirial.force_);
+
+            /* Add the direct virial contributions */
+            GMX_ASSERT(
+                    forceWithVirial.computeVirial_,
+                    "forceWithVirial should request virial computation when we request the virial");
+            m_add(vir_force, forceWithVirial.getVirial(), vir_force);
+
+            if (debug)
+            {
+                pr_rvecs(debug, 0, "vir_force", vir_force, DIM);
+            }
+        }
+    }
+    else
+    {
+        GMX_ASSERT(vsite == nullptr || forceOutputs->forceWithShiftForces().haveSpreadVsiteForces(),
+                   "We should have spread the vsite forces (earlier)");
+    }
+
+    if (fr->print_force >= 0)
+    {
+        print_large_forces(stderr, mdatoms, cr, step, fr->print_force, x, f);
+    }
+}
+
+static void do_nb_verlet(t_forcerec*                fr,
+                         const interaction_const_t* ic,
+                         gmx_enerdata_t*            enerd,
+                         const StepWorkload&        stepWork,
+                         const InteractionLocality  ilocality,
+                         const int                  clearF,
+                         const int64_t              step,
+                         t_nrnb*                    nrnb,
+                         gmx_wallcycle*             wcycle)
+{
+    if (!stepWork.computeNonbondedForces)
+    {
+        /* skip non-bonded calculation */
+        return;
+    }
+
+    nonbonded_verlet_t* nbv = fr->nbv.get();
+
+    /* GPU kernel launch overhead is already timed separately */
+    if (!nbv->useGpu())
+    {
+        /* When dynamic pair-list  pruning is requested, we need to prune
+         * at nstlistPrune steps.
+         */
+        if (nbv->isDynamicPruningStepCpu(step))
+        {
+            /* Prune the pair-list beyond fr->ic->rlistPrune using
+             * the current coordinates of the atoms.
+             */
+            wallcycle_sub_start(wcycle, WallCycleSubCounter::NonbondedPruning);
+            nbv->dispatchPruneKernelCpu(ilocality, fr->shift_vec);
+            wallcycle_sub_stop(wcycle, WallCycleSubCounter::NonbondedPruning);
+        }
+    }
+
+    nbv->dispatchNonbondedKernel(
+            ilocality,
+            *ic,
+            stepWork,
+            clearF,
+            fr->shift_vec,
+            enerd->grpp.energyGroupPairTerms[fr->haveBuckingham ? NonBondedEnergyTerms::BuckinghamSR
+                                                                : NonBondedEnergyTerms::LJSR],
+            enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::CoulombSR],
+            nrnb);
+}
+
+static inline void clearRVecs(ArrayRef<RVec> v, const bool useOpenmpThreading)
+{
+    int nth = gmx_omp_nthreads_get_simple_rvec_task(ModuleMultiThread::Default, v.ssize());
+
+    /* Note that we would like to avoid this conditional by putting it
+     * into the omp pragma instead, but then we still take the full
+     * omp parallel for overhead (at least with gcc5).
+     */
+    if (!useOpenmpThreading || nth == 1)
+    {
+        for (RVec& elem : v)
+        {
+            clear_rvec(elem);
+        }
+    }
+    else
+    {
+#pragma omp parallel for num_threads(nth) schedule(static)
+        for (Index i = 0; i < v.ssize(); i++)
+        {
+            clear_rvec(v[i]);
+        }
+    }
+}
+
+/*! \brief Return an estimate of the average kinetic energy or 0 when unreliable
+ *
+ * \param groupOptions  Group options, containing T-coupling options
+ */
+static real averageKineticEnergyEstimate(const t_grpopts& groupOptions)
+{
+    real nrdfCoupled   = 0;
+    real nrdfUncoupled = 0;
+    real kineticEnergy = 0;
+    for (int g = 0; g < groupOptions.ngtc; g++)
+    {
+        if (groupOptions.tau_t[g] >= 0)
+        {
+            nrdfCoupled += groupOptions.nrdf[g];
+            kineticEnergy += groupOptions.nrdf[g] * 0.5 * groupOptions.ref_t[g] * c_boltz;
+        }
+        else
+        {
+            nrdfUncoupled += groupOptions.nrdf[g];
+        }
+    }
+
+    /* This conditional with > also catches nrdf=0 */
+    if (nrdfCoupled > nrdfUncoupled)
+    {
+        return kineticEnergy * (nrdfCoupled + nrdfUncoupled) / nrdfCoupled;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+/*! \brief This routine checks that the potential energy is finite.
+ *
+ * Always checks that the potential energy is finite. If step equals
+ * inputrec.init_step also checks that the magnitude of the potential energy
+ * is reasonable. Terminates with a fatal error when a check fails.
+ * Note that passing this check does not guarantee finite forces,
+ * since those use slightly different arithmetics. But in most cases
+ * there is just a narrow coordinate range where forces are not finite
+ * and energies are finite.
+ *
+ * \param[in] step      The step number, used for checking and printing
+ * \param[in] enerd     The energy data; the non-bonded group energies need to be added to
+ *                      \c enerd.term[F_EPOT] before calling this routine
+ * \param[in] inputrec  The input record
+ */
+static void checkPotentialEnergyValidity(int64_t step, const gmx_enerdata_t& enerd, const t_inputrec& inputrec)
+{
+    /* Threshold valid for comparing absolute potential energy against
+     * the kinetic energy. Normally one should not consider absolute
+     * potential energy values, but with a factor of one million
+     * we should never get false positives.
+     */
+    constexpr real c_thresholdFactor = 1e6;
+
+    bool energyIsNotFinite    = !std::isfinite(enerd.term[F_EPOT]);
+    real averageKineticEnergy = 0;
+    /* We only check for large potential energy at the initial step,
+     * because that is by far the most likely step for this too occur
+     * and because computing the average kinetic energy is not free.
+     * Note: nstcalcenergy >> 1 often does not allow to catch large energies
+     * before they become NaN.
+     */
+    if (step == inputrec.init_step && EI_DYNAMICS(inputrec.eI))
+    {
+        averageKineticEnergy = averageKineticEnergyEstimate(inputrec.opts);
+    }
+
+    if (energyIsNotFinite
+        || (averageKineticEnergy > 0 && enerd.term[F_EPOT] > c_thresholdFactor * averageKineticEnergy))
+    {
+        GMX_THROW(InternalError(formatString(
+                "Step %" PRId64
+                ": The total potential energy is %g, which is %s. The LJ and electrostatic "
+                "contributions to the energy are %g and %g, respectively. A %s potential energy "
+                "can be caused by overlapping interactions in bonded interactions or very large%s "
+                "coordinate values. Usually this is caused by a badly- or non-equilibrated initial "
+                "configuration, incorrect interactions or parameters in the topology.",
+                step,
+                enerd.term[F_EPOT],
+                energyIsNotFinite ? "not finite" : "extremely high",
+                enerd.term[F_LJ],
+                enerd.term[F_COUL_SR],
+                energyIsNotFinite ? "non-finite" : "very high",
+                energyIsNotFinite ? " or Nan" : "")));
+    }
+}
+
+/*! \brief Compute forces and/or energies for special algorithms
+ *
+ * The intention is to collect all calls to algorithms that compute
+ * forces on local atoms only and that do not contribute to the local
+ * virial sum (but add their virial contribution separately).
+ * Eventually these should likely all become ForceProviders.
+ * Within this function the intention is to have algorithms that do
+ * global communication at the end, so global barriers within the MD loop
+ * are as close together as possible.
+ *
+ * \param[in]     fplog            The log file
+ * \param[in]     cr               The communication record
+ * \param[in]     inputrec         The input record
+ * \param[in]     awh              The Awh module (nullptr if none in use).
+ * \param[in]     enforcedRotation Enforced rotation module.
+ * \param[in]     imdSession       The IMD session
+ * \param[in]     pull_work        The pull work structure.
+ * \param[in]     step             The current MD step
+ * \param[in]     t                The current time
+ * \param[in,out] wcycle           Wallcycle accounting struct
+ * \param[in,out] forceProviders   Pointer to a list of force providers
+ * \param[in]     box              The unit cell
+ * \param[in]     x                The coordinates
+ * \param[in]     mdatoms          Per atom properties
+ * \param[in]     lambda           Array of free-energy lambda values
+ * \param[in]     stepWork         Step schedule flags
+ * \param[in,out] forceWithVirialMtsLevel0  Force and virial for MTS level0 forces
+ * \param[in,out] forceWithVirialMtsLevel1  Force and virial for MTS level1 forces, can be nullptr
+ * \param[in,out] enerd            Energy buffer
+ * \param[in,out] ed               Essential dynamics pointer
+ * \param[in]     didNeighborSearch  Tells if we did neighbor searching this step,
+ *                                   used for ED sampling
+ * \param[in]     wcycle           The wallcycle structure
+ *
+ * \todo Remove didNeighborSearch, which is used incorrectly.
+ * \todo Convert all other algorithms called here to ForceProviders.
+ */
+static void computeSpecialForces(FILE*                fplog,
+                                 const t_commrec*     cr,
+                                 const t_inputrec&    inputrec,
+                                 Awh*                 awh,
+                                 gmx_enfrot*          enforcedRotation,
+                                 ImdSession*          imdSession,
+                                 pull_t*              pull_work,
+                                 int64_t              step,
+                                 double               t,
+                                 gmx_wallcycle*       wcycle,
+                                 ForceProviders*      forceProviders,
+                                 const matrix         box,
+                                 ArrayRef<const RVec> x,
+                                 const t_mdatoms*     mdatoms,
+                                 ArrayRef<const real> lambda,
+                                 const StepWorkload&  stepWork,
+                                 ForceWithVirial*     forceWithVirialMtsLevel0,
+                                 ForceWithVirial*     forceWithVirialMtsLevel1,
+                                 gmx_enerdata_t*      enerd,
+                                 gmx_edsam*           ed,
+                                 bool                 didNeighborSearch)
+{
+    /* NOTE: Currently all ForceProviders only provide forces.
+     *       When they also provide energies, remove this conditional.
+     */
+    if (stepWork.computeForces)
+    {
+        ForceProviderInput  forceProviderInput(x,
+                                              mdatoms->homenr,
+                                              makeArrayRef(mdatoms->chargeA).subArray(0, mdatoms->homenr),
+                                              makeArrayRef(mdatoms->massT).subArray(0, mdatoms->homenr),
+                                              t,
+                                              step,
+                                              box,
+                                              *cr);
+        ForceProviderOutput forceProviderOutput(forceWithVirialMtsLevel0, enerd);
+
+        /* Collect forces from modules */
+        forceProviders->calculateForces(forceProviderInput, &forceProviderOutput);
+    }
+
+    const int  pullMtsLevel = forceGroupMtsLevel(inputrec.mtsLevels, MtsForceGroups::Pull);
+    const bool doPulling    = (inputrec.bPull && pull_have_potential(*pull_work)
+                            && (pullMtsLevel == 0 || stepWork.computeSlowForces));
+
+    /* pull_potential_wrapper(), awh->applyBiasForcesAndUpdateBias(), pull_apply_forces()
+     * have to be called in this order
+     */
+    if (doPulling)
+    {
+        pull_potential_wrapper(cr, inputrec, box, x, mdatoms, enerd, pull_work, lambda.data(), t, wcycle);
+    }
+    if (awh && (pullMtsLevel == 0 || stepWork.computeSlowForces))
+    {
+        const bool          needForeignEnergyDifferences = awh->needForeignEnergyDifferences(step);
+        std::vector<double> foreignLambdaDeltaH, foreignLambdaDhDl;
+        if (needForeignEnergyDifferences)
+        {
+            enerd->foreignLambdaTerms.finalizePotentialContributions(
+                    enerd->dvdl_lin, lambda, *inputrec.fepvals);
+            std::tie(foreignLambdaDeltaH, foreignLambdaDhDl) = enerd->foreignLambdaTerms.getTerms(cr);
+        }
+
+        enerd->term[F_COM_PULL] += awh->applyBiasForcesAndUpdateBias(
+                inputrec.pbcType, foreignLambdaDeltaH, foreignLambdaDhDl, box, t, step, wcycle, fplog);
+    }
+    if (doPulling)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::PullPot);
+        auto& forceWithVirial = (pullMtsLevel == 0) ? forceWithVirialMtsLevel0 : forceWithVirialMtsLevel1;
+        pull_apply_forces(pull_work, mdatoms->massT, cr, forceWithVirial);
+        wallcycle_stop(wcycle, WallCycleCounter::PullPot);
+    }
+
+    /* Add the forces from enforced rotation potentials (if any) */
+    if (inputrec.bRot)
+    {
+        wallcycle_start(wcycle, WallCycleCounter::RotAdd);
+        enerd->term[F_COM_PULL] +=
+                add_rot_forces(enforcedRotation, forceWithVirialMtsLevel0->force_, cr, step, t);
+        wallcycle_stop(wcycle, WallCycleCounter::RotAdd);
+    }
+
+    if (ed)
+    {
+        /* Note that since init_edsam() is called after the initialization
+         * of forcerec, edsam doesn't request the noVirSum force buffer.
+         * Thus if no other algorithm (e.g. PME) requires it, the forces
+         * here will contribute to the virial.
+         */
+        do_flood(cr, inputrec, x, forceWithVirialMtsLevel0->force_, ed, box, step, didNeighborSearch);
+    }
+
+    /* Add forces from interactive molecular dynamics (IMD), if any */
+    if (inputrec.bIMD && stepWork.computeForces)
+    {
+        imdSession->applyForces(forceWithVirialMtsLevel0->force_);
+    }
+}
+
+/*! \brief Launch the prepare_step and spread stages of PME GPU.
+ *
+ * \param[in]  pmedata              The PME structure
+ * \param[in]  box                  The box matrix
+ * \param[in]  stepWork             Step schedule flags
+ * \param[in]  xReadyOnDevice       Event synchronizer indicating that the coordinates are ready in the device memory.
+ * \param[in]  lambdaQ              The Coulomb lambda of the current state.
+ * \param[in]  useMdGpuGraph        Whether MD GPU Graph is in use.
+ * \param[in]  wcycle               The wallcycle structure
+ */
+static inline void launchPmeGpuSpread(gmx_pme_t*            pmedata,
+                                      const matrix          box,
+                                      const StepWorkload&   stepWork,
+                                      GpuEventSynchronizer* xReadyOnDevice,
+                                      const real            lambdaQ,
+                                      bool                  useMdGpuGraph,
+                                      gmx_wallcycle*        wcycle)
+{
+    wallcycle_start(wcycle, WallCycleCounter::PmeGpuMesh);
+    pme_gpu_prepare_computation(pmedata, box, wcycle, stepWork);
+    bool                      useGpuDirectComm         = false;
+    PmeCoordinateReceiverGpu* pmeCoordinateReceiverGpu = nullptr;
+    pme_gpu_launch_spread(
+            pmedata, xReadyOnDevice, wcycle, lambdaQ, useGpuDirectComm, pmeCoordinateReceiverGpu, useMdGpuGraph);
+    wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+}
+
+/*! \brief Launch the FFT and gather stages of PME GPU
+ *
+ * This function only implements setting the output forces (no accumulation).
+ *
+ * \param[in]  pmedata        The PME structure
+ * \param[in]  lambdaQ        The Coulomb lambda of the current system state.
+ * \param[in]  wcycle         The wallcycle structure
+ * \param[in]  stepWork       Step schedule flags
+ */
+static void launchPmeGpuFftAndGather(gmx_pme_t*          pmedata,
+                                     const real          lambdaQ,
+                                     gmx_wallcycle*      wcycle,
+                                     const StepWorkload& stepWork)
+{
+    wallcycle_start_nocount(wcycle, WallCycleCounter::PmeGpuMesh);
+    pme_gpu_launch_complex_transforms(pmedata, wcycle, stepWork);
+    pme_gpu_launch_gather(pmedata, wcycle, lambdaQ, stepWork.computeVirial);
+    wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+}
+
+/*! \brief
+ * Blocks until PME GPU tasks are completed, and gets the output forces and virial/energy
+ * (if they were to be computed).
+ *
+ * \param[in]  pme             The PME data structure.
+ * \param[in]  stepWork        The required work for this simulation step
+ * \param[in]  wcycle          The wallclock counter.
+ * \param[out] forceWithVirial The output force and virial
+ * \param[out] enerd           The output energies
+ * \param[in]  lambdaQ         The Coulomb lambda to use when calculating the results.
+ */
+static void pmeGpuWaitAndReduce(gmx_pme_t*          pme,
+                                const StepWorkload& stepWork,
+                                gmx_wallcycle*      wcycle,
+                                ForceWithVirial*    forceWithVirial,
+                                gmx_enerdata_t*     enerd,
+                                const real          lambdaQ)
+{
+    wallcycle_start_nocount(wcycle, WallCycleCounter::PmeGpuMesh);
+
+    pme_gpu_wait_and_reduce(pme, stepWork, wcycle, forceWithVirial, enerd, lambdaQ);
+
+    wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+}
+
+/*! \brief
+ *  Polling wait for either of the PME or nonbonded GPU tasks.
+ *
+ * Instead of a static order in waiting for GPU tasks, this function
+ * polls checking which of the two tasks completes first, and does the
+ * associated force buffer reduction overlapped with the other task.
+ * By doing that, unlike static scheduling order, it can always overlap
+ * one of the reductions, regardless of the GPU task completion order.
+ *
+ * \param[in]     nbv              Nonbonded verlet structure
+ * \param[in,out] pmedata          PME module data
+ * \param[in,out] forceOutputsNonbonded  Force outputs for the non-bonded forces and shift forces
+ * \param[in,out] forceOutputsPme  Force outputs for the PME forces and virial
+ * \param[in,out] enerd            Energy data structure results are reduced into
+ * \param[in]     lambdaQ          The Coulomb lambda of the current system state.
+ * \param[in]     stepWork         Step schedule flags
+ * \param[in]     wcycle           The wallcycle structure
+ */
+static void alternatePmeNbGpuWaitReduce(nonbonded_verlet_t* nbv,
+                                        gmx_pme_t*          pmedata,
+                                        ForceOutputs*       forceOutputsNonbonded,
+                                        ForceOutputs*       forceOutputsPme,
+                                        gmx_enerdata_t*     enerd,
+                                        const real          lambdaQ,
+                                        const StepWorkload& stepWork,
+                                        gmx_wallcycle*      wcycle)
+{
+    bool isPmeGpuDone = false;
+    bool isNbGpuDone  = false;
+
+    ArrayRef<const RVec> pmeGpuForces;
+
+    while (!isPmeGpuDone || !isNbGpuDone)
+    {
+        if (!isPmeGpuDone)
+        {
+            wallcycle_start_nocount(wcycle, WallCycleCounter::PmeGpuMesh);
+            GpuTaskCompletion completionType =
+                    (isNbGpuDone) ? GpuTaskCompletion::Wait : GpuTaskCompletion::Check;
+            isPmeGpuDone = pme_gpu_try_finish_task(
+                    pmedata, stepWork, wcycle, &forceOutputsPme->forceWithVirial(), enerd, lambdaQ, completionType);
+            wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+        }
+
+        if (!isNbGpuDone)
+        {
+            auto&             forceBuffersNonbonded = forceOutputsNonbonded->forceWithShiftForces();
+            GpuTaskCompletion completionType =
+                    (isPmeGpuDone) ? GpuTaskCompletion::Wait : GpuTaskCompletion::Check;
+            // To get the wcycle call count right, when in GpuTaskCompletion::Check mode,
+            // we start without counting and only when the task finished we issue a
+            // start/stop to increment.
+            // GpuTaskCompletion::Wait mode the timing is expected to be done in the caller.
+            wallcycle_start_nocount(wcycle, WallCycleCounter::WaitGpuNbL);
+            isNbGpuDone = gpu_try_finish_task(
+                    nbv->gpuNbv(),
+                    stepWork,
+                    AtomLocality::Local,
+                    enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::LJSR].data(),
+                    enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::CoulombSR].data(),
+                    forceBuffersNonbonded.shiftForces(),
+                    completionType);
+            wallcycle_stop(wcycle, WallCycleCounter::WaitGpuNbL);
+
+            if (isNbGpuDone)
+            {
+                wallcycle_increment_event_count(wcycle, WallCycleCounter::WaitGpuNbL);
+                nbv->atomdata_add_nbat_f_to_f(AtomLocality::Local, forceBuffersNonbonded.force());
+            }
+        }
+    }
+}
+
+/*! \brief Set up the different force buffers; also does clearing.
+ *
+ * \param[in] forceHelperBuffers        Helper force buffers
+ * \param[in] force                     force array
+ * \param[in] domainWork                Domain lifetime workload flags
+ * \param[in] stepWork                  Step schedule flags
+ * \param[in] havePpDomainDecomposition Whether we have a PP domain decomposition
+ * \param[out] wcycle                   wallcycle recording structure
+ *
+ * \returns                             Cleared force output structure
+ */
+static ForceOutputs setupForceOutputs(ForceHelperBuffers*           forceHelperBuffers,
+                                      ArrayRefWithPadding<RVec>     force,
+                                      const DomainLifetimeWorkload& domainWork,
+                                      const StepWorkload&           stepWork,
+                                      const bool                    havePpDomainDecomposition,
+                                      gmx_wallcycle*                wcycle)
+{
+    /* NOTE: We assume fr->shiftForces is all zeros here */
+    ForceWithShiftForces forceWithShiftForces(
+            force, stepWork.computeVirial, forceHelperBuffers->shiftForces());
+
+    if (stepWork.computeForces
+        && (domainWork.haveCpuLocalForceWork || !stepWork.useGpuFBufferOps
+            || (havePpDomainDecomposition && !stepWork.useGpuFHalo)))
+    {
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::ClearForceBuffer);
+        /* Clear the short- and long-range forces */
+        clearRVecs(forceWithShiftForces.force(), true);
+
+        /* Clear the shift forces */
+        clearRVecs(forceWithShiftForces.shiftForces(), false);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::ClearForceBuffer);
+    }
+
+    /* If we need to compute the virial, we might need a separate
+     * force buffer for algorithms for which the virial is calculated
+     * directly, such as PME. Otherwise, forceWithVirial uses the
+     * the same force (f in legacy calls) buffer as other algorithms.
+     */
+    const bool useSeparateForceWithVirialBuffer =
+            (stepWork.computeForces
+             && (stepWork.computeVirial && forceHelperBuffers->haveDirectVirialContributions()));
+    /* forceWithVirial uses the local atom range only */
+    ForceWithVirial forceWithVirial(useSeparateForceWithVirialBuffer
+                                            ? forceHelperBuffers->forceBufferForDirectVirialContributions()
+                                            : force.unpaddedArrayRef(),
+                                    stepWork.computeVirial);
+
+    if (useSeparateForceWithVirialBuffer)
+    {
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::ClearForceBuffer);
+        /* TODO: update comment
+         * We only compute forces on local atoms. Note that vsites can
+         * spread to non-local atoms, but that part of the buffer is
+         * cleared separately in the vsite spreading code.
+         */
+        clearRVecs(forceWithVirial.force_, true);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::ClearForceBuffer);
+    }
+
+
+    return ForceOutputs(
+            forceWithShiftForces, forceHelperBuffers->haveDirectVirialContributions(), forceWithVirial);
+}
+
+/* \brief Launch end-of-step GPU tasks: buffer clearing and rolling pruning.
+ *
+ */
+static void launchGpuEndOfStepTasks(nonbonded_verlet_t*          nbv,
+                                    ListedForcesGpu*             listedForcesGpu,
+                                    gmx_pme_t*                   pmedata,
+                                    gmx_enerdata_t*              enerd,
+                                    const MdrunScheduleWorkload& runScheduleWork,
+                                    int64_t                      step,
+                                    gmx_wallcycle*               wcycle)
+{
+    if (runScheduleWork.simulationWork.useGpuNonbonded && runScheduleWork.stepWork.computeNonbondedForces)
+    {
+        /* Launch pruning before buffer clearing because the API overhead of the
+         * clear kernel launches can leave the GPU idle while it could be running
+         * the prune kernel.
+         */
+        if (nbv->isDynamicPruningStepGpu(step))
+        {
+            nbv->dispatchPruneKernelGpu(step);
+        }
+
+        /* now clear the GPU outputs while we finish the step on the CPU */
+        wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        gpu_clear_outputs(nbv->gpuNbv(), runScheduleWork.stepWork.computeVirial);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+    }
+
+    if (runScheduleWork.stepWork.haveGpuPmeOnThisRank)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::PmeGpuMesh);
+        bool gpuGraphWithSeparatePmeRank = false;
+        pme_gpu_reinit_computation(pmedata, gpuGraphWithSeparatePmeRank, wcycle);
+        wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+    }
+
+    if (runScheduleWork.domainWork.haveGpuBondedWork && runScheduleWork.stepWork.computeEnergy)
+    {
+        // in principle this should be included in the DD balancing region,
+        // but generally it is infrequent so we'll omit it for the sake of
+        // simpler code
+        listedForcesGpu->waitAccumulateEnergyTerms(enerd);
+
+        listedForcesGpu->clearEnergies();
+    }
+}
+
+/*! \brief Compute the number of times the "local coordinates ready on device" GPU event will be used as a synchronization point.
+ *
+ * When some work is offloaded to GPU, force calculation should wait for the atom coordinates to
+ * be ready on the device. The coordinates can come either from H2D copy at the beginning of the step,
+ * or from the GPU integration at the end of the previous step.
+ *
+ * In GROMACS, we usually follow the "mark once - wait once" approach. But this event is "consumed"
+ * (that is, waited upon either on host or on the device) multiple times, since many tasks
+ * in different streams depend on the coordinates.
+ *
+ * This function return the number of times the event will be consumed based on this step's workload.
+ *
+ * \param simulationWork Simulation workload flags.
+ * \param stepWork Step workload flags.
+ * \param domainWork Domain workload flags.
+ * \param pmeSendCoordinatesFromGpu Whether peer-to-peer communication is used for PME coordinates.
+ * \return
+ */
+static int getExpectedLocalXReadyOnDeviceConsumptionCount(const SimulationWorkload& simulationWork,
+                                                          const StepWorkload&       stepWork,
+                                                          const DomainLifetimeWorkload& domainWork,
+                                                          bool pmeSendCoordinatesFromGpu)
+{
+    int result = 0;
+    if (stepWork.computeSlowForces)
+    {
+        if (pmeSendCoordinatesFromGpu)
+        {
+            GMX_ASSERT(simulationWork.haveSeparatePmeRank,
+                       "GPU PME PP communications require having a separate PME rank");
+            // Event is consumed by gmx_pme_send_coordinates for GPU PME PP Communications
+            result++;
+        }
+        if (stepWork.haveGpuPmeOnThisRank)
+        {
+            // Event is consumed by launchPmeGpuSpread
+            result++;
+        }
+        if (stepWork.computeNonbondedForces && stepWork.useGpuXBufferOps)
+        {
+            // Event is consumed by convertCoordinatesGpu
+            result++;
+        }
+    }
+    if (stepWork.useGpuXHalo)
+    {
+        // Event is consumed by communicateGpuHaloCoordinates
+        result++;
+        if (GMX_THREAD_MPI) // Issue #4262
+        {
+            result++;
+        }
+    }
+    if (stepWork.clearGpuFBufferEarly && simulationWork.useGpuUpdate)
+    {
+        // Event is consumed by force clearing which waits for the update to complete
+        result++;
+    }
+    if (simulationWork.useGpuUpdate && domainWork.haveCpuLocalForceWork)
+    {
+        // Event is consumed when waiting for it on the CPU prior to CPU force buffer clearing.
+        // The actual data dependency does not involve coordinates, but we use this event
+        // as an "end-of-step" mark.
+        if (!(stepWork.doNeighborSearch || simulationWork.useCpuHaloExchange
+              || (stepWork.computePmeOnSeparateRank && !pmeSendCoordinatesFromGpu)))
+        {
+            result++;
+        }
+    }
+    return result;
+}
+
+/*! \brief Compute the number of times the "local forces ready on device" GPU event will be used as a synchronization point.
+ *
+ * In GROMACS, we usually follow the "mark once - wait once" approach. But this event is "consumed"
+ * (that is, waited upon either on host or on the device) multiple times, since many tasks
+ * in different streams depend on the local forces.
+ *
+ * \param simulationWork Simulation workload flags.
+ * \param domainWork Domain workload flags.
+ * \param stepWork Step workload flags.
+ * \param useOrEmulateGpuNb Whether GPU non-bonded calculations are used or emulated.
+ * \param alternateGpuWait Whether alternating wait/reduce scheme is used.
+ * \return The number of times the event will be consumed based on this step's workload.
+ */
+static int getExpectedLocalFReadyOnDeviceConsumptionCount(const SimulationWorkload& simulationWork,
+                                                          const DomainLifetimeWorkload& domainWork,
+                                                          const StepWorkload&           stepWork,
+                                                          bool useOrEmulateGpuNb,
+                                                          bool alternateGpuWait)
+{
+    int  counter = 0;
+    bool eventUsedInGpuForceReduction =
+            (domainWork.haveCpuLocalForceWork
+             || (simulationWork.havePpDomainDecomposition && !simulationWork.useGpuHaloExchange));
+    bool gpuForceReductionUsed = useOrEmulateGpuNb && !alternateGpuWait && stepWork.useGpuFBufferOps
+                                 && stepWork.computeNonbondedForces;
+    if (gpuForceReductionUsed && eventUsedInGpuForceReduction)
+    {
+        counter++;
+    }
+    bool gpuForceHaloUsed = simulationWork.havePpDomainDecomposition && stepWork.computeForces
+                            && stepWork.useGpuFHalo;
+    if (gpuForceHaloUsed)
+    {
+        counter++;
+    }
+    return counter;
+}
+
+//! \brief Data structure to hold dipole-related data and staging arrays
+struct DipoleData
+{
+    //! Dipole staging for fast summing over MPI
+    DVec muStaging[2] = { { 0.0, 0.0, 0.0 } };
+    //! Dipole staging for states A and B (index 0 and 1 resp.)
+    RVec muStateAB[2] = { { 0.0_real, 0.0_real, 0.0_real } };
+};
+
+
+static void reduceAndUpdateMuTot(DipoleData*                   dipoleData,
+                                 const t_commrec*              cr,
+                                 const bool                    haveFreeEnergy,
+                                 ArrayRef<const real>          lambda,
+                                 rvec                          muTotal,
+                                 const DDBalanceRegionHandler& ddBalanceRegionHandler)
+{
+    if (PAR(cr))
+    {
+        gmx_sumd(2 * DIM, dipoleData->muStaging[0], cr);
+        ddBalanceRegionHandler.reopenRegionCpu();
+    }
+    for (int i = 0; i < 2; i++)
+    {
+        for (int j = 0; j < DIM; j++)
+        {
+            dipoleData->muStateAB[i][j] = dipoleData->muStaging[i][j];
+        }
+    }
+
+    if (!haveFreeEnergy)
+    {
+        copy_rvec(dipoleData->muStateAB[0], muTotal);
+    }
+    else
+    {
+        for (int j = 0; j < DIM; j++)
+        {
+            muTotal[j] = (1.0 - lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)])
+                                 * dipoleData->muStateAB[0][j]
+                         + lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)]
+                                   * dipoleData->muStateAB[1][j];
+        }
+    }
+}
+
+/*! \brief Combines MTS level0 and level1 force buffers into a full and MTS-combined force buffer.
+ *
+ * \param[in]     numAtoms        The number of atoms to combine forces for
+ * \param[in,out] forceMtsLevel0  Input: F_level0, output: F_level0 + F_level1
+ * \param[in,out] forceMts        Input: F_level1, output: F_level0 + mtsFactor * F_level1
+ * \param[in]     mtsFactor       The factor between the level0 and level1 time step
+ */
+static void combineMtsForces(const int      numAtoms,
+                             ArrayRef<RVec> forceMtsLevel0,
+                             ArrayRef<RVec> forceMts,
+                             const real     mtsFactor)
+{
+    const int gmx_unused numThreads = gmx_omp_nthreads_get(ModuleMultiThread::Default);
+#pragma omp parallel for num_threads(numThreads) schedule(static)
+    for (int i = 0; i < numAtoms; i++)
+    {
+        const RVec forceMtsLevel0Tmp = forceMtsLevel0[i];
+        forceMtsLevel0[i] += forceMts[i];
+        forceMts[i] = forceMtsLevel0Tmp + mtsFactor * forceMts[i];
+    }
+}
+
+/*! \brief Setup for the local GPU force reduction:
+ * reinitialization plus the registration of forces and dependencies.
+ *
+ * \param [in] runScheduleWork     Schedule workload flag structure
+ * \param [in] nbv                 Non-bonded Verlet object
+ * \param [in] stateGpu            GPU state propagator object
+ * \param [in] gpuForceReduction   GPU force reduction object
+ * \param [in] pmePpCommGpu        PME-PP GPU communication object
+ * \param [in] pmedata             PME data object
+ * \param [in] dd                  Domain decomposition object
+ */
+static void setupLocalGpuForceReduction(const MdrunScheduleWorkload& runScheduleWork,
+                                        nonbonded_verlet_t*          nbv,
+                                        StatePropagatorDataGpu*      stateGpu,
+                                        GpuForceReduction*           gpuForceReduction,
+                                        PmePpCommGpu*                pmePpCommGpu,
+                                        const gmx_pme_t*             pmedata,
+                                        const gmx_domdec_t*          dd)
+{
+    GMX_ASSERT(!runScheduleWork.simulationWork.useMts,
+               "GPU force reduction is not compatible with MTS");
+
+    // (re-)initialize local GPU force reduction
+    const bool accumulate = runScheduleWork.domainWork.haveCpuLocalForceWork
+                            || runScheduleWork.simulationWork.havePpDomainDecomposition;
+    const int atomStart = 0;
+    gpuForceReduction->reinit(stateGpu->getForces(),
+                              nbv->getNumAtoms(AtomLocality::Local),
+                              nbv->getGridIndices(),
+                              atomStart,
+                              accumulate,
+                              stateGpu->fReducedOnDevice(AtomLocality::Local));
+
+    // register forces and add dependencies
+    gpuForceReduction->registerNbnxmForce(gpu_get_f(nbv->gpuNbv()));
+
+    DeviceBuffer<RVec>    pmeForcePtr;
+    GpuEventSynchronizer* pmeSynchronizer     = nullptr;
+    bool                  havePmeContribution = false;
+
+    if (runScheduleWork.simulationWork.haveGpuPmeOnPpRank())
+    {
+        pmeForcePtr = pme_gpu_get_device_f(pmedata);
+        if (pmeForcePtr)
+        {
+            pmeSynchronizer     = pme_gpu_get_f_ready_synchronizer(pmedata);
+            havePmeContribution = true;
+        }
+    }
+    else if (runScheduleWork.simulationWork.useGpuPmePpCommunication)
+    {
+        pmeForcePtr = pmePpCommGpu->getGpuForceStagingPtr();
+        GMX_ASSERT(pmeForcePtr, "PME force for reduction has no data");
+        if (GMX_THREAD_MPI)
+        {
+            pmeSynchronizer = pmePpCommGpu->getForcesReadySynchronizer();
+        }
+        havePmeContribution = true;
+    }
+
+    if (havePmeContribution)
+    {
+        gpuForceReduction->registerRvecForce(pmeForcePtr);
+        if (runScheduleWork.simulationWork.useNvshmem)
+        {
+            DeviceBuffer<uint64_t> forcesReadyNvshmemFlags = pmePpCommGpu->getGpuForcesSyncObj();
+            gpuForceReduction->registerForcesReadyNvshmemFlags(forcesReadyNvshmemFlags);
+        }
+
+        if (!runScheduleWork.simulationWork.useGpuPmePpCommunication || GMX_THREAD_MPI)
+        {
+            GMX_ASSERT(pmeSynchronizer != nullptr, "PME force ready cuda event should not be NULL");
+            gpuForceReduction->addDependency(pmeSynchronizer);
+        }
+    }
+
+    if (runScheduleWork.domainWork.haveCpuLocalForceWork
+        || (runScheduleWork.simulationWork.havePpDomainDecomposition
+            && !runScheduleWork.simulationWork.useGpuHaloExchange))
+    {
+        gpuForceReduction->addDependency(stateGpu->fReadyOnDevice(AtomLocality::Local));
+    }
+
+    if (runScheduleWork.simulationWork.useGpuHaloExchange)
+    {
+        gpuForceReduction->addDependency(dd->gpuHaloExchange[0][0]->getForcesReadyOnDeviceEvent());
+    }
+}
+
+/*! \brief Setup for the non-local GPU force reduction:
+ * reinitialization plus the registration of forces and dependencies.
+ *
+ * \param [in] runScheduleWork     Schedule workload flag structure
+ * \param [in] nbv                 Non-bonded Verlet object
+ * \param [in] stateGpu            GPU state propagator object
+ * \param [in] gpuForceReduction   GPU force reduction object
+ * \param [in] dd                  Domain decomposition object
+ */
+static void setupNonLocalGpuForceReduction(const MdrunScheduleWorkload& runScheduleWork,
+                                           nonbonded_verlet_t*          nbv,
+                                           StatePropagatorDataGpu*      stateGpu,
+                                           GpuForceReduction*           gpuForceReduction,
+                                           const gmx_domdec_t*          dd)
+{
+    // (re-)initialize non-local GPU force reduction
+    const bool accumulate = runScheduleWork.domainWork.haveCpuNonLocalForceWork;
+    const int  atomStart  = dd_numHomeAtoms(*dd);
+    gpuForceReduction->reinit(stateGpu->getForces(),
+                              nbv->getNumAtoms(AtomLocality::NonLocal),
+                              nbv->getGridIndices(),
+                              atomStart,
+                              accumulate,
+                              stateGpu->fReducedOnDevice(AtomLocality::NonLocal));
+
+    // register forces and add dependencies
+    gpuForceReduction->registerNbnxmForce(gpu_get_f(nbv->gpuNbv()));
+
+    if (runScheduleWork.domainWork.haveCpuNonLocalForceWork)
+    {
+        gpuForceReduction->addDependency(stateGpu->fReadyOnDevice(AtomLocality::NonLocal));
+    }
+}
+
+
+/*! \brief Return the number of local atoms.
+ */
+static int getLocalAtomCount(const gmx_domdec_t* dd, const t_mdatoms& mdatoms, bool havePPDomainDecomposition)
+{
+    GMX_ASSERT(!(havePPDomainDecomposition && (dd == nullptr)),
+               "Can't have PP decomposition with dd uninitialized!");
+    return havePPDomainDecomposition ? dd_numAtomsZones(*dd) : mdatoms.homenr;
+}
+
+/*! \brief Does pair search and closely related activities required on search steps.
+ */
+static void doPairSearch(const t_commrec*             cr,
+                         const t_inputrec&            inputrec,
+                         const MDModulesNotifiers&    mdModulesNotifiers,
+                         int64_t                      step,
+                         t_nrnb*                      nrnb,
+                         gmx_wallcycle*               wcycle,
+                         const gmx_localtop_t&        top,
+                         const matrix                 box,
+                         ArrayRefWithPadding<RVec>    x,
+                         ArrayRef<RVec>               v,
+                         const t_mdatoms&             mdatoms,
+                         t_forcerec*                  fr,
+                         const MdrunScheduleWorkload& runScheduleWork)
+{
+    nonbonded_verlet_t* nbv = fr->nbv.get();
+
+    StatePropagatorDataGpu* stateGpu = fr->stateGpu;
+
+    const SimulationWorkload& simulationWork = runScheduleWork.simulationWork;
+    const StepWorkload&       stepWork       = runScheduleWork.stepWork;
+
+    if (needStateGpu(simulationWork))
+    {
+        // TODO refactor this to do_md, after partitioning.
+        stateGpu->reinit(mdatoms.homenr,
+                         getLocalAtomCount(cr->dd, mdatoms, simulationWork.havePpDomainDecomposition),
+                         *cr,
+                         -1);
+    }
+
+    if (simulationWork.haveGpuPmeOnPpRank())
+    {
+        GMX_ASSERT(needStateGpu(simulationWork), "StatePropagatorDataGpu is needed");
+        // TODO: This should be moved into PME setup function ( pme_gpu_prepare_computation(...) )
+        pme_gpu_set_device_x(fr->pmedata, stateGpu->getCoordinates());
+    }
+
+    if (fr->pbcType != PbcType::No)
+    {
+        const bool calcCGCM = (stepWork.stateChanged && !haveDDAtomOrdering(*cr));
+        if (calcCGCM)
+        {
+            put_atoms_in_box_omp(fr->pbcType,
+                                 box,
+                                 fr->haveBoxDeformation,
+                                 inputrec.deform,
+                                 x.unpaddedArrayRef().subArray(0, mdatoms.homenr),
+                                 v.empty() ? ArrayRef<RVec>() : v.subArray(0, mdatoms.homenr),
+                                 gmx_omp_nthreads_get(ModuleMultiThread::Default));
+            inc_nrnb(nrnb, eNR_SHIFTX, mdatoms.homenr);
+        }
+
+        if (!haveDDAtomOrdering(*cr))
+        {
+            // Atoms might have changed periodic image, signal MDModules
+            MDModulesAtomsRedistributedSignal mdModulesAtomsRedistributedSignal(
+                    box, x.unpaddedArrayRef().subArray(0, mdatoms.homenr));
+            mdModulesNotifiers.simulationSetupNotifier_.notify(mdModulesAtomsRedistributedSignal);
+        }
+    }
+
+    if (fr->wholeMoleculeTransform && stepWork.stateChanged)
+    {
+        fr->wholeMoleculeTransform->updateForAtomPbcJumps(x.unpaddedArrayRef(), box);
+    }
+
+    wallcycle_start(wcycle, WallCycleCounter::NS);
+    if (!haveDDAtomOrdering(*cr))
+    {
+        const rvec vzero       = { 0.0_real, 0.0_real, 0.0_real };
+        const rvec boxDiagonal = { box[XX][XX], box[YY][YY], box[ZZ][ZZ] };
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::NBSGridLocal);
+        nbv->putAtomsOnGrid(box,
+                            0,
+                            vzero,
+                            boxDiagonal,
+                            nullptr,
+                            { 0, mdatoms.homenr },
+                            mdatoms.homenr,
+                            -1,
+                            fr->atomInfo,
+                            x.unpaddedArrayRef(),
+                            nullptr);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::NBSGridLocal);
+    }
+    else
+    {
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::NBSGridNonLocal);
+        if (!nbv->localAtomOrderMatchesNbnxmOrder())
+        {
+            nbnxn_put_on_grid_nonlocal(nbv, getDomdecZones(*cr->dd), fr->atomInfo, x.unpaddedArrayRef());
+        }
+        nbv->convertCoordinates(AtomLocality::NonLocal, x.unpaddedArrayRef());
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::NBSGridNonLocal);
+    }
+
+    nbv->setAtomProperties(mdatoms.typeA, mdatoms.chargeA, fr->atomInfo);
+
+    wallcycle_stop(wcycle, WallCycleCounter::NS);
+
+    /* initialize the GPU nbnxm atom data and bonded data structures */
+    if (simulationWork.useGpuNonbonded)
+    {
+        // Note: cycle counting only nononbondeds, GPU listed forces counts internally
+        wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        gpu_init_atomdata(nbv->gpuNbv(), &nbv->nbat());
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+
+        if (fr->listedForcesGpu)
+        {
+            /* Now we put all atoms on the grid, we can assign bonded
+             * interactions to the GPU, where the grid order is
+             * needed. Also the xq, f and fshift device buffers have
+             * been reallocated if needed, so the bonded code can
+             * learn about them. */
+            // TODO the xq, f, and fshift buffers are now shared
+            // resources, so they should be maintained by a
+            // higher-level object than the nb module.
+            fr->listedForcesGpu->updateInteractionListsAndDeviceBuffers(
+                    nbv->getGridIndices(), top.idef, gpuGetNBAtomData(nbv->gpuNbv()));
+        }
+    }
+
+    wallcycle_start_nocount(wcycle, WallCycleCounter::NS);
+    wallcycle_sub_start(wcycle, WallCycleSubCounter::NBSSearchLocal);
+    /* Note that with a GPU the launch overhead of the list transfer is not timed separately */
+    nbv->constructPairlist(InteractionLocality::Local, top.excls, step, nrnb);
+
+    nbv->setupGpuShortRangeWork(fr->listedForcesGpu.get(), InteractionLocality::Local);
+
+    wallcycle_sub_stop(wcycle, WallCycleSubCounter::NBSSearchLocal);
+    wallcycle_stop(wcycle, WallCycleCounter::NS);
+
+    if (simulationWork.useGpuXBufferOpsWhenAllowed)
+    {
+        nbv->atomdata_init_copy_x_to_nbat_x_gpu();
+    }
+
+    if (simulationWork.useGpuFBufferOpsWhenAllowed)
+    {
+        // with MPI, direct GPU communication, and separate PME ranks we need
+        // gmx_pme_send_coordinates() to be called before we can set up force reduction
+        bool delaySetupLocalGpuForceReduction = GMX_MPI && simulationWork.useGpuPmePpCommunication;
+        if (!delaySetupLocalGpuForceReduction)
+        {
+            setupLocalGpuForceReduction(runScheduleWork,
+                                        nbv,
+                                        stateGpu,
+                                        fr->gpuForceReduction[AtomLocality::Local].get(),
+                                        fr->pmePpCommGpu.get(),
+                                        fr->pmedata,
+                                        cr->dd);
+        }
+
+        if (simulationWork.havePpDomainDecomposition)
+        {
+            setupNonLocalGpuForceReduction(runScheduleWork,
+                                           nbv,
+                                           stateGpu,
+                                           fr->gpuForceReduction[AtomLocality::NonLocal].get(),
+                                           cr->dd);
+        }
+    }
+
+    /* do non-local pair search */
+    if (simulationWork.havePpDomainDecomposition)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::NS);
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::NBSSearchNonLocal);
+        /* Note that with a GPU the launch overhead of the list transfer is not timed separately */
+        nbv->constructPairlist(InteractionLocality::NonLocal, top.excls, step, nrnb);
+
+        nbv->setupGpuShortRangeWork(fr->listedForcesGpu.get(), InteractionLocality::NonLocal);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::NBSSearchNonLocal);
+        wallcycle_stop(wcycle, WallCycleCounter::NS);
+        // TODO refactor this GPU halo exchange re-initialisation
+        // to location in do_md where GPU halo exchange is
+        // constructed at partitioning, after above stateGpu
+        // re-initialization has similarly been refactored
+        if (simulationWork.useGpuHaloExchange)
+        {
+            reinitGpuHaloExchange(*cr, stateGpu->getCoordinates(), stateGpu->getForces());
+        }
+    }
+
+    // With FEP we set up the reduction over threads for local+non-local simultaneously,
+    // so we need to do that here after the local and non-local pairlist construction.
+    if (fr->efep != FreeEnergyPerturbationType::No)
+    {
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::NonbondedFep);
+        nbv->setupFepThreadedForceBuffer(fr->natoms_force_constr);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::NonbondedFep);
+    }
+}
+
+void do_force(FILE*                         fplog,
+              const t_commrec*              cr,
+              const gmx_multisim_t*         ms,
+              const t_inputrec&             inputrec,
+              const MDModulesNotifiers&     mdModulesNotifiers,
+              Awh*                          awh,
+              gmx_enfrot*                   enforcedRotation,
+              ImdSession*                   imdSession,
+              pull_t*                       pull_work,
+              int64_t                       step,
+              t_nrnb*                       nrnb,
+              gmx_wallcycle*                wcycle,
+              const gmx_localtop_t*         top,
+              const matrix                  box,
+              ArrayRefWithPadding<RVec>     x,
+              ArrayRef<RVec>                v,
+              const history_t*              hist,
+              ForceBuffersView*             forceView,
+              tensor                        vir_force,
+              const t_mdatoms*              mdatoms,
+              gmx_enerdata_t*               enerd,
+              ArrayRef<const real>          lambda,
+              t_forcerec*                   fr,
+              const MdrunScheduleWorkload&  runScheduleWork,
+              VirtualSitesHandler*          vsite,
+              rvec                          muTotal,
+              double                        t,
+              gmx_edsam*                    ed,
+              CpuPpLongRangeNonbondeds*     longRangeNonbondeds,
+              const DDBalanceRegionHandler& ddBalanceRegionHandler)
+{
+    auto force = forceView->forceWithPadding();
+    GMX_ASSERT(force.unpaddedArrayRef().ssize() >= fr->natoms_force_constr,
+               "The size of the force buffer should be at least the number of atoms to compute "
+               "forces for");
+
+    nonbonded_verlet_t*  nbv = fr->nbv.get();
+    interaction_const_t* ic  = fr->ic.get();
+
+    StatePropagatorDataGpu* stateGpu = fr->stateGpu;
+
+    const SimulationWorkload& simulationWork = runScheduleWork.simulationWork;
+
+    const DomainLifetimeWorkload& domainWork = runScheduleWork.domainWork;
+
+    const StepWorkload& stepWork = runScheduleWork.stepWork;
+
+    const bool pmeSendCoordinatesFromGpu =
+            simulationWork.useGpuPmePpCommunication && !stepWork.doNeighborSearch;
+
+    const bool reinitGpuPmePpComms = simulationWork.useGpuPmePpCommunication && stepWork.doNeighborSearch;
+    if (stepWork.computePmeOnSeparateRank && stepWork.doNeighborSearch)
+    {
+        // We call the gmx_pme_send_coordinates early for reinit case
+        // in order for nvshmem collective calls in StatePropagatorDataGpu::Impl::reinit
+        // to be in sync with PME-PP
+        gmx_pme_send_coordinates(fr,
+                                 cr,
+                                 box,
+                                 x.unpaddedArrayRef(),
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Vdw)],
+                                 (stepWork.computeVirial || stepWork.computeEnergy),
+                                 step,
+                                 simulationWork.useGpuPmePpCommunication,
+                                 reinitGpuPmePpComms,
+                                 pmeSendCoordinatesFromGpu,
+                                 stepWork.useGpuPmeFReduction,
+                                 nullptr,
+                                 simulationWork.useMdGpuGraph,
+                                 wcycle);
+    }
+
+    if (stepWork.doNeighborSearch)
+    {
+        doPairSearch(cr, inputrec, mdModulesNotifiers, step, nrnb, wcycle, *top, box, x, v, *mdatoms, fr, runScheduleWork);
+
+        /* At a search step we need to start the first balancing region
+         * somewhere early inside the step after communication during domain
+         * decomposition (and not during the previous step as usual).
+         */
+        ddBalanceRegionHandler.openBeforeForceComputationCpu(DdAllowBalanceRegionReopen::yes);
+    }
+
+    auto* localXReadyOnDevice = (stepWork.haveGpuPmeOnThisRank || stepWork.useGpuXBufferOps
+                                 || simulationWork.useGpuUpdate || pmeSendCoordinatesFromGpu)
+                                        ? stateGpu->getCoordinatesReadyOnDeviceEvent(
+                                                  AtomLocality::Local, simulationWork, stepWork)
+                                        : nullptr;
+
+    if (stepWork.clearGpuFBufferEarly)
+    {
+        // GPU Force halo exchange will set a subset of local atoms with remote non-local data.
+        // First clear local portion of force array, so that untouched atoms are zero.
+        // The dependency for this is that forces from previous timestep have been consumed,
+        // which is satisfied when localXReadyOnDevice has been marked for GPU update case.
+        // For CPU update, the forces are consumed by the beginning of the step, so no extra sync needed.
+        GpuEventSynchronizer* dependency = simulationWork.useGpuUpdate ? localXReadyOnDevice : nullptr;
+        stateGpu->clearForcesOnGpu(AtomLocality::Local, dependency);
+    }
+
+    clear_mat(vir_force);
+
+    if (fr->pbcType != PbcType::No)
+    {
+        /* Compute shift vectors every step,
+         * because of pressure coupling or box deformation!
+         */
+        if (stepWork.haveDynamicBox && stepWork.stateChanged)
+        {
+            calc_shifts(box, fr->shift_vec);
+        }
+    }
+    nbnxn_atomdata_copy_shiftvec(stepWork.haveDynamicBox, fr->shift_vec, &nbv->nbat());
+
+
+    GMX_ASSERT(simulationWork.useGpuHaloExchange
+                       == ((cr->dd != nullptr) && (!cr->dd->gpuHaloExchange[0].empty())),
+               "The GPU halo exchange is active, but it has not been constructed.");
+
+    bool gmx_used_in_debug haveCopiedXFromGpu = false;
+    // Copy coordinate from the GPU if update is on the GPU and there
+    // are forces to be computed on the CPU, or for the computation of
+    // virial, or if host-side data will be transferred from this task
+    // to a remote task for halo exchange or PME-PP communication. At
+    // search steps the current coordinates are already on the host,
+    // hence copy is not needed.
+    if (simulationWork.useGpuUpdate && !stepWork.doNeighborSearch
+        && (runScheduleWork.domainWork.haveCpuLocalForceWork || stepWork.computeVirial
+            || simulationWork.useCpuPmePpCommunication || simulationWork.useCpuHaloExchange
+            || simulationWork.computeMuTot))
+    {
+        stateGpu->copyCoordinatesFromGpu(x.unpaddedArrayRef(), AtomLocality::Local);
+        haveCopiedXFromGpu = true;
+    }
+
+    // Coordinates on the device are needed if PME or BufferOps are offloaded.
+    // The local coordinates can be copied right away.
+    // NOTE: Consider moving this copy to right after they are updated and constrained,
+    //       if the later is not offloaded.
+    if (stepWork.haveGpuPmeOnThisRank || stepWork.useGpuXBufferOps || pmeSendCoordinatesFromGpu)
+    {
+        GMX_ASSERT(stateGpu != nullptr, "stateGpu should not be null");
+        const int expectedLocalXReadyOnDeviceConsumptionCount =
+                getExpectedLocalXReadyOnDeviceConsumptionCount(
+                        simulationWork, stepWork, domainWork, pmeSendCoordinatesFromGpu);
+
+        // We need to copy coordinates when:
+        // 1. Update is not offloaded
+        // 2. The buffers were reinitialized on search step
+        if (!simulationWork.useGpuUpdate || stepWork.doNeighborSearch)
+        {
+            stateGpu->copyCoordinatesToGpu(x.unpaddedArrayRef(),
+                                           AtomLocality::Local,
+                                           expectedLocalXReadyOnDeviceConsumptionCount);
+        }
+        else if (simulationWork.useGpuUpdate)
+        {
+            stateGpu->setXUpdatedOnDeviceEventExpectedConsumptionCount(
+                    expectedLocalXReadyOnDeviceConsumptionCount);
+        }
+    }
+
+    if (stepWork.computePmeOnSeparateRank && !stepWork.doNeighborSearch)
+    {
+        /* Send particle coordinates to the pme nodes */
+        if (!pmeSendCoordinatesFromGpu && simulationWork.useGpuUpdate)
+        {
+            GMX_ASSERT(haveCopiedXFromGpu,
+                       "a wait should only be triggered if copy has been scheduled");
+            stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+        }
+
+        gmx_pme_send_coordinates(fr,
+                                 cr,
+                                 box,
+                                 x.unpaddedArrayRef(),
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Vdw)],
+                                 (stepWork.computeVirial || stepWork.computeEnergy),
+                                 step,
+                                 simulationWork.useGpuPmePpCommunication,
+                                 reinitGpuPmePpComms,
+                                 pmeSendCoordinatesFromGpu,
+                                 stepWork.useGpuPmeFReduction,
+                                 pmeSendCoordinatesFromGpu ? localXReadyOnDevice : nullptr,
+                                 simulationWork.useMdGpuGraph,
+                                 wcycle);
+    }
+
+    if (simulationWork.useGpuFBufferOpsWhenAllowed && stepWork.doNeighborSearch)
+    {
+        // with MPI, direct GPU communication, and separate PME ranks we need
+        // gmx_pme_send_coordinates() to be called before we can set up force reduction
+        bool doSetupLocalGpuForceReduction = GMX_MPI && simulationWork.useGpuPmePpCommunication;
+        if (doSetupLocalGpuForceReduction)
+        {
+            setupLocalGpuForceReduction(runScheduleWork,
+                                        fr->nbv.get(),
+                                        stateGpu,
+                                        fr->gpuForceReduction[AtomLocality::Local].get(),
+                                        fr->pmePpCommGpu.get(),
+                                        fr->pmedata,
+                                        cr->dd);
+        }
+    }
+
+    if (stepWork.haveGpuPmeOnThisRank)
+    {
+        launchPmeGpuSpread(fr->pmedata,
+                           box,
+                           stepWork,
+                           localXReadyOnDevice,
+                           lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                           simulationWork.useMdGpuGraph,
+                           wcycle);
+    }
+
+
+    if (!stepWork.doNeighborSearch && !EI_TPI(inputrec.eI) && stepWork.computeNonbondedForces)
+    {
+        if (stepWork.useGpuXBufferOps)
+        {
+            GMX_ASSERT(stateGpu, "stateGpu should be valid when buffer ops are offloaded");
+            nbv->convertCoordinatesGpu(AtomLocality::Local, stateGpu->getCoordinates(), localXReadyOnDevice);
+        }
+        else
+        {
+            if (simulationWork.useGpuUpdate)
+            {
+                GMX_ASSERT(stateGpu, "need a valid stateGpu object");
+                GMX_ASSERT(haveCopiedXFromGpu,
+                           "a wait should only be triggered if copy has been scheduled");
+                stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+            }
+            nbv->convertCoordinates(AtomLocality::Local, x.unpaddedArrayRef());
+        }
+    }
+
+    if (simulationWork.useGpuNonbonded && (stepWork.computeNonbondedForces || domainWork.haveGpuBondedWork))
+    {
+        ddBalanceRegionHandler.openBeforeForceComputationGpu();
+
+        wallcycle_start(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        gpu_upload_shiftvec(nbv->gpuNbv(), &nbv->nbat());
+        if (!stepWork.useGpuXBufferOps)
+        {
+            gpu_copy_xq_to_gpu(nbv->gpuNbv(), &nbv->nbat(), AtomLocality::Local);
+        }
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+        // with X buffer ops offloaded to the GPU on all but the search steps
+
+        // bonded work not split into separate local and non-local, so with DD
+        // we can only launch the kernel after non-local coordinates have been received.
+        if (domainWork.haveGpuBondedWork && !simulationWork.havePpDomainDecomposition)
+        {
+            fr->listedForcesGpu->setPbcAndlaunchKernel(fr->pbcType, box, fr->bMolPBC, stepWork);
+        }
+
+        /* launch local nonbonded work on GPU */
+        wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        do_nb_verlet(fr, ic, enerd, stepWork, InteractionLocality::Local, enbvClearFNo, step, nrnb, wcycle);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+    }
+
+    if (stepWork.haveGpuPmeOnThisRank)
+    {
+        // In PME GPU and mixed mode we launch FFT / gather after the
+        // X copy/transform to allow overlap as well as after the GPU NB
+        // launch to avoid FFT launch overhead hijacking the CPU and delaying
+        // the nonbonded kernel.
+        launchPmeGpuFftAndGather(fr->pmedata,
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                                 wcycle,
+                                 stepWork);
+    }
+
+    /* Communicate coordinates and sum dipole if necessary */
+    if (simulationWork.havePpDomainDecomposition)
+    {
+        GpuEventSynchronizer* gpuCoordinateHaloLaunched = nullptr;
+        if (!stepWork.doNeighborSearch)
+        {
+            if (stepWork.useGpuXHalo)
+            {
+                // The following must be called after local setCoordinates (which records an event
+                // when the coordinate data has been copied to the device).
+                gpuCoordinateHaloLaunched = communicateGpuHaloCoordinates(*cr, box, localXReadyOnDevice);
+
+                if (domainWork.haveCpuNonLocalForceWork)
+                {
+                    // non-local part of coordinate buffer must be copied back to host for CPU work
+                    stateGpu->copyCoordinatesFromGpu(
+                            x.unpaddedArrayRef(), AtomLocality::NonLocal, gpuCoordinateHaloLaunched);
+                }
+            }
+            else
+            {
+                if (simulationWork.useGpuUpdate)
+                {
+                    GMX_ASSERT(haveCopiedXFromGpu,
+                               "a wait should only be triggered if copy has been scheduled");
+                    const bool haveAlreadyWaited =
+                            (stepWork.computePmeOnSeparateRank && !pmeSendCoordinatesFromGpu);
+                    if (!haveAlreadyWaited)
+                    {
+                        stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+                    }
+                }
+
+                if (cr->dd->haloExchange)
+                {
+                    wallcycle_start(wcycle, WallCycleCounter::MoveX);
+                    cr->dd->haloExchange->moveX(box, x.unpaddedArrayRef());
+                    wallcycle_stop(wcycle, WallCycleCounter::MoveX);
+                }
+                else
+                {
+                    dd_move_x(cr->dd, box, x.unpaddedArrayRef(), wcycle);
+                }
+            }
+        }
+
+        if (stepWork.useGpuXBufferOps)
+        {
+            if (!stepWork.useGpuXHalo)
+            {
+                stateGpu->copyCoordinatesToGpu(x.unpaddedArrayRef(), AtomLocality::NonLocal);
+            }
+            GpuEventSynchronizer* xReadyOnDeviceEvent = stateGpu->getCoordinatesReadyOnDeviceEvent(
+                    AtomLocality::NonLocal, simulationWork, stepWork, gpuCoordinateHaloLaunched);
+            if (stepWork.useGpuXHalo && domainWork.haveCpuNonLocalForceWork)
+            {
+                /* We already enqueued an event for Gpu Halo exchange completion into the
+                 * NonLocal stream when D2H copying the coordinates. */
+                xReadyOnDeviceEvent = nullptr;
+            }
+            nbv->convertCoordinatesGpu(
+                    AtomLocality::NonLocal, stateGpu->getCoordinates(), xReadyOnDeviceEvent);
+        }
+        else if (!stepWork.doNeighborSearch)
+        {
+            nbv->convertCoordinates(AtomLocality::NonLocal, x.unpaddedArrayRef());
+        }
+
+        if (simulationWork.useGpuNonbonded)
+        {
+
+            if (!stepWork.useGpuXBufferOps)
+            {
+                wallcycle_start(wcycle, WallCycleCounter::LaunchGpuPp);
+                wallcycle_sub_start(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+                gpu_copy_xq_to_gpu(nbv->gpuNbv(), &nbv->nbat(), AtomLocality::NonLocal);
+                wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+                wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+            }
+
+            if (domainWork.haveGpuBondedWork)
+            {
+                fr->listedForcesGpu->setPbcAndlaunchKernel(fr->pbcType, box, fr->bMolPBC, stepWork);
+            }
+
+            /* launch non-local nonbonded tasks on GPU */
+            wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+            wallcycle_sub_start(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+            do_nb_verlet(fr, ic, enerd, stepWork, InteractionLocality::NonLocal, enbvClearFNo, step, nrnb, wcycle);
+            wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+            wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+        }
+    }
+
+    if (simulationWork.useGpuNonbonded && stepWork.computeNonbondedForces)
+    {
+        /* launch D2H copy-back F */
+        wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+
+        if (simulationWork.havePpDomainDecomposition)
+        {
+            gpu_launch_cpyback(nbv->gpuNbv(), &nbv->nbat(), stepWork, AtomLocality::NonLocal);
+        }
+        gpu_launch_cpyback(nbv->gpuNbv(), &nbv->nbat(), stepWork, AtomLocality::Local);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+
+        if (domainWork.haveGpuBondedWork && stepWork.computeEnergy)
+        {
+            fr->listedForcesGpu->launchEnergyTransfer();
+        }
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+    }
+
+    ArrayRef<const RVec> xWholeMolecules;
+    if (fr->wholeMoleculeTransform)
+    {
+        xWholeMolecules = fr->wholeMoleculeTransform->wholeMoleculeCoordinates(x.unpaddedArrayRef(), box);
+    }
+
+    // The CPU force buffer force clearing needs to happen after the previous step
+    // force reduction has already completed. To minimize the cross-step dependencies
+    // we wait on the coordinates to be updated on the device which is sufficient but
+    // a later event than what we strictly need to synchronize with.
+    if (simulationWork.useGpuUpdate && domainWork.haveCpuLocalForceWork)
+    {
+        const bool coordinatesAlreadyUpdatedOnDevice =
+                stepWork.doNeighborSearch || simulationWork.useCpuHaloExchange
+                || (stepWork.computePmeOnSeparateRank && !pmeSendCoordinatesFromGpu);
+        if (!coordinatesAlreadyUpdatedOnDevice)
+        {
+            stateGpu->waitCoordinatesUpdatedOnDevice();
+        }
+    }
+
+    /* Start the force cycle counter.
+     * Note that a different counter is used for dynamic load balancing.
+     */
+    wallcycle_start(wcycle, WallCycleCounter::Force);
+
+    /* Set up and clear force outputs:
+     * forceOutMtsLevel0:  everything except what is in the other two outputs
+     * forceOutMtsLevel1:  PME-mesh and listed-forces group 1
+     * forceOutNonbonded: non-bonded forces
+     * Without multiple time stepping all point to the same object.
+     * With multiple time-stepping the use is different for MTS fast (level0 only) and slow steps.
+     */
+    ForceOutputs forceOutMtsLevel0 = setupForceOutputs(
+            &fr->forceHelperBuffers[0], force, domainWork, stepWork, simulationWork.havePpDomainDecomposition, wcycle);
+
+    // Force output for MTS combined forces, only set at level1 MTS steps
+    std::optional<ForceOutputs> forceOutMts =
+            (simulationWork.useMts && stepWork.computeSlowForces)
+                    ? std::optional(setupForceOutputs(&fr->forceHelperBuffers[1],
+                                                      forceView->forceMtsCombinedWithPadding(),
+                                                      domainWork,
+                                                      stepWork,
+                                                      simulationWork.havePpDomainDecomposition,
+                                                      wcycle))
+                    : std::nullopt;
+
+    ForceOutputs* forceOutMtsLevel1 =
+            simulationWork.useMts ? (stepWork.computeSlowForces ? &forceOutMts.value() : nullptr)
+                                  : &forceOutMtsLevel0;
+
+    const bool nonbondedAtMtsLevel1 = runScheduleWork.simulationWork.computeNonbondedAtMtsLevel1;
+
+    ForceOutputs* forceOutNonbonded = nonbondedAtMtsLevel1 ? forceOutMtsLevel1 : &forceOutMtsLevel0;
+
+    if (inputrec.bPull && pull_have_constraint(*pull_work))
+    {
+        clear_pull_forces(pull_work);
+    }
+    wallcycle_stop(wcycle, WallCycleCounter::Force);
+
+    // For the rest of the CPU tasks that depend on GPU-update produced coordinates,
+    // this wait ensures that the D2H transfer is complete.
+    if (simulationWork.useGpuUpdate && !stepWork.doNeighborSearch)
+    {
+        const bool needCoordsOnHost = (runScheduleWork.domainWork.haveCpuLocalForceWork
+                                       || stepWork.computeVirial || simulationWork.computeMuTot);
+        const bool haveAlreadyWaited =
+                simulationWork.useCpuHaloExchange
+                || (stepWork.computePmeOnSeparateRank && !pmeSendCoordinatesFromGpu);
+        if (needCoordsOnHost && !haveAlreadyWaited)
+        {
+            GMX_ASSERT(haveCopiedXFromGpu,
+                       "a wait should only be triggered if copy has been scheduled");
+            stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+        }
+    }
+
+    DipoleData dipoleData;
+
+    if (simulationWork.computeMuTot)
+    {
+        const int start = 0;
+
+        /* Calculate total (local) dipole moment in a temporary common array.
+         * This makes it possible to sum them over nodes faster.
+         */
+        ArrayRef<const RVec> xRef = (xWholeMolecules.empty() ? x.unpaddedArrayRef() : xWholeMolecules);
+        calc_mu(start,
+                mdatoms->homenr,
+                xRef,
+                mdatoms->chargeA,
+                mdatoms->chargeB,
+                mdatoms->nChargePerturbed != 0,
+                dipoleData.muStaging[0],
+                dipoleData.muStaging[1]);
+
+        reduceAndUpdateMuTot(
+                &dipoleData, cr, (fr->efep != FreeEnergyPerturbationType::No), lambda, muTotal, ddBalanceRegionHandler);
+    }
+
+    /* Reset energies */
+    reset_enerdata(enerd);
+
+    if (haveDDAtomOrdering(*cr) && simulationWork.haveSeparatePmeRank)
+    {
+        wallcycle_start(wcycle, WallCycleCounter::PpDuringPme);
+        dd_force_flop_start(cr->dd, nrnb);
+    }
+
+    if (inputrec.bRot)
+    {
+        wallcycle_start(wcycle, WallCycleCounter::Rot);
+        do_rotation(cr, enforcedRotation, box, x.unpaddedConstArrayRef(), t, step, stepWork.doNeighborSearch);
+        wallcycle_stop(wcycle, WallCycleCounter::Rot);
+    }
+
+    /* We calculate the non-bonded forces, when done on the CPU, here.
+     * We do this before calling do_force_lowlevel, because in that
+     * function, the listed forces are calculated before PME, which
+     * does communication.  With this order, non-bonded and listed
+     * force calculation imbalance can be balanced out by the domain
+     * decomposition load balancing.
+     */
+
+    const bool useOrEmulateGpuNb = simulationWork.useGpuNonbonded || fr->nbv->emulateGpu();
+
+    if (!useOrEmulateGpuNb)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+        do_nb_verlet(fr, ic, enerd, stepWork, InteractionLocality::Local, enbvClearFYes, step, nrnb, wcycle);
+        wallcycle_stop(wcycle, WallCycleCounter::Force);
+    }
+
+    if (stepWork.useGpuXHalo && domainWork.haveCpuNonLocalForceWork)
+    {
+        /* Wait for non-local coordinate data to be copied from device */
+        stateGpu->waitCoordinatesReadyOnHost(AtomLocality::NonLocal);
+    }
+
+    wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+    if (fr->efep != FreeEnergyPerturbationType::No && stepWork.computeNonbondedForces)
+    {
+        /* Calculate the local and non-local free energy interactions here.
+         * Happens here on the CPU both with and without GPU.
+         */
+        nbv->dispatchFreeEnergyKernels(x,
+                                       &forceOutNonbonded->forceWithShiftForces(),
+                                       fr->use_simd_kernels,
+                                       fr->ntype,
+                                       *fr->ic,
+                                       fr->shift_vec,
+                                       fr->nbfp,
+                                       fr->ljpme_c6grid,
+                                       mdatoms->chargeA,
+                                       mdatoms->chargeB,
+                                       mdatoms->typeA,
+                                       mdatoms->typeB,
+                                       lambda,
+                                       enerd,
+                                       stepWork,
+                                       nrnb);
+    }
+
+    if (stepWork.computeNonbondedForces && !useOrEmulateGpuNb)
+    {
+        if (simulationWork.havePpDomainDecomposition)
+        {
+            do_nb_verlet(fr, ic, enerd, stepWork, InteractionLocality::NonLocal, enbvClearFNo, step, nrnb, wcycle);
+        }
+
+        if (stepWork.computeForces)
+        {
+            /* Add all the non-bonded force to the normal force array.
+             * This can be split into a local and a non-local part when overlapping
+             * communication with calculation with domain decomposition.
+             */
+            wallcycle_stop(wcycle, WallCycleCounter::Force);
+            nbv->atomdata_add_nbat_f_to_f(AtomLocality::All,
+                                          forceOutNonbonded->forceWithShiftForces().force());
+            wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+        }
+
+        /* If there are multiple fshift output buffers we need to reduce them */
+        if (stepWork.computeVirial)
+        {
+            /* This is not in a subcounter because it takes a
+               negligible and constant-sized amount of time */
+            nbnxn_atomdata_add_nbat_fshift_to_fshift(
+                    nbv->nbat(), forceOutNonbonded->forceWithShiftForces().shiftForces());
+        }
+    }
+
+    // Compute wall interactions, when present.
+    // Note: should be moved to special forces.
+    if (inputrec.nwall && stepWork.computeNonbondedForces)
+    {
+        /* foreign lambda component for walls */
+        real dvdl_walls = do_walls(inputrec,
+                                   *fr,
+                                   box,
+                                   mdatoms->typeA,
+                                   mdatoms->typeB,
+                                   mdatoms->cENER,
+                                   mdatoms->homenr,
+                                   mdatoms->nPerturbed,
+                                   x.unpaddedConstArrayRef(),
+                                   &forceOutMtsLevel0.forceWithVirial(),
+                                   lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Vdw)],
+                                   enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::LJSR],
+                                   nrnb);
+        enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Vdw] += dvdl_walls;
+    }
+
+    if (stepWork.computeListedForces)
+    {
+        /* Check whether we need to take into account PBC in listed interactions */
+        bool needMolPbc = false;
+        for (const auto& listedForces : fr->listedForces)
+        {
+            if (listedForces.haveCpuListedForces(*fr->fcdata))
+            {
+                needMolPbc = fr->bMolPBC;
+            }
+        }
+
+        t_pbc pbc;
+
+        if (needMolPbc)
+        {
+            /* Since all atoms are in the rectangular or triclinic unit-cell,
+             * only single box vector shifts (2 in x) are required.
+             */
+            set_pbc_dd(&pbc, fr->pbcType, haveDDAtomOrdering(*cr) ? &cr->dd->numCells : nullptr, TRUE, box);
+        }
+
+        for (int mtsIndex = 0; mtsIndex < (simulationWork.useMts && stepWork.computeSlowForces ? 2 : 1);
+             mtsIndex++)
+        {
+            ListedForces& listedForces = fr->listedForces[mtsIndex];
+            ForceOutputs& forceOut     = (mtsIndex == 0 ? forceOutMtsLevel0 : *forceOutMtsLevel1);
+            listedForces.calculate(wcycle,
+                                   box,
+                                   cr,
+                                   ms,
+                                   x,
+                                   xWholeMolecules,
+                                   fr->fcdata.get(),
+                                   hist,
+                                   &forceOut,
+                                   fr,
+                                   &pbc,
+                                   enerd,
+                                   nrnb,
+                                   lambda,
+                                   mdatoms->chargeA,
+                                   mdatoms->chargeB,
+                                   makeConstArrayRef(mdatoms->bPerturbed),
+                                   mdatoms->cENER,
+                                   mdatoms->nPerturbed,
+                                   haveDDAtomOrdering(*cr) ? cr->dd->globalAtomIndices.data() : nullptr,
+                                   stepWork);
+        }
+    }
+
+    if (stepWork.computeSlowForces)
+    {
+        longRangeNonbondeds->calculate(fr->pmedata,
+                                       cr,
+                                       x.unpaddedConstArrayRef(),
+                                       &forceOutMtsLevel1->forceWithVirial(),
+                                       enerd,
+                                       box,
+                                       lambda,
+                                       dipoleData.muStateAB,
+                                       stepWork,
+                                       ddBalanceRegionHandler);
+    }
+
+    wallcycle_stop(wcycle, WallCycleCounter::Force);
+
+    // VdW dispersion correction, only computed on main rank to avoid double counting
+    if ((stepWork.computeEnergy || stepWork.computeVirial) && fr->dispersionCorrection && MAIN(cr))
+    {
+        // Calculate long range corrections to pressure and energy
+        const DispersionCorrection::Correction correction = fr->dispersionCorrection->calculate(
+                box, lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Vdw)]);
+
+        if (stepWork.computeEnergy)
+        {
+            enerd->term[F_DISPCORR] = correction.energy;
+            enerd->term[F_DVDL_VDW] += correction.dvdl;
+            enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Vdw] += correction.dvdl;
+        }
+        if (stepWork.computeVirial)
+        {
+            correction.correctVirial(vir_force);
+            enerd->term[F_PDISPCORR] = correction.pressure;
+        }
+    }
+
+    const bool needToReceivePmeResultsFromSeparateRank = (PAR(cr) && stepWork.computePmeOnSeparateRank);
+    const bool needToReceivePmeResults =
+            (stepWork.haveGpuPmeOnThisRank || needToReceivePmeResultsFromSeparateRank);
+
+    /* When running free energy perturbations steered by AWH and doing PME calculations on the
+     * GPU we must wait for the PME calculation (dhdl) results to finish before sampling the
+     * FEP dimension with AWH. */
+    const bool needEarlyPmeResults = (awh != nullptr && awh->hasFepLambdaDimension() && needToReceivePmeResults
+                                      && stepWork.computeEnergy && stepWork.computeSlowForces);
+    if (needEarlyPmeResults)
+    {
+        if (stepWork.haveGpuPmeOnThisRank)
+        {
+            pmeGpuWaitAndReduce(fr->pmedata,
+                                stepWork,
+                                wcycle,
+                                &forceOutMtsLevel1->forceWithVirial(),
+                                enerd,
+                                lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)]);
+        }
+        else if (needToReceivePmeResultsFromSeparateRank)
+        {
+            /* In case of node-splitting, the PP nodes receive the long-range
+             * forces, virial and energy from the PME nodes here.
+             */
+            pme_receive_force_ener(fr,
+                                   cr,
+                                   &forceOutMtsLevel1->forceWithVirial(),
+                                   enerd,
+                                   simulationWork.useGpuPmePpCommunication,
+                                   stepWork.useGpuPmeFReduction,
+                                   wcycle);
+        }
+    }
+
+    if (domainWork.haveSpecialForces)
+    {
+        // Communication often happens for special forces, so we should close the balancing region here
+        ddBalanceRegionHandler.closeAfterForceComputationCpu();
+
+        computeSpecialForces(fplog,
+                             cr,
+                             inputrec,
+                             awh,
+                             enforcedRotation,
+                             imdSession,
+                             pull_work,
+                             step,
+                             t,
+                             wcycle,
+                             fr->forceProviders,
+                             box,
+                             x.unpaddedArrayRef(),
+                             mdatoms,
+                             lambda,
+                             stepWork,
+                             &forceOutMtsLevel0.forceWithVirial(),
+                             forceOutMtsLevel1 ? &forceOutMtsLevel1->forceWithVirial() : nullptr,
+                             enerd,
+                             ed,
+                             stepWork.doNeighborSearch);
+    }
+
+    if (simulationWork.havePpDomainDecomposition && stepWork.computeForces && stepWork.useGpuFHalo
+        && domainWork.haveCpuLocalForceWork)
+    {
+        stateGpu->copyForcesToGpu(forceOutMtsLevel0.forceWithShiftForces().force(), AtomLocality::Local);
+    }
+
+    GMX_ASSERT(!(nonbondedAtMtsLevel1 && stepWork.useGpuFBufferOps),
+               "The schedule below does not allow for nonbonded MTS with GPU buffer ops");
+    GMX_ASSERT(!(nonbondedAtMtsLevel1 && stepWork.useGpuFHalo),
+               "The schedule below does not allow for nonbonded MTS with GPU halo exchange");
+    // Will store the amount of cycles spent waiting for the GPU that
+    // will be later used in the DLB accounting.
+    float cycles_wait_gpu = 0;
+    if (useOrEmulateGpuNb && stepWork.computeNonbondedForces)
+    {
+        auto& forceWithShiftForces = forceOutNonbonded->forceWithShiftForces();
+
+        /* wait for non-local forces (or calculate in emulation mode) */
+        if (simulationWork.havePpDomainDecomposition)
+        {
+            if (simulationWork.useGpuNonbonded)
+            {
+                cycles_wait_gpu += gpu_wait_finish_task(
+                        nbv->gpuNbv(),
+                        stepWork,
+                        AtomLocality::NonLocal,
+                        enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::LJSR].data(),
+                        enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::CoulombSR].data(),
+                        forceWithShiftForces.shiftForces(),
+                        wcycle);
+            }
+            else
+            {
+                wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+                do_nb_verlet(
+                        fr, ic, enerd, stepWork, InteractionLocality::NonLocal, enbvClearFYes, step, nrnb, wcycle);
+                wallcycle_stop(wcycle, WallCycleCounter::Force);
+            }
+
+            if (stepWork.useGpuFBufferOps)
+            {
+                if (domainWork.haveCpuNonLocalForceWork)
+                {
+                    stateGpu->copyForcesToGpu(forceOutMtsLevel0.forceWithShiftForces().force(),
+                                              AtomLocality::NonLocal);
+                }
+
+
+                fr->gpuForceReduction[AtomLocality::NonLocal]->execute();
+
+                if (!stepWork.useGpuFHalo)
+                {
+                    /* We don't explicitly wait for the forces to be reduced on device,
+                     * but wait for them to finish copying to CPU instead.
+                     * So, we manually consume the event, see Issue #3988. */
+                    stateGpu->consumeForcesReducedOnDeviceEvent(AtomLocality::NonLocal);
+                    // copy from GPU input for dd_move_f()
+                    stateGpu->copyForcesFromGpu(forceOutMtsLevel0.forceWithShiftForces().force(),
+                                                AtomLocality::NonLocal);
+                }
+            }
+            else
+            {
+                nbv->atomdata_add_nbat_f_to_f(AtomLocality::NonLocal, forceWithShiftForces.force());
+            }
+
+            if (fr->nbv->emulateGpu() && stepWork.computeVirial)
+            {
+                nbnxn_atomdata_add_nbat_fshift_to_fshift(nbv->nbat(), forceWithShiftForces.shiftForces());
+            }
+        }
+    }
+
+    /* Combining the forces for multiple time stepping before the halo exchange, when possible,
+     * avoids an extra halo exchange (when DD is used) and post-processing step.
+     */
+    if (stepWork.combineMtsForcesBeforeHaloExchange)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+        combineMtsForces(getLocalAtomCount(cr->dd, *mdatoms, simulationWork.havePpDomainDecomposition),
+                         force.unpaddedArrayRef(),
+                         forceView->forceMtsCombined(),
+                         inputrec.mtsLevels[1].stepFactor);
+        wallcycle_stop(wcycle, WallCycleCounter::Force);
+    }
+
+    // With both nonbonded and PME offloaded a GPU on the same rank, we use
+    // an alternating wait/reduction scheme.
+    // When running free energy perturbations steered by AWH and calculating PME on GPU,
+    // i.e. if needEarlyPmeResults == true, the PME results have already been reduced above.
+    const bool alternateGpuWait = (!c_disableAlternatingWait && stepWork.haveGpuPmeOnThisRank
+                                   && simulationWork.useGpuNonbonded && !simulationWork.havePpDomainDecomposition
+                                   && !stepWork.useGpuFBufferOps && !needEarlyPmeResults);
+
+
+    const int expectedLocalFReadyOnDeviceConsumptionCount = getExpectedLocalFReadyOnDeviceConsumptionCount(
+            simulationWork, domainWork, stepWork, useOrEmulateGpuNb, alternateGpuWait);
+    // If expectedLocalFReadyOnDeviceConsumptionCount == 0, stateGpu can be uninitialized
+    if (expectedLocalFReadyOnDeviceConsumptionCount > 0)
+    {
+        stateGpu->setFReadyOnDeviceEventExpectedConsumptionCount(
+                AtomLocality::Local, expectedLocalFReadyOnDeviceConsumptionCount);
+    }
+
+    if (simulationWork.havePpDomainDecomposition)
+    {
+        /* We are done with the CPU compute.
+         * We will now communicate the non-local forces.
+         * If we use a GPU this will overlap with GPU work, so in that case
+         * we do not close the DD force balancing region here.
+         * With special forces we closed this region already before computing the special forces.
+         */
+        ddBalanceRegionHandler.closeAfterForceComputationCpu();
+
+        if (stepWork.computeForces)
+        {
+
+            if (stepWork.useGpuFHalo)
+            {
+                // If there exist CPU forces, data from halo exchange should accumulate into these
+                bool accumulateForces = domainWork.haveCpuLocalForceWork;
+                FixedCapacityVector<GpuEventSynchronizer*, 2> gpuForceHaloDependencies;
+                // completion of both H2D copy and clearing is signaled by fReadyOnDevice
+                if (domainWork.haveCpuLocalForceWork || stepWork.clearGpuFBufferEarly)
+                {
+                    gpuForceHaloDependencies.push_back(stateGpu->fReadyOnDevice(AtomLocality::Local));
+                }
+                gpuForceHaloDependencies.push_back(stateGpu->fReducedOnDevice(AtomLocality::NonLocal));
+
+                communicateGpuHaloForces(*cr, accumulateForces, &gpuForceHaloDependencies);
+            }
+            else
+            {
+                if (stepWork.useGpuFBufferOps)
+                {
+                    stateGpu->waitForcesReadyOnHost(AtomLocality::NonLocal);
+                }
+
+                // Without MTS or with MTS at slow steps with uncombined forces we need to
+                // communicate the fast forces
+                if (!simulationWork.useMts || !stepWork.combineMtsForcesBeforeHaloExchange)
+                {
+                    dd_move_f(cr->dd, &forceOutMtsLevel0.forceWithShiftForces(), wcycle);
+                }
+                // With MTS we need to communicate the slow or combined (in forceOutMtsLevel1) forces
+                if (simulationWork.useMts && stepWork.computeSlowForces)
+                {
+                    dd_move_f(cr->dd, &forceOutMtsLevel1->forceWithShiftForces(), wcycle);
+                }
+            }
+        }
+    }
+
+    if (alternateGpuWait)
+    {
+        alternatePmeNbGpuWaitReduce(fr->nbv.get(),
+                                    fr->pmedata,
+                                    forceOutNonbonded,
+                                    forceOutMtsLevel1,
+                                    enerd,
+                                    lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                                    stepWork,
+                                    wcycle);
+    }
+
+    if (!alternateGpuWait && stepWork.haveGpuPmeOnThisRank && !needEarlyPmeResults)
+    {
+        pmeGpuWaitAndReduce(fr->pmedata,
+                            stepWork,
+                            wcycle,
+                            &forceOutMtsLevel1->forceWithVirial(),
+                            enerd,
+                            lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)]);
+    }
+
+    /* Wait for local GPU NB outputs on the non-alternating wait path */
+    if (!alternateGpuWait && stepWork.computeNonbondedForces && simulationWork.useGpuNonbonded)
+    {
+        /* Measured overhead on CUDA and OpenCL with(out) GPU sharing
+         * is between 0.5 and 1.5 Mcycles. So 2 MCycles is an overestimate,
+         * but even with a step of 0.1 ms the difference is less than 1%
+         * of the step time.
+         */
+        const float gpuWaitApiOverheadMargin = 2e6F; /* cycles */
+        const float waitCycles               = gpu_wait_finish_task(
+                nbv->gpuNbv(),
+                stepWork,
+                AtomLocality::Local,
+                enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::LJSR].data(),
+                enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::CoulombSR].data(),
+                forceOutNonbonded->forceWithShiftForces().shiftForces(),
+                wcycle);
+
+        if (ddBalanceRegionHandler.useBalancingRegion())
+        {
+            DdBalanceRegionWaitedForGpu waitedForGpu = DdBalanceRegionWaitedForGpu::yes;
+            if (stepWork.computeForces && waitCycles <= gpuWaitApiOverheadMargin)
+            {
+                /* We measured few cycles, it could be that the kernel
+                 * and transfer finished earlier and there was no actual
+                 * wait time, only API call overhead.
+                 * Then the actual time could be anywhere between 0 and
+                 * cycles_wait_est. We will use half of cycles_wait_est.
+                 */
+                waitedForGpu = DdBalanceRegionWaitedForGpu::no;
+            }
+            ddBalanceRegionHandler.closeAfterForceComputationGpu(cycles_wait_gpu, waitedForGpu);
+        }
+    }
+
+    if (fr->nbv->emulateGpu())
+    {
+        // NOTE: emulation kernel is not included in the balancing region,
+        // but emulation mode does not target performance anyway
+        wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+        do_nb_verlet(fr,
+                     ic,
+                     enerd,
+                     stepWork,
+                     InteractionLocality::Local,
+                     haveDDAtomOrdering(*cr) ? enbvClearFNo : enbvClearFYes,
+                     step,
+                     nrnb,
+                     wcycle);
+        wallcycle_stop(wcycle, WallCycleCounter::Force);
+    }
+
+    // If on GPU PME-PP comms path, receive forces from PME before GPU buffer ops
+    // TODO refactor this and unify with below default-path call to the same function
+    // When running free energy perturbations steered by AWH and calculating PME on GPU,
+    // i.e. if needEarlyPmeResults == true, the PME results have already been reduced above.
+    if (needToReceivePmeResultsFromSeparateRank && simulationWork.useGpuPmePpCommunication && !needEarlyPmeResults)
+    {
+        /* In case of node-splitting, the PP nodes receive the long-range
+         * forces, virial and energy from the PME nodes here.
+         */
+        pme_receive_force_ener(fr,
+                               cr,
+                               &forceOutMtsLevel1->forceWithVirial(),
+                               enerd,
+                               simulationWork.useGpuPmePpCommunication,
+                               stepWork.useGpuPmeFReduction,
+                               wcycle);
+    }
+
+
+    /* Do the nonbonded GPU (or emulation) force buffer reduction
+     * on the non-alternating path. */
+    GMX_ASSERT(!(nonbondedAtMtsLevel1 && stepWork.useGpuFBufferOps),
+               "The schedule below does not allow for nonbonded MTS with GPU buffer ops");
+    if (useOrEmulateGpuNb && !alternateGpuWait)
+    {
+        if (stepWork.useGpuFBufferOps)
+        {
+            ArrayRef<RVec> forceWithShift = forceOutNonbonded->forceWithShiftForces().force();
+
+            // TODO: move these steps as early as possible:
+            // - CPU f H2D should be as soon as all CPU-side forces are done
+            // - wait for force reduction does not need to block host (at least not here, it's sufficient to wait
+            //   before the next CPU task that consumes the forces: vsite spread or update)
+            // - copy is not performed if GPU force halo exchange is active, because it would overwrite the result
+            //   of the halo exchange. In that case the copy is instead performed above, before the exchange.
+            //   These should be unified.
+            if (domainWork.haveLocalForceContribInCpuBuffer && !stepWork.useGpuFHalo)
+            {
+                stateGpu->copyForcesToGpu(forceWithShift, AtomLocality::Local);
+            }
+
+            if (stepWork.computeNonbondedForces)
+            {
+                fr->gpuForceReduction[AtomLocality::Local]->execute();
+            }
+
+            // Copy forces to host if they are needed for update or if virtual sites are enabled.
+            // If there are vsites, we need to copy forces every step to spread vsite forces on host.
+            // TODO: When the output flags will be included in step workload, this copy can be combined with the
+            //       copy call done in sim_utils(...) for the output.
+            // NOTE: If there are virtual sites, the forces are modified on host after this D2H copy. Hence,
+            //       they should not be copied in do_md(...) for the output.
+            if (!simulationWork.useGpuUpdate
+                || (simulationWork.useGpuUpdate && haveDDAtomOrdering(*cr) && simulationWork.useCpuPmePpCommunication)
+                || vsite)
+            {
+                if (stepWork.computeNonbondedForces)
+                {
+                    /* We have previously issued force reduction on the GPU, but we will
+                     * not use this event, instead relying on the stream being in-order.
+                     * Issue #3988. */
+                    stateGpu->consumeForcesReducedOnDeviceEvent(AtomLocality::Local);
+                }
+                stateGpu->copyForcesFromGpu(forceWithShift, AtomLocality::Local);
+                stateGpu->waitForcesReadyOnHost(AtomLocality::Local);
+            }
+        }
+        else if (stepWork.computeNonbondedForces)
+        {
+            ArrayRef<RVec> forceWithShift = forceOutNonbonded->forceWithShiftForces().force();
+            nbv->atomdata_add_nbat_f_to_f(AtomLocality::Local, forceWithShift);
+        }
+    }
+
+    if (expectedLocalFReadyOnDeviceConsumptionCount > 0)
+    {
+        /* The same fReadyOnDevice device synchronizer is later used to track buffer clearing,
+         * so we reset the expected consumption value back to the default (1). */
+        stateGpu->setFReadyOnDeviceEventExpectedConsumptionCount(AtomLocality::Local, 1);
+    }
+
+    launchGpuEndOfStepTasks(
+            nbv, fr->listedForcesGpu.get(), fr->pmedata, enerd, runScheduleWork, step, wcycle);
+
+    if (haveDDAtomOrdering(*cr))
+    {
+        dd_force_flop_stop(cr->dd, nrnb);
+    }
+
+    const bool haveCombinedMtsForces = (stepWork.computeForces && simulationWork.useMts && stepWork.computeSlowForces
+                                        && stepWork.combineMtsForcesBeforeHaloExchange);
+    if (stepWork.computeForces)
+    {
+        postProcessForceWithShiftForces(
+                nrnb, wcycle, box, x.unpaddedArrayRef(), &forceOutMtsLevel0, vir_force, *mdatoms, *fr, vsite, stepWork);
+
+        if (simulationWork.useMts && stepWork.computeSlowForces && !haveCombinedMtsForces)
+        {
+            postProcessForceWithShiftForces(
+                    nrnb, wcycle, box, x.unpaddedArrayRef(), forceOutMtsLevel1, vir_force, *mdatoms, *fr, vsite, stepWork);
+        }
+    }
+
+    // TODO refactor this and unify with above GPU PME-PP / GPU update path call to the same function
+    // When running free energy perturbations steered by AWH and calculating PME on GPU,
+    // i.e. if needEarlyPmeResults == true, the PME results have already been reduced above.
+    if (needToReceivePmeResultsFromSeparateRank && simulationWork.useCpuPmePpCommunication && !needEarlyPmeResults)
+    {
+        /* In case of node-splitting, the PP nodes receive the long-range
+         * forces, virial and energy from the PME nodes here.
+         */
+        pme_receive_force_ener(fr,
+                               cr,
+                               &forceOutMtsLevel1->forceWithVirial(),
+                               enerd,
+                               simulationWork.useGpuPmePpCommunication,
+                               false,
+                               wcycle);
+    }
+
+    if (stepWork.computeForces)
+    {
+        /* If we don't use MTS or if we already combined the MTS forces before, we only
+         * need to post-process one ForceOutputs object here, called forceOutCombined,
+         * otherwise we have to post-process two outputs and then combine them.
+         */
+        ForceOutputs& forceOutCombined = (haveCombinedMtsForces ? forceOutMts.value() : forceOutMtsLevel0);
+        postProcessForces(
+                cr, step, nrnb, wcycle, box, x.unpaddedArrayRef(), &forceOutCombined, vir_force, mdatoms, fr, vsite, stepWork);
+
+        if (simulationWork.useMts && stepWork.computeSlowForces && !haveCombinedMtsForces)
+        {
+            postProcessForces(
+                    cr, step, nrnb, wcycle, box, x.unpaddedArrayRef(), forceOutMtsLevel1, vir_force, mdatoms, fr, vsite, stepWork);
+
+            combineMtsForces(mdatoms->homenr,
+                             force.unpaddedArrayRef(),
+                             forceView->forceMtsCombined(),
+                             inputrec.mtsLevels[1].stepFactor);
+        }
+    }
+
+    if (stepWork.computeEnergy)
+    {
+        /* Compute the final potential energy terms */
+        accumulatePotentialEnergies(enerd, lambda, inputrec.fepvals.get());
+
+        if (!EI_TPI(inputrec.eI))
+        {
+            checkPotentialEnergyValidity(step, *enerd, inputrec);
+        }
+    }
+
+    /* PLUMED */
+    if (fr->forceProviders != nullptr)
+    {
+        ArrayRef<RVec> forceForPlumed = force.unpaddedArrayRef();
+        if (simulationWork.useMts && stepWork.computeSlowForces)
+        {
+            forceForPlumed = forceView->forceMtsCombined();
+        }
+        fr->forceProviders->applyAfterPotentialEnergy(
+                stepWork.computeEnergy, &enerd->term[F_EPOT], forceForPlumed, vir_force);
+    }
+    /* END PLUMED */
+
+    /* In case we don't have constraints and are using GPUs, the next balancing
+     * region starts here.
+     * Some "special" work at the end of do_force_cuts?, such as vsite spread,
+     * virial calculation and COM pulling, is not thus not included in
+     * the balance timing, which is ok as most tasks do communication.
+     */
+    ddBalanceRegionHandler.openBeforeForceComputationCpu(DdAllowBalanceRegionReopen::no);
+}
+
+} // namespace gmx

--- a/patches/gromacs-2025.0.diff/src/gromacs/mdlib/sim_util.cpp.preplumed
+++ b/patches/gromacs-2025.0.diff/src/gromacs/mdlib/sim_util.cpp.preplumed
@@ -1,0 +1,2646 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 1991- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+#include "gmxpre.h"
+
+#include "config.h"
+
+#include <cinttypes>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <array>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "gromacs/applied_forces/awh/awh.h"
+#include "gromacs/domdec/dlbtiming.h"
+#include "gromacs/domdec/domdec.h"
+#include "gromacs/domdec/domdec_struct.h"
+#include "gromacs/domdec/gpuhaloexchange.h"
+#include "gromacs/domdec/haloexchange.h"
+#include "gromacs/domdec/partition.h"
+#include "gromacs/essentialdynamics/edsam.h"
+#include "gromacs/ewald/pme.h"
+#include "gromacs/ewald/pme_coordinate_receiver_gpu.h"
+#include "gromacs/ewald/pme_pp.h"
+#include "gromacs/ewald/pme_pp_comm_gpu.h"
+#include "gromacs/gmxlib/network.h"
+#include "gromacs/gmxlib/nonbonded/nb_free_energy.h"
+#include "gromacs/gmxlib/nonbonded/nonbonded.h"
+#include "gromacs/gmxlib/nrnb.h"
+#include "gromacs/gpu_utils/devicebuffer_datatype.h"
+#include "gromacs/gpu_utils/gpu_utils.h"
+#include "gromacs/imd/imd.h"
+#include "gromacs/listed_forces/disre.h"
+#include "gromacs/listed_forces/listed_forces.h"
+#include "gromacs/listed_forces/listed_forces_gpu.h"
+#include "gromacs/listed_forces/orires.h"
+#include "gromacs/math/arrayrefwithpadding.h"
+#include "gromacs/math/functions.h"
+#include "gromacs/math/units.h"
+#include "gromacs/math/vec.h"
+#include "gromacs/math/vecdump.h"
+#include "gromacs/math/vectypes.h"
+#include "gromacs/mdlib/calcmu.h"
+#include "gromacs/mdlib/calcvir.h"
+#include "gromacs/mdlib/constr.h"
+#include "gromacs/mdlib/dispersioncorrection.h"
+#include "gromacs/mdlib/enerdata_utils.h"
+#include "gromacs/mdlib/force.h"
+#include "gromacs/mdlib/force_flags.h"
+#include "gromacs/mdlib/forcerec.h"
+#include "gromacs/mdlib/gmx_omp_nthreads.h"
+#include "gromacs/mdlib/update.h"
+#include "gromacs/mdlib/vsite.h"
+#include "gromacs/mdlib/wall.h"
+#include "gromacs/mdlib/wholemoleculetransform.h"
+#include "gromacs/mdrunutility/mdmodulesnotifiers.h"
+#include "gromacs/mdtypes/commrec.h"
+#include "gromacs/mdtypes/enerdata.h"
+#include "gromacs/mdtypes/forcebuffers.h"
+#include "gromacs/mdtypes/forceoutput.h"
+#include "gromacs/mdtypes/forcerec.h"
+#include "gromacs/mdtypes/iforceprovider.h"
+#include "gromacs/mdtypes/inputrec.h"
+#include "gromacs/mdtypes/locality.h"
+#include "gromacs/mdtypes/md_enums.h"
+#include "gromacs/mdtypes/mdatom.h"
+#include "gromacs/mdtypes/multipletimestepping.h"
+#include "gromacs/mdtypes/simulation_workload.h"
+#include "gromacs/mdtypes/state.h"
+#include "gromacs/mdtypes/state_propagator_data_gpu.h"
+#include "gromacs/nbnxm/atomdata.h"
+#include "gromacs/nbnxm/gpu_data_mgmt.h"
+#include "gromacs/nbnxm/nbnxm.h"
+#include "gromacs/nbnxm/nbnxm_gpu.h"
+#include "gromacs/pbcutil/ishift.h"
+#include "gromacs/pbcutil/pbc.h"
+#include "gromacs/pulling/pull.h"
+#include "gromacs/pulling/pull_rotation.h"
+#include "gromacs/timing/cyclecounter.h"
+#include "gromacs/timing/gpu_timing.h"
+#include "gromacs/timing/wallcycle.h"
+#include "gromacs/timing/wallcyclereporting.h"
+#include "gromacs/timing/walltime_accounting.h"
+#include "gromacs/topology/ifunc.h"
+#include "gromacs/topology/topology.h"
+#include "gromacs/utility/arrayref.h"
+#include "gromacs/utility/basedefinitions.h"
+#include "gromacs/utility/booltype.h"
+#include "gromacs/utility/cstringutil.h"
+#include "gromacs/utility/enumerationhelpers.h"
+#include "gromacs/utility/exceptions.h"
+#include "gromacs/utility/fatalerror.h"
+#include "gromacs/utility/fixedcapacityvector.h"
+#include "gromacs/utility/gmxassert.h"
+#include "gromacs/utility/gmxmpi.h"
+#include "gromacs/utility/logger.h"
+#include "gromacs/utility/range.h"
+#include "gromacs/utility/real.h"
+#include "gromacs/utility/smalloc.h"
+#include "gromacs/utility/strconvert.h"
+#include "gromacs/utility/stringutil.h"
+#include "gromacs/utility/sysinfo.h"
+
+#include "gpuforcereduction.h"
+
+class GpuEventSynchronizer;
+struct gmx_edsam;
+struct gmx_enfrot;
+struct gmx_multisim_t;
+struct gmx_pme_t;
+struct interaction_const_t;
+struct pull_t;
+
+namespace gmx
+{
+
+// TODO: this environment variable allows us to verify before release
+// that on less common architectures the total cost of polling is not larger than
+// a blocking wait (so polling does not introduce overhead when the static
+// PME-first ordering would suffice).
+static const bool c_disableAlternatingWait = (getenv("GMX_DISABLE_ALTERNATING_GPU_WAIT") != nullptr);
+
+static void sum_forces(ArrayRef<RVec> f, ArrayRef<const RVec> forceToAdd)
+{
+    GMX_ASSERT(f.size() >= forceToAdd.size(), "Accumulation buffer should be sufficiently large");
+    const int end = forceToAdd.size();
+
+    int gmx_unused nt = gmx_omp_nthreads_get(ModuleMultiThread::Default);
+#pragma omp parallel for num_threads(nt) schedule(static)
+    for (int i = 0; i < end; i++)
+    {
+        rvec_inc(f[i], forceToAdd[i]);
+    }
+}
+
+static void calc_virial(int                         start,
+                        int                         homenr,
+                        const rvec                  x[],
+                        const ForceWithShiftForces& forceWithShiftForces,
+                        tensor                      vir_part,
+                        const matrix                box,
+                        t_nrnb*                     nrnb,
+                        const t_forcerec*           fr,
+                        PbcType                     pbcType)
+{
+    /* The short-range virial from surrounding boxes */
+    const rvec* fshift          = as_rvec_array(forceWithShiftForces.shiftForces().data());
+    const rvec* shiftVecPointer = as_rvec_array(fr->shift_vec.data());
+    calc_vir(c_numShiftVectors, shiftVecPointer, fshift, vir_part, pbcType == PbcType::Screw, box);
+    inc_nrnb(nrnb, eNR_VIRIAL, c_numShiftVectors);
+
+    /* Calculate partial virial, for local atoms only, based on short range.
+     * Total virial is computed in global_stat, called from do_md
+     */
+    const rvec* f = as_rvec_array(forceWithShiftForces.force().data());
+    f_calc_vir(start, start + homenr, x, f, vir_part, box);
+    inc_nrnb(nrnb, eNR_VIRIAL, homenr);
+
+    if (debug)
+    {
+        pr_rvecs(debug, 0, "vir_part", vir_part, DIM);
+    }
+}
+
+static void pull_potential_wrapper(const t_commrec*     cr,
+                                   const t_inputrec&    ir,
+                                   const matrix         box,
+                                   ArrayRef<const RVec> x,
+                                   const t_mdatoms*     mdatoms,
+                                   gmx_enerdata_t*      enerd,
+                                   pull_t*              pull_work,
+                                   const real*          lambda,
+                                   double               t,
+                                   gmx_wallcycle*       wcycle)
+{
+    t_pbc pbc;
+    real  dvdl;
+
+    /* Calculate the center of mass forces, this requires communication,
+     * which is why pull_potential is called close to other communication.
+     */
+    wallcycle_start(wcycle, WallCycleCounter::PullPot);
+    set_pbc(&pbc, ir.pbcType, box);
+    dvdl = 0;
+    enerd->term[F_COM_PULL] +=
+            pull_potential(pull_work,
+                           mdatoms->massT,
+                           pbc,
+                           cr,
+                           t,
+                           lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Restraint)],
+                           x,
+                           &dvdl);
+    enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Restraint] += dvdl;
+    wallcycle_stop(wcycle, WallCycleCounter::PullPot);
+}
+
+static void pme_receive_force_ener(t_forcerec*      fr,
+                                   const t_commrec* cr,
+                                   ForceWithVirial* forceWithVirial,
+                                   gmx_enerdata_t*  enerd,
+                                   bool             useGpuPmePpComms,
+                                   bool             receivePmeForceToGpu,
+                                   gmx_wallcycle*   wcycle)
+{
+    real  e_q, e_lj, dvdl_q, dvdl_lj;
+    float cycles_ppdpme, cycles_seppme;
+
+    cycles_ppdpme = wallcycle_stop(wcycle, WallCycleCounter::PpDuringPme);
+    dd_cycles_add(cr->dd, cycles_ppdpme, ddCyclPPduringPME);
+
+    /* In case of node-splitting, the PP nodes receive the long-range
+     * forces, virial and energy from the PME nodes here.
+     */
+    wallcycle_start(wcycle, WallCycleCounter::PpPmeWaitRecvF);
+    dvdl_q  = 0;
+    dvdl_lj = 0;
+    gmx_pme_receive_f(fr->pmePpCommGpu.get(),
+                      cr,
+                      forceWithVirial,
+                      &e_q,
+                      &e_lj,
+                      &dvdl_q,
+                      &dvdl_lj,
+                      useGpuPmePpComms,
+                      receivePmeForceToGpu,
+                      &cycles_seppme);
+    enerd->term[F_COUL_RECIP] += e_q;
+    enerd->term[F_LJ_RECIP] += e_lj;
+    enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Coul] += dvdl_q;
+    enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Vdw] += dvdl_lj;
+
+    if (wcycle)
+    {
+        dd_cycles_add(cr->dd, cycles_seppme, ddCyclPME);
+    }
+    wallcycle_stop(wcycle, WallCycleCounter::PpPmeWaitRecvF);
+}
+
+static void print_large_forces(FILE*                fp,
+                               const t_mdatoms*     md,
+                               const t_commrec*     cr,
+                               int64_t              step,
+                               real                 forceTolerance,
+                               ArrayRef<const RVec> x,
+                               ArrayRef<const RVec> f)
+{
+    real  force2Tolerance = square(forceTolerance);
+    Index numNonFinite    = 0;
+    for (int i = 0; i < md->homenr; i++)
+    {
+        real force2    = norm2(f[i]);
+        bool nonFinite = !std::isfinite(force2);
+        if (force2 >= force2Tolerance || nonFinite)
+        {
+            fprintf(fp,
+                    "step %" PRId64 " atom %6d  x %8.3f %8.3f %8.3f  force %12.5e\n",
+                    step,
+                    ddglatnr(cr->dd, i),
+                    x[i][XX],
+                    x[i][YY],
+                    x[i][ZZ],
+                    std::sqrt(force2));
+        }
+        if (nonFinite)
+        {
+            numNonFinite++;
+        }
+    }
+    if (numNonFinite > 0)
+    {
+        /* Note that with MPI this fatal call on one rank might interrupt
+         * the printing on other ranks. But we can only avoid that with
+         * an expensive MPI barrier that we would need at each step.
+         */
+        gmx_fatal(FARGS, "At step %" PRId64 " detected non-finite forces on %td atoms", step, numNonFinite);
+    }
+}
+
+//! When necessary, spreads forces on vsites and computes the virial for \p forceOutputs->forceWithShiftForces()
+static void postProcessForceWithShiftForces(t_nrnb*              nrnb,
+                                            gmx_wallcycle*       wcycle,
+                                            const matrix         box,
+                                            ArrayRef<const RVec> x,
+                                            ForceOutputs*        forceOutputs,
+                                            tensor               vir_force,
+                                            const t_mdatoms&     mdatoms,
+                                            const t_forcerec&    fr,
+                                            VirtualSitesHandler* vsite,
+                                            const StepWorkload&  stepWork)
+{
+    ForceWithShiftForces& forceWithShiftForces = forceOutputs->forceWithShiftForces();
+
+    /* If we have NoVirSum forces, but we do not calculate the virial,
+     * we later sum the forceWithShiftForces buffer together with
+     * the noVirSum buffer and spread the combined vsite forces at once.
+     */
+    if (vsite && (!forceOutputs->haveForceWithVirial() || stepWork.computeVirial))
+    {
+        using VirialHandling = VirtualSitesHandler::VirialHandling;
+
+        auto                 f      = forceWithShiftForces.force();
+        auto                 fshift = forceWithShiftForces.shiftForces();
+        const VirialHandling virialHandling =
+                (stepWork.computeVirial ? VirialHandling::Pbc : VirialHandling::None);
+        vsite->spreadForces(x, f, virialHandling, fshift, nullptr, nrnb, box, wcycle);
+        forceWithShiftForces.haveSpreadVsiteForces() = true;
+    }
+
+    if (stepWork.computeVirial)
+    {
+        /* Calculation of the virial must be done after vsites! */
+        calc_virial(
+                0, mdatoms.homenr, as_rvec_array(x.data()), forceWithShiftForces, vir_force, box, nrnb, &fr, fr.pbcType);
+    }
+}
+
+//! Spread, compute virial for and sum forces, when necessary
+static void postProcessForces(const t_commrec*     cr,
+                              int64_t              step,
+                              t_nrnb*              nrnb,
+                              gmx_wallcycle*       wcycle,
+                              const matrix         box,
+                              ArrayRef<const RVec> x,
+                              ForceOutputs*        forceOutputs,
+                              tensor               vir_force,
+                              const t_mdatoms*     mdatoms,
+                              const t_forcerec*    fr,
+                              VirtualSitesHandler* vsite,
+                              const StepWorkload&  stepWork)
+{
+    // Extract the final output force buffer, which is also the buffer for forces with shift forces
+    ArrayRef<RVec> f = forceOutputs->forceWithShiftForces().force();
+
+    if (forceOutputs->haveForceWithVirial())
+    {
+        auto& forceWithVirial = forceOutputs->forceWithVirial();
+
+        if (vsite)
+        {
+            /* Spread the mesh force on virtual sites to the other particles...
+             * This is parallellized. MPI communication is performed
+             * if the constructing atoms aren't local.
+             */
+            GMX_ASSERT(!stepWork.computeVirial || f.data() != forceWithVirial.force_.data(),
+                       "We need separate force buffers for shift and virial forces when "
+                       "computing the virial");
+            GMX_ASSERT(!stepWork.computeVirial
+                               || forceOutputs->forceWithShiftForces().haveSpreadVsiteForces(),
+                       "We should spread the force with shift forces separately when computing "
+                       "the virial");
+            const VirtualSitesHandler::VirialHandling virialHandling =
+                    (stepWork.computeVirial ? VirtualSitesHandler::VirialHandling::NonLinear
+                                            : VirtualSitesHandler::VirialHandling::None);
+            matrix virial = { { 0 } };
+            vsite->spreadForces(x, forceWithVirial.force_, virialHandling, {}, virial, nrnb, box, wcycle);
+            forceWithVirial.addVirialContribution(virial);
+        }
+
+        if (stepWork.computeVirial)
+        {
+            /* Now add the forces, this is local */
+            sum_forces(f, forceWithVirial.force_);
+
+            /* Add the direct virial contributions */
+            GMX_ASSERT(
+                    forceWithVirial.computeVirial_,
+                    "forceWithVirial should request virial computation when we request the virial");
+            m_add(vir_force, forceWithVirial.getVirial(), vir_force);
+
+            if (debug)
+            {
+                pr_rvecs(debug, 0, "vir_force", vir_force, DIM);
+            }
+        }
+    }
+    else
+    {
+        GMX_ASSERT(vsite == nullptr || forceOutputs->forceWithShiftForces().haveSpreadVsiteForces(),
+                   "We should have spread the vsite forces (earlier)");
+    }
+
+    if (fr->print_force >= 0)
+    {
+        print_large_forces(stderr, mdatoms, cr, step, fr->print_force, x, f);
+    }
+}
+
+static void do_nb_verlet(t_forcerec*                fr,
+                         const interaction_const_t* ic,
+                         gmx_enerdata_t*            enerd,
+                         const StepWorkload&        stepWork,
+                         const InteractionLocality  ilocality,
+                         const int                  clearF,
+                         const int64_t              step,
+                         t_nrnb*                    nrnb,
+                         gmx_wallcycle*             wcycle)
+{
+    if (!stepWork.computeNonbondedForces)
+    {
+        /* skip non-bonded calculation */
+        return;
+    }
+
+    nonbonded_verlet_t* nbv = fr->nbv.get();
+
+    /* GPU kernel launch overhead is already timed separately */
+    if (!nbv->useGpu())
+    {
+        /* When dynamic pair-list  pruning is requested, we need to prune
+         * at nstlistPrune steps.
+         */
+        if (nbv->isDynamicPruningStepCpu(step))
+        {
+            /* Prune the pair-list beyond fr->ic->rlistPrune using
+             * the current coordinates of the atoms.
+             */
+            wallcycle_sub_start(wcycle, WallCycleSubCounter::NonbondedPruning);
+            nbv->dispatchPruneKernelCpu(ilocality, fr->shift_vec);
+            wallcycle_sub_stop(wcycle, WallCycleSubCounter::NonbondedPruning);
+        }
+    }
+
+    nbv->dispatchNonbondedKernel(
+            ilocality,
+            *ic,
+            stepWork,
+            clearF,
+            fr->shift_vec,
+            enerd->grpp.energyGroupPairTerms[fr->haveBuckingham ? NonBondedEnergyTerms::BuckinghamSR
+                                                                : NonBondedEnergyTerms::LJSR],
+            enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::CoulombSR],
+            nrnb);
+}
+
+static inline void clearRVecs(ArrayRef<RVec> v, const bool useOpenmpThreading)
+{
+    int nth = gmx_omp_nthreads_get_simple_rvec_task(ModuleMultiThread::Default, v.ssize());
+
+    /* Note that we would like to avoid this conditional by putting it
+     * into the omp pragma instead, but then we still take the full
+     * omp parallel for overhead (at least with gcc5).
+     */
+    if (!useOpenmpThreading || nth == 1)
+    {
+        for (RVec& elem : v)
+        {
+            clear_rvec(elem);
+        }
+    }
+    else
+    {
+#pragma omp parallel for num_threads(nth) schedule(static)
+        for (Index i = 0; i < v.ssize(); i++)
+        {
+            clear_rvec(v[i]);
+        }
+    }
+}
+
+/*! \brief Return an estimate of the average kinetic energy or 0 when unreliable
+ *
+ * \param groupOptions  Group options, containing T-coupling options
+ */
+static real averageKineticEnergyEstimate(const t_grpopts& groupOptions)
+{
+    real nrdfCoupled   = 0;
+    real nrdfUncoupled = 0;
+    real kineticEnergy = 0;
+    for (int g = 0; g < groupOptions.ngtc; g++)
+    {
+        if (groupOptions.tau_t[g] >= 0)
+        {
+            nrdfCoupled += groupOptions.nrdf[g];
+            kineticEnergy += groupOptions.nrdf[g] * 0.5 * groupOptions.ref_t[g] * c_boltz;
+        }
+        else
+        {
+            nrdfUncoupled += groupOptions.nrdf[g];
+        }
+    }
+
+    /* This conditional with > also catches nrdf=0 */
+    if (nrdfCoupled > nrdfUncoupled)
+    {
+        return kineticEnergy * (nrdfCoupled + nrdfUncoupled) / nrdfCoupled;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+/*! \brief This routine checks that the potential energy is finite.
+ *
+ * Always checks that the potential energy is finite. If step equals
+ * inputrec.init_step also checks that the magnitude of the potential energy
+ * is reasonable. Terminates with a fatal error when a check fails.
+ * Note that passing this check does not guarantee finite forces,
+ * since those use slightly different arithmetics. But in most cases
+ * there is just a narrow coordinate range where forces are not finite
+ * and energies are finite.
+ *
+ * \param[in] step      The step number, used for checking and printing
+ * \param[in] enerd     The energy data; the non-bonded group energies need to be added to
+ *                      \c enerd.term[F_EPOT] before calling this routine
+ * \param[in] inputrec  The input record
+ */
+static void checkPotentialEnergyValidity(int64_t step, const gmx_enerdata_t& enerd, const t_inputrec& inputrec)
+{
+    /* Threshold valid for comparing absolute potential energy against
+     * the kinetic energy. Normally one should not consider absolute
+     * potential energy values, but with a factor of one million
+     * we should never get false positives.
+     */
+    constexpr real c_thresholdFactor = 1e6;
+
+    bool energyIsNotFinite    = !std::isfinite(enerd.term[F_EPOT]);
+    real averageKineticEnergy = 0;
+    /* We only check for large potential energy at the initial step,
+     * because that is by far the most likely step for this too occur
+     * and because computing the average kinetic energy is not free.
+     * Note: nstcalcenergy >> 1 often does not allow to catch large energies
+     * before they become NaN.
+     */
+    if (step == inputrec.init_step && EI_DYNAMICS(inputrec.eI))
+    {
+        averageKineticEnergy = averageKineticEnergyEstimate(inputrec.opts);
+    }
+
+    if (energyIsNotFinite
+        || (averageKineticEnergy > 0 && enerd.term[F_EPOT] > c_thresholdFactor * averageKineticEnergy))
+    {
+        GMX_THROW(InternalError(formatString(
+                "Step %" PRId64
+                ": The total potential energy is %g, which is %s. The LJ and electrostatic "
+                "contributions to the energy are %g and %g, respectively. A %s potential energy "
+                "can be caused by overlapping interactions in bonded interactions or very large%s "
+                "coordinate values. Usually this is caused by a badly- or non-equilibrated initial "
+                "configuration, incorrect interactions or parameters in the topology.",
+                step,
+                enerd.term[F_EPOT],
+                energyIsNotFinite ? "not finite" : "extremely high",
+                enerd.term[F_LJ],
+                enerd.term[F_COUL_SR],
+                energyIsNotFinite ? "non-finite" : "very high",
+                energyIsNotFinite ? " or Nan" : "")));
+    }
+}
+
+/*! \brief Compute forces and/or energies for special algorithms
+ *
+ * The intention is to collect all calls to algorithms that compute
+ * forces on local atoms only and that do not contribute to the local
+ * virial sum (but add their virial contribution separately).
+ * Eventually these should likely all become ForceProviders.
+ * Within this function the intention is to have algorithms that do
+ * global communication at the end, so global barriers within the MD loop
+ * are as close together as possible.
+ *
+ * \param[in]     fplog            The log file
+ * \param[in]     cr               The communication record
+ * \param[in]     inputrec         The input record
+ * \param[in]     awh              The Awh module (nullptr if none in use).
+ * \param[in]     enforcedRotation Enforced rotation module.
+ * \param[in]     imdSession       The IMD session
+ * \param[in]     pull_work        The pull work structure.
+ * \param[in]     step             The current MD step
+ * \param[in]     t                The current time
+ * \param[in,out] wcycle           Wallcycle accounting struct
+ * \param[in,out] forceProviders   Pointer to a list of force providers
+ * \param[in]     box              The unit cell
+ * \param[in]     x                The coordinates
+ * \param[in]     mdatoms          Per atom properties
+ * \param[in]     lambda           Array of free-energy lambda values
+ * \param[in]     stepWork         Step schedule flags
+ * \param[in,out] forceWithVirialMtsLevel0  Force and virial for MTS level0 forces
+ * \param[in,out] forceWithVirialMtsLevel1  Force and virial for MTS level1 forces, can be nullptr
+ * \param[in,out] enerd            Energy buffer
+ * \param[in,out] ed               Essential dynamics pointer
+ * \param[in]     didNeighborSearch  Tells if we did neighbor searching this step,
+ *                                   used for ED sampling
+ * \param[in]     wcycle           The wallcycle structure
+ *
+ * \todo Remove didNeighborSearch, which is used incorrectly.
+ * \todo Convert all other algorithms called here to ForceProviders.
+ */
+static void computeSpecialForces(FILE*                fplog,
+                                 const t_commrec*     cr,
+                                 const t_inputrec&    inputrec,
+                                 Awh*                 awh,
+                                 gmx_enfrot*          enforcedRotation,
+                                 ImdSession*          imdSession,
+                                 pull_t*              pull_work,
+                                 int64_t              step,
+                                 double               t,
+                                 gmx_wallcycle*       wcycle,
+                                 ForceProviders*      forceProviders,
+                                 const matrix         box,
+                                 ArrayRef<const RVec> x,
+                                 const t_mdatoms*     mdatoms,
+                                 ArrayRef<const real> lambda,
+                                 const StepWorkload&  stepWork,
+                                 ForceWithVirial*     forceWithVirialMtsLevel0,
+                                 ForceWithVirial*     forceWithVirialMtsLevel1,
+                                 gmx_enerdata_t*      enerd,
+                                 gmx_edsam*           ed,
+                                 bool                 didNeighborSearch)
+{
+    /* NOTE: Currently all ForceProviders only provide forces.
+     *       When they also provide energies, remove this conditional.
+     */
+    if (stepWork.computeForces)
+    {
+        ForceProviderInput  forceProviderInput(x,
+                                              mdatoms->homenr,
+                                              makeArrayRef(mdatoms->chargeA).subArray(0, mdatoms->homenr),
+                                              makeArrayRef(mdatoms->massT).subArray(0, mdatoms->homenr),
+                                              t,
+                                              step,
+                                              box,
+                                              *cr);
+        ForceProviderOutput forceProviderOutput(forceWithVirialMtsLevel0, enerd);
+
+        /* Collect forces from modules */
+        forceProviders->calculateForces(forceProviderInput, &forceProviderOutput);
+    }
+
+    const int  pullMtsLevel = forceGroupMtsLevel(inputrec.mtsLevels, MtsForceGroups::Pull);
+    const bool doPulling    = (inputrec.bPull && pull_have_potential(*pull_work)
+                            && (pullMtsLevel == 0 || stepWork.computeSlowForces));
+
+    /* pull_potential_wrapper(), awh->applyBiasForcesAndUpdateBias(), pull_apply_forces()
+     * have to be called in this order
+     */
+    if (doPulling)
+    {
+        pull_potential_wrapper(cr, inputrec, box, x, mdatoms, enerd, pull_work, lambda.data(), t, wcycle);
+    }
+    if (awh && (pullMtsLevel == 0 || stepWork.computeSlowForces))
+    {
+        const bool          needForeignEnergyDifferences = awh->needForeignEnergyDifferences(step);
+        std::vector<double> foreignLambdaDeltaH, foreignLambdaDhDl;
+        if (needForeignEnergyDifferences)
+        {
+            enerd->foreignLambdaTerms.finalizePotentialContributions(
+                    enerd->dvdl_lin, lambda, *inputrec.fepvals);
+            std::tie(foreignLambdaDeltaH, foreignLambdaDhDl) = enerd->foreignLambdaTerms.getTerms(cr);
+        }
+
+        enerd->term[F_COM_PULL] += awh->applyBiasForcesAndUpdateBias(
+                inputrec.pbcType, foreignLambdaDeltaH, foreignLambdaDhDl, box, t, step, wcycle, fplog);
+    }
+    if (doPulling)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::PullPot);
+        auto& forceWithVirial = (pullMtsLevel == 0) ? forceWithVirialMtsLevel0 : forceWithVirialMtsLevel1;
+        pull_apply_forces(pull_work, mdatoms->massT, cr, forceWithVirial);
+        wallcycle_stop(wcycle, WallCycleCounter::PullPot);
+    }
+
+    /* Add the forces from enforced rotation potentials (if any) */
+    if (inputrec.bRot)
+    {
+        wallcycle_start(wcycle, WallCycleCounter::RotAdd);
+        enerd->term[F_COM_PULL] +=
+                add_rot_forces(enforcedRotation, forceWithVirialMtsLevel0->force_, cr, step, t);
+        wallcycle_stop(wcycle, WallCycleCounter::RotAdd);
+    }
+
+    if (ed)
+    {
+        /* Note that since init_edsam() is called after the initialization
+         * of forcerec, edsam doesn't request the noVirSum force buffer.
+         * Thus if no other algorithm (e.g. PME) requires it, the forces
+         * here will contribute to the virial.
+         */
+        do_flood(cr, inputrec, x, forceWithVirialMtsLevel0->force_, ed, box, step, didNeighborSearch);
+    }
+
+    /* Add forces from interactive molecular dynamics (IMD), if any */
+    if (inputrec.bIMD && stepWork.computeForces)
+    {
+        imdSession->applyForces(forceWithVirialMtsLevel0->force_);
+    }
+}
+
+/*! \brief Launch the prepare_step and spread stages of PME GPU.
+ *
+ * \param[in]  pmedata              The PME structure
+ * \param[in]  box                  The box matrix
+ * \param[in]  stepWork             Step schedule flags
+ * \param[in]  xReadyOnDevice       Event synchronizer indicating that the coordinates are ready in the device memory.
+ * \param[in]  lambdaQ              The Coulomb lambda of the current state.
+ * \param[in]  useMdGpuGraph        Whether MD GPU Graph is in use.
+ * \param[in]  wcycle               The wallcycle structure
+ */
+static inline void launchPmeGpuSpread(gmx_pme_t*            pmedata,
+                                      const matrix          box,
+                                      const StepWorkload&   stepWork,
+                                      GpuEventSynchronizer* xReadyOnDevice,
+                                      const real            lambdaQ,
+                                      bool                  useMdGpuGraph,
+                                      gmx_wallcycle*        wcycle)
+{
+    wallcycle_start(wcycle, WallCycleCounter::PmeGpuMesh);
+    pme_gpu_prepare_computation(pmedata, box, wcycle, stepWork);
+    bool                      useGpuDirectComm         = false;
+    PmeCoordinateReceiverGpu* pmeCoordinateReceiverGpu = nullptr;
+    pme_gpu_launch_spread(
+            pmedata, xReadyOnDevice, wcycle, lambdaQ, useGpuDirectComm, pmeCoordinateReceiverGpu, useMdGpuGraph);
+    wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+}
+
+/*! \brief Launch the FFT and gather stages of PME GPU
+ *
+ * This function only implements setting the output forces (no accumulation).
+ *
+ * \param[in]  pmedata        The PME structure
+ * \param[in]  lambdaQ        The Coulomb lambda of the current system state.
+ * \param[in]  wcycle         The wallcycle structure
+ * \param[in]  stepWork       Step schedule flags
+ */
+static void launchPmeGpuFftAndGather(gmx_pme_t*          pmedata,
+                                     const real          lambdaQ,
+                                     gmx_wallcycle*      wcycle,
+                                     const StepWorkload& stepWork)
+{
+    wallcycle_start_nocount(wcycle, WallCycleCounter::PmeGpuMesh);
+    pme_gpu_launch_complex_transforms(pmedata, wcycle, stepWork);
+    pme_gpu_launch_gather(pmedata, wcycle, lambdaQ, stepWork.computeVirial);
+    wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+}
+
+/*! \brief
+ * Blocks until PME GPU tasks are completed, and gets the output forces and virial/energy
+ * (if they were to be computed).
+ *
+ * \param[in]  pme             The PME data structure.
+ * \param[in]  stepWork        The required work for this simulation step
+ * \param[in]  wcycle          The wallclock counter.
+ * \param[out] forceWithVirial The output force and virial
+ * \param[out] enerd           The output energies
+ * \param[in]  lambdaQ         The Coulomb lambda to use when calculating the results.
+ */
+static void pmeGpuWaitAndReduce(gmx_pme_t*          pme,
+                                const StepWorkload& stepWork,
+                                gmx_wallcycle*      wcycle,
+                                ForceWithVirial*    forceWithVirial,
+                                gmx_enerdata_t*     enerd,
+                                const real          lambdaQ)
+{
+    wallcycle_start_nocount(wcycle, WallCycleCounter::PmeGpuMesh);
+
+    pme_gpu_wait_and_reduce(pme, stepWork, wcycle, forceWithVirial, enerd, lambdaQ);
+
+    wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+}
+
+/*! \brief
+ *  Polling wait for either of the PME or nonbonded GPU tasks.
+ *
+ * Instead of a static order in waiting for GPU tasks, this function
+ * polls checking which of the two tasks completes first, and does the
+ * associated force buffer reduction overlapped with the other task.
+ * By doing that, unlike static scheduling order, it can always overlap
+ * one of the reductions, regardless of the GPU task completion order.
+ *
+ * \param[in]     nbv              Nonbonded verlet structure
+ * \param[in,out] pmedata          PME module data
+ * \param[in,out] forceOutputsNonbonded  Force outputs for the non-bonded forces and shift forces
+ * \param[in,out] forceOutputsPme  Force outputs for the PME forces and virial
+ * \param[in,out] enerd            Energy data structure results are reduced into
+ * \param[in]     lambdaQ          The Coulomb lambda of the current system state.
+ * \param[in]     stepWork         Step schedule flags
+ * \param[in]     wcycle           The wallcycle structure
+ */
+static void alternatePmeNbGpuWaitReduce(nonbonded_verlet_t* nbv,
+                                        gmx_pme_t*          pmedata,
+                                        ForceOutputs*       forceOutputsNonbonded,
+                                        ForceOutputs*       forceOutputsPme,
+                                        gmx_enerdata_t*     enerd,
+                                        const real          lambdaQ,
+                                        const StepWorkload& stepWork,
+                                        gmx_wallcycle*      wcycle)
+{
+    bool isPmeGpuDone = false;
+    bool isNbGpuDone  = false;
+
+    ArrayRef<const RVec> pmeGpuForces;
+
+    while (!isPmeGpuDone || !isNbGpuDone)
+    {
+        if (!isPmeGpuDone)
+        {
+            wallcycle_start_nocount(wcycle, WallCycleCounter::PmeGpuMesh);
+            GpuTaskCompletion completionType =
+                    (isNbGpuDone) ? GpuTaskCompletion::Wait : GpuTaskCompletion::Check;
+            isPmeGpuDone = pme_gpu_try_finish_task(
+                    pmedata, stepWork, wcycle, &forceOutputsPme->forceWithVirial(), enerd, lambdaQ, completionType);
+            wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+        }
+
+        if (!isNbGpuDone)
+        {
+            auto&             forceBuffersNonbonded = forceOutputsNonbonded->forceWithShiftForces();
+            GpuTaskCompletion completionType =
+                    (isPmeGpuDone) ? GpuTaskCompletion::Wait : GpuTaskCompletion::Check;
+            // To get the wcycle call count right, when in GpuTaskCompletion::Check mode,
+            // we start without counting and only when the task finished we issue a
+            // start/stop to increment.
+            // GpuTaskCompletion::Wait mode the timing is expected to be done in the caller.
+            wallcycle_start_nocount(wcycle, WallCycleCounter::WaitGpuNbL);
+            isNbGpuDone = gpu_try_finish_task(
+                    nbv->gpuNbv(),
+                    stepWork,
+                    AtomLocality::Local,
+                    enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::LJSR].data(),
+                    enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::CoulombSR].data(),
+                    forceBuffersNonbonded.shiftForces(),
+                    completionType);
+            wallcycle_stop(wcycle, WallCycleCounter::WaitGpuNbL);
+
+            if (isNbGpuDone)
+            {
+                wallcycle_increment_event_count(wcycle, WallCycleCounter::WaitGpuNbL);
+                nbv->atomdata_add_nbat_f_to_f(AtomLocality::Local, forceBuffersNonbonded.force());
+            }
+        }
+    }
+}
+
+/*! \brief Set up the different force buffers; also does clearing.
+ *
+ * \param[in] forceHelperBuffers        Helper force buffers
+ * \param[in] force                     force array
+ * \param[in] domainWork                Domain lifetime workload flags
+ * \param[in] stepWork                  Step schedule flags
+ * \param[in] havePpDomainDecomposition Whether we have a PP domain decomposition
+ * \param[out] wcycle                   wallcycle recording structure
+ *
+ * \returns                             Cleared force output structure
+ */
+static ForceOutputs setupForceOutputs(ForceHelperBuffers*           forceHelperBuffers,
+                                      ArrayRefWithPadding<RVec>     force,
+                                      const DomainLifetimeWorkload& domainWork,
+                                      const StepWorkload&           stepWork,
+                                      const bool                    havePpDomainDecomposition,
+                                      gmx_wallcycle*                wcycle)
+{
+    /* NOTE: We assume fr->shiftForces is all zeros here */
+    ForceWithShiftForces forceWithShiftForces(
+            force, stepWork.computeVirial, forceHelperBuffers->shiftForces());
+
+    if (stepWork.computeForces
+        && (domainWork.haveCpuLocalForceWork || !stepWork.useGpuFBufferOps
+            || (havePpDomainDecomposition && !stepWork.useGpuFHalo)))
+    {
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::ClearForceBuffer);
+        /* Clear the short- and long-range forces */
+        clearRVecs(forceWithShiftForces.force(), true);
+
+        /* Clear the shift forces */
+        clearRVecs(forceWithShiftForces.shiftForces(), false);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::ClearForceBuffer);
+    }
+
+    /* If we need to compute the virial, we might need a separate
+     * force buffer for algorithms for which the virial is calculated
+     * directly, such as PME. Otherwise, forceWithVirial uses the
+     * the same force (f in legacy calls) buffer as other algorithms.
+     */
+    const bool useSeparateForceWithVirialBuffer =
+            (stepWork.computeForces
+             && (stepWork.computeVirial && forceHelperBuffers->haveDirectVirialContributions()));
+    /* forceWithVirial uses the local atom range only */
+    ForceWithVirial forceWithVirial(useSeparateForceWithVirialBuffer
+                                            ? forceHelperBuffers->forceBufferForDirectVirialContributions()
+                                            : force.unpaddedArrayRef(),
+                                    stepWork.computeVirial);
+
+    if (useSeparateForceWithVirialBuffer)
+    {
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::ClearForceBuffer);
+        /* TODO: update comment
+         * We only compute forces on local atoms. Note that vsites can
+         * spread to non-local atoms, but that part of the buffer is
+         * cleared separately in the vsite spreading code.
+         */
+        clearRVecs(forceWithVirial.force_, true);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::ClearForceBuffer);
+    }
+
+
+    return ForceOutputs(
+            forceWithShiftForces, forceHelperBuffers->haveDirectVirialContributions(), forceWithVirial);
+}
+
+/* \brief Launch end-of-step GPU tasks: buffer clearing and rolling pruning.
+ *
+ */
+static void launchGpuEndOfStepTasks(nonbonded_verlet_t*          nbv,
+                                    ListedForcesGpu*             listedForcesGpu,
+                                    gmx_pme_t*                   pmedata,
+                                    gmx_enerdata_t*              enerd,
+                                    const MdrunScheduleWorkload& runScheduleWork,
+                                    int64_t                      step,
+                                    gmx_wallcycle*               wcycle)
+{
+    if (runScheduleWork.simulationWork.useGpuNonbonded && runScheduleWork.stepWork.computeNonbondedForces)
+    {
+        /* Launch pruning before buffer clearing because the API overhead of the
+         * clear kernel launches can leave the GPU idle while it could be running
+         * the prune kernel.
+         */
+        if (nbv->isDynamicPruningStepGpu(step))
+        {
+            nbv->dispatchPruneKernelGpu(step);
+        }
+
+        /* now clear the GPU outputs while we finish the step on the CPU */
+        wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        gpu_clear_outputs(nbv->gpuNbv(), runScheduleWork.stepWork.computeVirial);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+    }
+
+    if (runScheduleWork.stepWork.haveGpuPmeOnThisRank)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::PmeGpuMesh);
+        bool gpuGraphWithSeparatePmeRank = false;
+        pme_gpu_reinit_computation(pmedata, gpuGraphWithSeparatePmeRank, wcycle);
+        wallcycle_stop(wcycle, WallCycleCounter::PmeGpuMesh);
+    }
+
+    if (runScheduleWork.domainWork.haveGpuBondedWork && runScheduleWork.stepWork.computeEnergy)
+    {
+        // in principle this should be included in the DD balancing region,
+        // but generally it is infrequent so we'll omit it for the sake of
+        // simpler code
+        listedForcesGpu->waitAccumulateEnergyTerms(enerd);
+
+        listedForcesGpu->clearEnergies();
+    }
+}
+
+/*! \brief Compute the number of times the "local coordinates ready on device" GPU event will be used as a synchronization point.
+ *
+ * When some work is offloaded to GPU, force calculation should wait for the atom coordinates to
+ * be ready on the device. The coordinates can come either from H2D copy at the beginning of the step,
+ * or from the GPU integration at the end of the previous step.
+ *
+ * In GROMACS, we usually follow the "mark once - wait once" approach. But this event is "consumed"
+ * (that is, waited upon either on host or on the device) multiple times, since many tasks
+ * in different streams depend on the coordinates.
+ *
+ * This function return the number of times the event will be consumed based on this step's workload.
+ *
+ * \param simulationWork Simulation workload flags.
+ * \param stepWork Step workload flags.
+ * \param domainWork Domain workload flags.
+ * \param pmeSendCoordinatesFromGpu Whether peer-to-peer communication is used for PME coordinates.
+ * \return
+ */
+static int getExpectedLocalXReadyOnDeviceConsumptionCount(const SimulationWorkload& simulationWork,
+                                                          const StepWorkload&       stepWork,
+                                                          const DomainLifetimeWorkload& domainWork,
+                                                          bool pmeSendCoordinatesFromGpu)
+{
+    int result = 0;
+    if (stepWork.computeSlowForces)
+    {
+        if (pmeSendCoordinatesFromGpu)
+        {
+            GMX_ASSERT(simulationWork.haveSeparatePmeRank,
+                       "GPU PME PP communications require having a separate PME rank");
+            // Event is consumed by gmx_pme_send_coordinates for GPU PME PP Communications
+            result++;
+        }
+        if (stepWork.haveGpuPmeOnThisRank)
+        {
+            // Event is consumed by launchPmeGpuSpread
+            result++;
+        }
+        if (stepWork.computeNonbondedForces && stepWork.useGpuXBufferOps)
+        {
+            // Event is consumed by convertCoordinatesGpu
+            result++;
+        }
+    }
+    if (stepWork.useGpuXHalo)
+    {
+        // Event is consumed by communicateGpuHaloCoordinates
+        result++;
+        if (GMX_THREAD_MPI) // Issue #4262
+        {
+            result++;
+        }
+    }
+    if (stepWork.clearGpuFBufferEarly && simulationWork.useGpuUpdate)
+    {
+        // Event is consumed by force clearing which waits for the update to complete
+        result++;
+    }
+    if (simulationWork.useGpuUpdate && domainWork.haveCpuLocalForceWork)
+    {
+        // Event is consumed when waiting for it on the CPU prior to CPU force buffer clearing.
+        // The actual data dependency does not involve coordinates, but we use this event
+        // as an "end-of-step" mark.
+        if (!(stepWork.doNeighborSearch || simulationWork.useCpuHaloExchange
+              || (stepWork.computePmeOnSeparateRank && !pmeSendCoordinatesFromGpu)))
+        {
+            result++;
+        }
+    }
+    return result;
+}
+
+/*! \brief Compute the number of times the "local forces ready on device" GPU event will be used as a synchronization point.
+ *
+ * In GROMACS, we usually follow the "mark once - wait once" approach. But this event is "consumed"
+ * (that is, waited upon either on host or on the device) multiple times, since many tasks
+ * in different streams depend on the local forces.
+ *
+ * \param simulationWork Simulation workload flags.
+ * \param domainWork Domain workload flags.
+ * \param stepWork Step workload flags.
+ * \param useOrEmulateGpuNb Whether GPU non-bonded calculations are used or emulated.
+ * \param alternateGpuWait Whether alternating wait/reduce scheme is used.
+ * \return The number of times the event will be consumed based on this step's workload.
+ */
+static int getExpectedLocalFReadyOnDeviceConsumptionCount(const SimulationWorkload& simulationWork,
+                                                          const DomainLifetimeWorkload& domainWork,
+                                                          const StepWorkload&           stepWork,
+                                                          bool useOrEmulateGpuNb,
+                                                          bool alternateGpuWait)
+{
+    int  counter = 0;
+    bool eventUsedInGpuForceReduction =
+            (domainWork.haveCpuLocalForceWork
+             || (simulationWork.havePpDomainDecomposition && !simulationWork.useGpuHaloExchange));
+    bool gpuForceReductionUsed = useOrEmulateGpuNb && !alternateGpuWait && stepWork.useGpuFBufferOps
+                                 && stepWork.computeNonbondedForces;
+    if (gpuForceReductionUsed && eventUsedInGpuForceReduction)
+    {
+        counter++;
+    }
+    bool gpuForceHaloUsed = simulationWork.havePpDomainDecomposition && stepWork.computeForces
+                            && stepWork.useGpuFHalo;
+    if (gpuForceHaloUsed)
+    {
+        counter++;
+    }
+    return counter;
+}
+
+//! \brief Data structure to hold dipole-related data and staging arrays
+struct DipoleData
+{
+    //! Dipole staging for fast summing over MPI
+    DVec muStaging[2] = { { 0.0, 0.0, 0.0 } };
+    //! Dipole staging for states A and B (index 0 and 1 resp.)
+    RVec muStateAB[2] = { { 0.0_real, 0.0_real, 0.0_real } };
+};
+
+
+static void reduceAndUpdateMuTot(DipoleData*                   dipoleData,
+                                 const t_commrec*              cr,
+                                 const bool                    haveFreeEnergy,
+                                 ArrayRef<const real>          lambda,
+                                 rvec                          muTotal,
+                                 const DDBalanceRegionHandler& ddBalanceRegionHandler)
+{
+    if (PAR(cr))
+    {
+        gmx_sumd(2 * DIM, dipoleData->muStaging[0], cr);
+        ddBalanceRegionHandler.reopenRegionCpu();
+    }
+    for (int i = 0; i < 2; i++)
+    {
+        for (int j = 0; j < DIM; j++)
+        {
+            dipoleData->muStateAB[i][j] = dipoleData->muStaging[i][j];
+        }
+    }
+
+    if (!haveFreeEnergy)
+    {
+        copy_rvec(dipoleData->muStateAB[0], muTotal);
+    }
+    else
+    {
+        for (int j = 0; j < DIM; j++)
+        {
+            muTotal[j] = (1.0 - lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)])
+                                 * dipoleData->muStateAB[0][j]
+                         + lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)]
+                                   * dipoleData->muStateAB[1][j];
+        }
+    }
+}
+
+/*! \brief Combines MTS level0 and level1 force buffers into a full and MTS-combined force buffer.
+ *
+ * \param[in]     numAtoms        The number of atoms to combine forces for
+ * \param[in,out] forceMtsLevel0  Input: F_level0, output: F_level0 + F_level1
+ * \param[in,out] forceMts        Input: F_level1, output: F_level0 + mtsFactor * F_level1
+ * \param[in]     mtsFactor       The factor between the level0 and level1 time step
+ */
+static void combineMtsForces(const int      numAtoms,
+                             ArrayRef<RVec> forceMtsLevel0,
+                             ArrayRef<RVec> forceMts,
+                             const real     mtsFactor)
+{
+    const int gmx_unused numThreads = gmx_omp_nthreads_get(ModuleMultiThread::Default);
+#pragma omp parallel for num_threads(numThreads) schedule(static)
+    for (int i = 0; i < numAtoms; i++)
+    {
+        const RVec forceMtsLevel0Tmp = forceMtsLevel0[i];
+        forceMtsLevel0[i] += forceMts[i];
+        forceMts[i] = forceMtsLevel0Tmp + mtsFactor * forceMts[i];
+    }
+}
+
+/*! \brief Setup for the local GPU force reduction:
+ * reinitialization plus the registration of forces and dependencies.
+ *
+ * \param [in] runScheduleWork     Schedule workload flag structure
+ * \param [in] nbv                 Non-bonded Verlet object
+ * \param [in] stateGpu            GPU state propagator object
+ * \param [in] gpuForceReduction   GPU force reduction object
+ * \param [in] pmePpCommGpu        PME-PP GPU communication object
+ * \param [in] pmedata             PME data object
+ * \param [in] dd                  Domain decomposition object
+ */
+static void setupLocalGpuForceReduction(const MdrunScheduleWorkload& runScheduleWork,
+                                        nonbonded_verlet_t*          nbv,
+                                        StatePropagatorDataGpu*      stateGpu,
+                                        GpuForceReduction*           gpuForceReduction,
+                                        PmePpCommGpu*                pmePpCommGpu,
+                                        const gmx_pme_t*             pmedata,
+                                        const gmx_domdec_t*          dd)
+{
+    GMX_ASSERT(!runScheduleWork.simulationWork.useMts,
+               "GPU force reduction is not compatible with MTS");
+
+    // (re-)initialize local GPU force reduction
+    const bool accumulate = runScheduleWork.domainWork.haveCpuLocalForceWork
+                            || runScheduleWork.simulationWork.havePpDomainDecomposition;
+    const int atomStart = 0;
+    gpuForceReduction->reinit(stateGpu->getForces(),
+                              nbv->getNumAtoms(AtomLocality::Local),
+                              nbv->getGridIndices(),
+                              atomStart,
+                              accumulate,
+                              stateGpu->fReducedOnDevice(AtomLocality::Local));
+
+    // register forces and add dependencies
+    gpuForceReduction->registerNbnxmForce(gpu_get_f(nbv->gpuNbv()));
+
+    DeviceBuffer<RVec>    pmeForcePtr;
+    GpuEventSynchronizer* pmeSynchronizer     = nullptr;
+    bool                  havePmeContribution = false;
+
+    if (runScheduleWork.simulationWork.haveGpuPmeOnPpRank())
+    {
+        pmeForcePtr = pme_gpu_get_device_f(pmedata);
+        if (pmeForcePtr)
+        {
+            pmeSynchronizer     = pme_gpu_get_f_ready_synchronizer(pmedata);
+            havePmeContribution = true;
+        }
+    }
+    else if (runScheduleWork.simulationWork.useGpuPmePpCommunication)
+    {
+        pmeForcePtr = pmePpCommGpu->getGpuForceStagingPtr();
+        GMX_ASSERT(pmeForcePtr, "PME force for reduction has no data");
+        if (GMX_THREAD_MPI)
+        {
+            pmeSynchronizer = pmePpCommGpu->getForcesReadySynchronizer();
+        }
+        havePmeContribution = true;
+    }
+
+    if (havePmeContribution)
+    {
+        gpuForceReduction->registerRvecForce(pmeForcePtr);
+        if (runScheduleWork.simulationWork.useNvshmem)
+        {
+            DeviceBuffer<uint64_t> forcesReadyNvshmemFlags = pmePpCommGpu->getGpuForcesSyncObj();
+            gpuForceReduction->registerForcesReadyNvshmemFlags(forcesReadyNvshmemFlags);
+        }
+
+        if (!runScheduleWork.simulationWork.useGpuPmePpCommunication || GMX_THREAD_MPI)
+        {
+            GMX_ASSERT(pmeSynchronizer != nullptr, "PME force ready cuda event should not be NULL");
+            gpuForceReduction->addDependency(pmeSynchronizer);
+        }
+    }
+
+    if (runScheduleWork.domainWork.haveCpuLocalForceWork
+        || (runScheduleWork.simulationWork.havePpDomainDecomposition
+            && !runScheduleWork.simulationWork.useGpuHaloExchange))
+    {
+        gpuForceReduction->addDependency(stateGpu->fReadyOnDevice(AtomLocality::Local));
+    }
+
+    if (runScheduleWork.simulationWork.useGpuHaloExchange)
+    {
+        gpuForceReduction->addDependency(dd->gpuHaloExchange[0][0]->getForcesReadyOnDeviceEvent());
+    }
+}
+
+/*! \brief Setup for the non-local GPU force reduction:
+ * reinitialization plus the registration of forces and dependencies.
+ *
+ * \param [in] runScheduleWork     Schedule workload flag structure
+ * \param [in] nbv                 Non-bonded Verlet object
+ * \param [in] stateGpu            GPU state propagator object
+ * \param [in] gpuForceReduction   GPU force reduction object
+ * \param [in] dd                  Domain decomposition object
+ */
+static void setupNonLocalGpuForceReduction(const MdrunScheduleWorkload& runScheduleWork,
+                                           nonbonded_verlet_t*          nbv,
+                                           StatePropagatorDataGpu*      stateGpu,
+                                           GpuForceReduction*           gpuForceReduction,
+                                           const gmx_domdec_t*          dd)
+{
+    // (re-)initialize non-local GPU force reduction
+    const bool accumulate = runScheduleWork.domainWork.haveCpuNonLocalForceWork;
+    const int  atomStart  = dd_numHomeAtoms(*dd);
+    gpuForceReduction->reinit(stateGpu->getForces(),
+                              nbv->getNumAtoms(AtomLocality::NonLocal),
+                              nbv->getGridIndices(),
+                              atomStart,
+                              accumulate,
+                              stateGpu->fReducedOnDevice(AtomLocality::NonLocal));
+
+    // register forces and add dependencies
+    gpuForceReduction->registerNbnxmForce(gpu_get_f(nbv->gpuNbv()));
+
+    if (runScheduleWork.domainWork.haveCpuNonLocalForceWork)
+    {
+        gpuForceReduction->addDependency(stateGpu->fReadyOnDevice(AtomLocality::NonLocal));
+    }
+}
+
+
+/*! \brief Return the number of local atoms.
+ */
+static int getLocalAtomCount(const gmx_domdec_t* dd, const t_mdatoms& mdatoms, bool havePPDomainDecomposition)
+{
+    GMX_ASSERT(!(havePPDomainDecomposition && (dd == nullptr)),
+               "Can't have PP decomposition with dd uninitialized!");
+    return havePPDomainDecomposition ? dd_numAtomsZones(*dd) : mdatoms.homenr;
+}
+
+/*! \brief Does pair search and closely related activities required on search steps.
+ */
+static void doPairSearch(const t_commrec*             cr,
+                         const t_inputrec&            inputrec,
+                         const MDModulesNotifiers&    mdModulesNotifiers,
+                         int64_t                      step,
+                         t_nrnb*                      nrnb,
+                         gmx_wallcycle*               wcycle,
+                         const gmx_localtop_t&        top,
+                         const matrix                 box,
+                         ArrayRefWithPadding<RVec>    x,
+                         ArrayRef<RVec>               v,
+                         const t_mdatoms&             mdatoms,
+                         t_forcerec*                  fr,
+                         const MdrunScheduleWorkload& runScheduleWork)
+{
+    nonbonded_verlet_t* nbv = fr->nbv.get();
+
+    StatePropagatorDataGpu* stateGpu = fr->stateGpu;
+
+    const SimulationWorkload& simulationWork = runScheduleWork.simulationWork;
+    const StepWorkload&       stepWork       = runScheduleWork.stepWork;
+
+    if (needStateGpu(simulationWork))
+    {
+        // TODO refactor this to do_md, after partitioning.
+        stateGpu->reinit(mdatoms.homenr,
+                         getLocalAtomCount(cr->dd, mdatoms, simulationWork.havePpDomainDecomposition),
+                         *cr,
+                         -1);
+    }
+
+    if (simulationWork.haveGpuPmeOnPpRank())
+    {
+        GMX_ASSERT(needStateGpu(simulationWork), "StatePropagatorDataGpu is needed");
+        // TODO: This should be moved into PME setup function ( pme_gpu_prepare_computation(...) )
+        pme_gpu_set_device_x(fr->pmedata, stateGpu->getCoordinates());
+    }
+
+    if (fr->pbcType != PbcType::No)
+    {
+        const bool calcCGCM = (stepWork.stateChanged && !haveDDAtomOrdering(*cr));
+        if (calcCGCM)
+        {
+            put_atoms_in_box_omp(fr->pbcType,
+                                 box,
+                                 fr->haveBoxDeformation,
+                                 inputrec.deform,
+                                 x.unpaddedArrayRef().subArray(0, mdatoms.homenr),
+                                 v.empty() ? ArrayRef<RVec>() : v.subArray(0, mdatoms.homenr),
+                                 gmx_omp_nthreads_get(ModuleMultiThread::Default));
+            inc_nrnb(nrnb, eNR_SHIFTX, mdatoms.homenr);
+        }
+
+        if (!haveDDAtomOrdering(*cr))
+        {
+            // Atoms might have changed periodic image, signal MDModules
+            MDModulesAtomsRedistributedSignal mdModulesAtomsRedistributedSignal(
+                    box, x.unpaddedArrayRef().subArray(0, mdatoms.homenr));
+            mdModulesNotifiers.simulationSetupNotifier_.notify(mdModulesAtomsRedistributedSignal);
+        }
+    }
+
+    if (fr->wholeMoleculeTransform && stepWork.stateChanged)
+    {
+        fr->wholeMoleculeTransform->updateForAtomPbcJumps(x.unpaddedArrayRef(), box);
+    }
+
+    wallcycle_start(wcycle, WallCycleCounter::NS);
+    if (!haveDDAtomOrdering(*cr))
+    {
+        const rvec vzero       = { 0.0_real, 0.0_real, 0.0_real };
+        const rvec boxDiagonal = { box[XX][XX], box[YY][YY], box[ZZ][ZZ] };
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::NBSGridLocal);
+        nbv->putAtomsOnGrid(box,
+                            0,
+                            vzero,
+                            boxDiagonal,
+                            nullptr,
+                            { 0, mdatoms.homenr },
+                            mdatoms.homenr,
+                            -1,
+                            fr->atomInfo,
+                            x.unpaddedArrayRef(),
+                            nullptr);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::NBSGridLocal);
+    }
+    else
+    {
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::NBSGridNonLocal);
+        if (!nbv->localAtomOrderMatchesNbnxmOrder())
+        {
+            nbnxn_put_on_grid_nonlocal(nbv, getDomdecZones(*cr->dd), fr->atomInfo, x.unpaddedArrayRef());
+        }
+        nbv->convertCoordinates(AtomLocality::NonLocal, x.unpaddedArrayRef());
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::NBSGridNonLocal);
+    }
+
+    nbv->setAtomProperties(mdatoms.typeA, mdatoms.chargeA, fr->atomInfo);
+
+    wallcycle_stop(wcycle, WallCycleCounter::NS);
+
+    /* initialize the GPU nbnxm atom data and bonded data structures */
+    if (simulationWork.useGpuNonbonded)
+    {
+        // Note: cycle counting only nononbondeds, GPU listed forces counts internally
+        wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        gpu_init_atomdata(nbv->gpuNbv(), &nbv->nbat());
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+
+        if (fr->listedForcesGpu)
+        {
+            /* Now we put all atoms on the grid, we can assign bonded
+             * interactions to the GPU, where the grid order is
+             * needed. Also the xq, f and fshift device buffers have
+             * been reallocated if needed, so the bonded code can
+             * learn about them. */
+            // TODO the xq, f, and fshift buffers are now shared
+            // resources, so they should be maintained by a
+            // higher-level object than the nb module.
+            fr->listedForcesGpu->updateInteractionListsAndDeviceBuffers(
+                    nbv->getGridIndices(), top.idef, gpuGetNBAtomData(nbv->gpuNbv()));
+        }
+    }
+
+    wallcycle_start_nocount(wcycle, WallCycleCounter::NS);
+    wallcycle_sub_start(wcycle, WallCycleSubCounter::NBSSearchLocal);
+    /* Note that with a GPU the launch overhead of the list transfer is not timed separately */
+    nbv->constructPairlist(InteractionLocality::Local, top.excls, step, nrnb);
+
+    nbv->setupGpuShortRangeWork(fr->listedForcesGpu.get(), InteractionLocality::Local);
+
+    wallcycle_sub_stop(wcycle, WallCycleSubCounter::NBSSearchLocal);
+    wallcycle_stop(wcycle, WallCycleCounter::NS);
+
+    if (simulationWork.useGpuXBufferOpsWhenAllowed)
+    {
+        nbv->atomdata_init_copy_x_to_nbat_x_gpu();
+    }
+
+    if (simulationWork.useGpuFBufferOpsWhenAllowed)
+    {
+        // with MPI, direct GPU communication, and separate PME ranks we need
+        // gmx_pme_send_coordinates() to be called before we can set up force reduction
+        bool delaySetupLocalGpuForceReduction = GMX_MPI && simulationWork.useGpuPmePpCommunication;
+        if (!delaySetupLocalGpuForceReduction)
+        {
+            setupLocalGpuForceReduction(runScheduleWork,
+                                        nbv,
+                                        stateGpu,
+                                        fr->gpuForceReduction[AtomLocality::Local].get(),
+                                        fr->pmePpCommGpu.get(),
+                                        fr->pmedata,
+                                        cr->dd);
+        }
+
+        if (simulationWork.havePpDomainDecomposition)
+        {
+            setupNonLocalGpuForceReduction(runScheduleWork,
+                                           nbv,
+                                           stateGpu,
+                                           fr->gpuForceReduction[AtomLocality::NonLocal].get(),
+                                           cr->dd);
+        }
+    }
+
+    /* do non-local pair search */
+    if (simulationWork.havePpDomainDecomposition)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::NS);
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::NBSSearchNonLocal);
+        /* Note that with a GPU the launch overhead of the list transfer is not timed separately */
+        nbv->constructPairlist(InteractionLocality::NonLocal, top.excls, step, nrnb);
+
+        nbv->setupGpuShortRangeWork(fr->listedForcesGpu.get(), InteractionLocality::NonLocal);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::NBSSearchNonLocal);
+        wallcycle_stop(wcycle, WallCycleCounter::NS);
+        // TODO refactor this GPU halo exchange re-initialisation
+        // to location in do_md where GPU halo exchange is
+        // constructed at partitioning, after above stateGpu
+        // re-initialization has similarly been refactored
+        if (simulationWork.useGpuHaloExchange)
+        {
+            reinitGpuHaloExchange(*cr, stateGpu->getCoordinates(), stateGpu->getForces());
+        }
+    }
+
+    // With FEP we set up the reduction over threads for local+non-local simultaneously,
+    // so we need to do that here after the local and non-local pairlist construction.
+    if (fr->efep != FreeEnergyPerturbationType::No)
+    {
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::NonbondedFep);
+        nbv->setupFepThreadedForceBuffer(fr->natoms_force_constr);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::NonbondedFep);
+    }
+}
+
+void do_force(FILE*                         fplog,
+              const t_commrec*              cr,
+              const gmx_multisim_t*         ms,
+              const t_inputrec&             inputrec,
+              const MDModulesNotifiers&     mdModulesNotifiers,
+              Awh*                          awh,
+              gmx_enfrot*                   enforcedRotation,
+              ImdSession*                   imdSession,
+              pull_t*                       pull_work,
+              int64_t                       step,
+              t_nrnb*                       nrnb,
+              gmx_wallcycle*                wcycle,
+              const gmx_localtop_t*         top,
+              const matrix                  box,
+              ArrayRefWithPadding<RVec>     x,
+              ArrayRef<RVec>                v,
+              const history_t*              hist,
+              ForceBuffersView*             forceView,
+              tensor                        vir_force,
+              const t_mdatoms*              mdatoms,
+              gmx_enerdata_t*               enerd,
+              ArrayRef<const real>          lambda,
+              t_forcerec*                   fr,
+              const MdrunScheduleWorkload&  runScheduleWork,
+              VirtualSitesHandler*          vsite,
+              rvec                          muTotal,
+              double                        t,
+              gmx_edsam*                    ed,
+              CpuPpLongRangeNonbondeds*     longRangeNonbondeds,
+              const DDBalanceRegionHandler& ddBalanceRegionHandler)
+{
+    auto force = forceView->forceWithPadding();
+    GMX_ASSERT(force.unpaddedArrayRef().ssize() >= fr->natoms_force_constr,
+               "The size of the force buffer should be at least the number of atoms to compute "
+               "forces for");
+
+    nonbonded_verlet_t*  nbv = fr->nbv.get();
+    interaction_const_t* ic  = fr->ic.get();
+
+    StatePropagatorDataGpu* stateGpu = fr->stateGpu;
+
+    const SimulationWorkload& simulationWork = runScheduleWork.simulationWork;
+
+    const DomainLifetimeWorkload& domainWork = runScheduleWork.domainWork;
+
+    const StepWorkload& stepWork = runScheduleWork.stepWork;
+
+    const bool pmeSendCoordinatesFromGpu =
+            simulationWork.useGpuPmePpCommunication && !stepWork.doNeighborSearch;
+
+    const bool reinitGpuPmePpComms = simulationWork.useGpuPmePpCommunication && stepWork.doNeighborSearch;
+    if (stepWork.computePmeOnSeparateRank && stepWork.doNeighborSearch)
+    {
+        // We call the gmx_pme_send_coordinates early for reinit case
+        // in order for nvshmem collective calls in StatePropagatorDataGpu::Impl::reinit
+        // to be in sync with PME-PP
+        gmx_pme_send_coordinates(fr,
+                                 cr,
+                                 box,
+                                 x.unpaddedArrayRef(),
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Vdw)],
+                                 (stepWork.computeVirial || stepWork.computeEnergy),
+                                 step,
+                                 simulationWork.useGpuPmePpCommunication,
+                                 reinitGpuPmePpComms,
+                                 pmeSendCoordinatesFromGpu,
+                                 stepWork.useGpuPmeFReduction,
+                                 nullptr,
+                                 simulationWork.useMdGpuGraph,
+                                 wcycle);
+    }
+
+    if (stepWork.doNeighborSearch)
+    {
+        doPairSearch(cr, inputrec, mdModulesNotifiers, step, nrnb, wcycle, *top, box, x, v, *mdatoms, fr, runScheduleWork);
+
+        /* At a search step we need to start the first balancing region
+         * somewhere early inside the step after communication during domain
+         * decomposition (and not during the previous step as usual).
+         */
+        ddBalanceRegionHandler.openBeforeForceComputationCpu(DdAllowBalanceRegionReopen::yes);
+    }
+
+    auto* localXReadyOnDevice = (stepWork.haveGpuPmeOnThisRank || stepWork.useGpuXBufferOps
+                                 || simulationWork.useGpuUpdate || pmeSendCoordinatesFromGpu)
+                                        ? stateGpu->getCoordinatesReadyOnDeviceEvent(
+                                                  AtomLocality::Local, simulationWork, stepWork)
+                                        : nullptr;
+
+    if (stepWork.clearGpuFBufferEarly)
+    {
+        // GPU Force halo exchange will set a subset of local atoms with remote non-local data.
+        // First clear local portion of force array, so that untouched atoms are zero.
+        // The dependency for this is that forces from previous timestep have been consumed,
+        // which is satisfied when localXReadyOnDevice has been marked for GPU update case.
+        // For CPU update, the forces are consumed by the beginning of the step, so no extra sync needed.
+        GpuEventSynchronizer* dependency = simulationWork.useGpuUpdate ? localXReadyOnDevice : nullptr;
+        stateGpu->clearForcesOnGpu(AtomLocality::Local, dependency);
+    }
+
+    clear_mat(vir_force);
+
+    if (fr->pbcType != PbcType::No)
+    {
+        /* Compute shift vectors every step,
+         * because of pressure coupling or box deformation!
+         */
+        if (stepWork.haveDynamicBox && stepWork.stateChanged)
+        {
+            calc_shifts(box, fr->shift_vec);
+        }
+    }
+    nbnxn_atomdata_copy_shiftvec(stepWork.haveDynamicBox, fr->shift_vec, &nbv->nbat());
+
+
+    GMX_ASSERT(simulationWork.useGpuHaloExchange
+                       == ((cr->dd != nullptr) && (!cr->dd->gpuHaloExchange[0].empty())),
+               "The GPU halo exchange is active, but it has not been constructed.");
+
+    bool gmx_used_in_debug haveCopiedXFromGpu = false;
+    // Copy coordinate from the GPU if update is on the GPU and there
+    // are forces to be computed on the CPU, or for the computation of
+    // virial, or if host-side data will be transferred from this task
+    // to a remote task for halo exchange or PME-PP communication. At
+    // search steps the current coordinates are already on the host,
+    // hence copy is not needed.
+    if (simulationWork.useGpuUpdate && !stepWork.doNeighborSearch
+        && (runScheduleWork.domainWork.haveCpuLocalForceWork || stepWork.computeVirial
+            || simulationWork.useCpuPmePpCommunication || simulationWork.useCpuHaloExchange
+            || simulationWork.computeMuTot))
+    {
+        stateGpu->copyCoordinatesFromGpu(x.unpaddedArrayRef(), AtomLocality::Local);
+        haveCopiedXFromGpu = true;
+    }
+
+    // Coordinates on the device are needed if PME or BufferOps are offloaded.
+    // The local coordinates can be copied right away.
+    // NOTE: Consider moving this copy to right after they are updated and constrained,
+    //       if the later is not offloaded.
+    if (stepWork.haveGpuPmeOnThisRank || stepWork.useGpuXBufferOps || pmeSendCoordinatesFromGpu)
+    {
+        GMX_ASSERT(stateGpu != nullptr, "stateGpu should not be null");
+        const int expectedLocalXReadyOnDeviceConsumptionCount =
+                getExpectedLocalXReadyOnDeviceConsumptionCount(
+                        simulationWork, stepWork, domainWork, pmeSendCoordinatesFromGpu);
+
+        // We need to copy coordinates when:
+        // 1. Update is not offloaded
+        // 2. The buffers were reinitialized on search step
+        if (!simulationWork.useGpuUpdate || stepWork.doNeighborSearch)
+        {
+            stateGpu->copyCoordinatesToGpu(x.unpaddedArrayRef(),
+                                           AtomLocality::Local,
+                                           expectedLocalXReadyOnDeviceConsumptionCount);
+        }
+        else if (simulationWork.useGpuUpdate)
+        {
+            stateGpu->setXUpdatedOnDeviceEventExpectedConsumptionCount(
+                    expectedLocalXReadyOnDeviceConsumptionCount);
+        }
+    }
+
+    if (stepWork.computePmeOnSeparateRank && !stepWork.doNeighborSearch)
+    {
+        /* Send particle coordinates to the pme nodes */
+        if (!pmeSendCoordinatesFromGpu && simulationWork.useGpuUpdate)
+        {
+            GMX_ASSERT(haveCopiedXFromGpu,
+                       "a wait should only be triggered if copy has been scheduled");
+            stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+        }
+
+        gmx_pme_send_coordinates(fr,
+                                 cr,
+                                 box,
+                                 x.unpaddedArrayRef(),
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Vdw)],
+                                 (stepWork.computeVirial || stepWork.computeEnergy),
+                                 step,
+                                 simulationWork.useGpuPmePpCommunication,
+                                 reinitGpuPmePpComms,
+                                 pmeSendCoordinatesFromGpu,
+                                 stepWork.useGpuPmeFReduction,
+                                 pmeSendCoordinatesFromGpu ? localXReadyOnDevice : nullptr,
+                                 simulationWork.useMdGpuGraph,
+                                 wcycle);
+    }
+
+    if (simulationWork.useGpuFBufferOpsWhenAllowed && stepWork.doNeighborSearch)
+    {
+        // with MPI, direct GPU communication, and separate PME ranks we need
+        // gmx_pme_send_coordinates() to be called before we can set up force reduction
+        bool doSetupLocalGpuForceReduction = GMX_MPI && simulationWork.useGpuPmePpCommunication;
+        if (doSetupLocalGpuForceReduction)
+        {
+            setupLocalGpuForceReduction(runScheduleWork,
+                                        fr->nbv.get(),
+                                        stateGpu,
+                                        fr->gpuForceReduction[AtomLocality::Local].get(),
+                                        fr->pmePpCommGpu.get(),
+                                        fr->pmedata,
+                                        cr->dd);
+        }
+    }
+
+    if (stepWork.haveGpuPmeOnThisRank)
+    {
+        launchPmeGpuSpread(fr->pmedata,
+                           box,
+                           stepWork,
+                           localXReadyOnDevice,
+                           lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                           simulationWork.useMdGpuGraph,
+                           wcycle);
+    }
+
+
+    if (!stepWork.doNeighborSearch && !EI_TPI(inputrec.eI) && stepWork.computeNonbondedForces)
+    {
+        if (stepWork.useGpuXBufferOps)
+        {
+            GMX_ASSERT(stateGpu, "stateGpu should be valid when buffer ops are offloaded");
+            nbv->convertCoordinatesGpu(AtomLocality::Local, stateGpu->getCoordinates(), localXReadyOnDevice);
+        }
+        else
+        {
+            if (simulationWork.useGpuUpdate)
+            {
+                GMX_ASSERT(stateGpu, "need a valid stateGpu object");
+                GMX_ASSERT(haveCopiedXFromGpu,
+                           "a wait should only be triggered if copy has been scheduled");
+                stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+            }
+            nbv->convertCoordinates(AtomLocality::Local, x.unpaddedArrayRef());
+        }
+    }
+
+    if (simulationWork.useGpuNonbonded && (stepWork.computeNonbondedForces || domainWork.haveGpuBondedWork))
+    {
+        ddBalanceRegionHandler.openBeforeForceComputationGpu();
+
+        wallcycle_start(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        gpu_upload_shiftvec(nbv->gpuNbv(), &nbv->nbat());
+        if (!stepWork.useGpuXBufferOps)
+        {
+            gpu_copy_xq_to_gpu(nbv->gpuNbv(), &nbv->nbat(), AtomLocality::Local);
+        }
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+        // with X buffer ops offloaded to the GPU on all but the search steps
+
+        // bonded work not split into separate local and non-local, so with DD
+        // we can only launch the kernel after non-local coordinates have been received.
+        if (domainWork.haveGpuBondedWork && !simulationWork.havePpDomainDecomposition)
+        {
+            fr->listedForcesGpu->setPbcAndlaunchKernel(fr->pbcType, box, fr->bMolPBC, stepWork);
+        }
+
+        /* launch local nonbonded work on GPU */
+        wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        do_nb_verlet(fr, ic, enerd, stepWork, InteractionLocality::Local, enbvClearFNo, step, nrnb, wcycle);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+    }
+
+    if (stepWork.haveGpuPmeOnThisRank)
+    {
+        // In PME GPU and mixed mode we launch FFT / gather after the
+        // X copy/transform to allow overlap as well as after the GPU NB
+        // launch to avoid FFT launch overhead hijacking the CPU and delaying
+        // the nonbonded kernel.
+        launchPmeGpuFftAndGather(fr->pmedata,
+                                 lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                                 wcycle,
+                                 stepWork);
+    }
+
+    /* Communicate coordinates and sum dipole if necessary */
+    if (simulationWork.havePpDomainDecomposition)
+    {
+        GpuEventSynchronizer* gpuCoordinateHaloLaunched = nullptr;
+        if (!stepWork.doNeighborSearch)
+        {
+            if (stepWork.useGpuXHalo)
+            {
+                // The following must be called after local setCoordinates (which records an event
+                // when the coordinate data has been copied to the device).
+                gpuCoordinateHaloLaunched = communicateGpuHaloCoordinates(*cr, box, localXReadyOnDevice);
+
+                if (domainWork.haveCpuNonLocalForceWork)
+                {
+                    // non-local part of coordinate buffer must be copied back to host for CPU work
+                    stateGpu->copyCoordinatesFromGpu(
+                            x.unpaddedArrayRef(), AtomLocality::NonLocal, gpuCoordinateHaloLaunched);
+                }
+            }
+            else
+            {
+                if (simulationWork.useGpuUpdate)
+                {
+                    GMX_ASSERT(haveCopiedXFromGpu,
+                               "a wait should only be triggered if copy has been scheduled");
+                    const bool haveAlreadyWaited =
+                            (stepWork.computePmeOnSeparateRank && !pmeSendCoordinatesFromGpu);
+                    if (!haveAlreadyWaited)
+                    {
+                        stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+                    }
+                }
+
+                if (cr->dd->haloExchange)
+                {
+                    wallcycle_start(wcycle, WallCycleCounter::MoveX);
+                    cr->dd->haloExchange->moveX(box, x.unpaddedArrayRef());
+                    wallcycle_stop(wcycle, WallCycleCounter::MoveX);
+                }
+                else
+                {
+                    dd_move_x(cr->dd, box, x.unpaddedArrayRef(), wcycle);
+                }
+            }
+        }
+
+        if (stepWork.useGpuXBufferOps)
+        {
+            if (!stepWork.useGpuXHalo)
+            {
+                stateGpu->copyCoordinatesToGpu(x.unpaddedArrayRef(), AtomLocality::NonLocal);
+            }
+            GpuEventSynchronizer* xReadyOnDeviceEvent = stateGpu->getCoordinatesReadyOnDeviceEvent(
+                    AtomLocality::NonLocal, simulationWork, stepWork, gpuCoordinateHaloLaunched);
+            if (stepWork.useGpuXHalo && domainWork.haveCpuNonLocalForceWork)
+            {
+                /* We already enqueued an event for Gpu Halo exchange completion into the
+                 * NonLocal stream when D2H copying the coordinates. */
+                xReadyOnDeviceEvent = nullptr;
+            }
+            nbv->convertCoordinatesGpu(
+                    AtomLocality::NonLocal, stateGpu->getCoordinates(), xReadyOnDeviceEvent);
+        }
+        else if (!stepWork.doNeighborSearch)
+        {
+            nbv->convertCoordinates(AtomLocality::NonLocal, x.unpaddedArrayRef());
+        }
+
+        if (simulationWork.useGpuNonbonded)
+        {
+
+            if (!stepWork.useGpuXBufferOps)
+            {
+                wallcycle_start(wcycle, WallCycleCounter::LaunchGpuPp);
+                wallcycle_sub_start(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+                gpu_copy_xq_to_gpu(nbv->gpuNbv(), &nbv->nbat(), AtomLocality::NonLocal);
+                wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+                wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+            }
+
+            if (domainWork.haveGpuBondedWork)
+            {
+                fr->listedForcesGpu->setPbcAndlaunchKernel(fr->pbcType, box, fr->bMolPBC, stepWork);
+            }
+
+            /* launch non-local nonbonded tasks on GPU */
+            wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+            wallcycle_sub_start(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+            do_nb_verlet(fr, ic, enerd, stepWork, InteractionLocality::NonLocal, enbvClearFNo, step, nrnb, wcycle);
+            wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+            wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+        }
+    }
+
+    if (simulationWork.useGpuNonbonded && stepWork.computeNonbondedForces)
+    {
+        /* launch D2H copy-back F */
+        wallcycle_start_nocount(wcycle, WallCycleCounter::LaunchGpuPp);
+        wallcycle_sub_start_nocount(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+
+        if (simulationWork.havePpDomainDecomposition)
+        {
+            gpu_launch_cpyback(nbv->gpuNbv(), &nbv->nbat(), stepWork, AtomLocality::NonLocal);
+        }
+        gpu_launch_cpyback(nbv->gpuNbv(), &nbv->nbat(), stepWork, AtomLocality::Local);
+        wallcycle_sub_stop(wcycle, WallCycleSubCounter::LaunchGpuNonBonded);
+
+        if (domainWork.haveGpuBondedWork && stepWork.computeEnergy)
+        {
+            fr->listedForcesGpu->launchEnergyTransfer();
+        }
+        wallcycle_stop(wcycle, WallCycleCounter::LaunchGpuPp);
+    }
+
+    ArrayRef<const RVec> xWholeMolecules;
+    if (fr->wholeMoleculeTransform)
+    {
+        xWholeMolecules = fr->wholeMoleculeTransform->wholeMoleculeCoordinates(x.unpaddedArrayRef(), box);
+    }
+
+    // The CPU force buffer force clearing needs to happen after the previous step
+    // force reduction has already completed. To minimize the cross-step dependencies
+    // we wait on the coordinates to be updated on the device which is sufficient but
+    // a later event than what we strictly need to synchronize with.
+    if (simulationWork.useGpuUpdate && domainWork.haveCpuLocalForceWork)
+    {
+        const bool coordinatesAlreadyUpdatedOnDevice =
+                stepWork.doNeighborSearch || simulationWork.useCpuHaloExchange
+                || (stepWork.computePmeOnSeparateRank && !pmeSendCoordinatesFromGpu);
+        if (!coordinatesAlreadyUpdatedOnDevice)
+        {
+            stateGpu->waitCoordinatesUpdatedOnDevice();
+        }
+    }
+
+    /* Start the force cycle counter.
+     * Note that a different counter is used for dynamic load balancing.
+     */
+    wallcycle_start(wcycle, WallCycleCounter::Force);
+
+    /* Set up and clear force outputs:
+     * forceOutMtsLevel0:  everything except what is in the other two outputs
+     * forceOutMtsLevel1:  PME-mesh and listed-forces group 1
+     * forceOutNonbonded: non-bonded forces
+     * Without multiple time stepping all point to the same object.
+     * With multiple time-stepping the use is different for MTS fast (level0 only) and slow steps.
+     */
+    ForceOutputs forceOutMtsLevel0 = setupForceOutputs(
+            &fr->forceHelperBuffers[0], force, domainWork, stepWork, simulationWork.havePpDomainDecomposition, wcycle);
+
+    // Force output for MTS combined forces, only set at level1 MTS steps
+    std::optional<ForceOutputs> forceOutMts =
+            (simulationWork.useMts && stepWork.computeSlowForces)
+                    ? std::optional(setupForceOutputs(&fr->forceHelperBuffers[1],
+                                                      forceView->forceMtsCombinedWithPadding(),
+                                                      domainWork,
+                                                      stepWork,
+                                                      simulationWork.havePpDomainDecomposition,
+                                                      wcycle))
+                    : std::nullopt;
+
+    ForceOutputs* forceOutMtsLevel1 =
+            simulationWork.useMts ? (stepWork.computeSlowForces ? &forceOutMts.value() : nullptr)
+                                  : &forceOutMtsLevel0;
+
+    const bool nonbondedAtMtsLevel1 = runScheduleWork.simulationWork.computeNonbondedAtMtsLevel1;
+
+    ForceOutputs* forceOutNonbonded = nonbondedAtMtsLevel1 ? forceOutMtsLevel1 : &forceOutMtsLevel0;
+
+    if (inputrec.bPull && pull_have_constraint(*pull_work))
+    {
+        clear_pull_forces(pull_work);
+    }
+    wallcycle_stop(wcycle, WallCycleCounter::Force);
+
+    // For the rest of the CPU tasks that depend on GPU-update produced coordinates,
+    // this wait ensures that the D2H transfer is complete.
+    if (simulationWork.useGpuUpdate && !stepWork.doNeighborSearch)
+    {
+        const bool needCoordsOnHost = (runScheduleWork.domainWork.haveCpuLocalForceWork
+                                       || stepWork.computeVirial || simulationWork.computeMuTot);
+        const bool haveAlreadyWaited =
+                simulationWork.useCpuHaloExchange
+                || (stepWork.computePmeOnSeparateRank && !pmeSendCoordinatesFromGpu);
+        if (needCoordsOnHost && !haveAlreadyWaited)
+        {
+            GMX_ASSERT(haveCopiedXFromGpu,
+                       "a wait should only be triggered if copy has been scheduled");
+            stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+        }
+    }
+
+    DipoleData dipoleData;
+
+    if (simulationWork.computeMuTot)
+    {
+        const int start = 0;
+
+        /* Calculate total (local) dipole moment in a temporary common array.
+         * This makes it possible to sum them over nodes faster.
+         */
+        ArrayRef<const RVec> xRef = (xWholeMolecules.empty() ? x.unpaddedArrayRef() : xWholeMolecules);
+        calc_mu(start,
+                mdatoms->homenr,
+                xRef,
+                mdatoms->chargeA,
+                mdatoms->chargeB,
+                mdatoms->nChargePerturbed != 0,
+                dipoleData.muStaging[0],
+                dipoleData.muStaging[1]);
+
+        reduceAndUpdateMuTot(
+                &dipoleData, cr, (fr->efep != FreeEnergyPerturbationType::No), lambda, muTotal, ddBalanceRegionHandler);
+    }
+
+    /* Reset energies */
+    reset_enerdata(enerd);
+
+    if (haveDDAtomOrdering(*cr) && simulationWork.haveSeparatePmeRank)
+    {
+        wallcycle_start(wcycle, WallCycleCounter::PpDuringPme);
+        dd_force_flop_start(cr->dd, nrnb);
+    }
+
+    if (inputrec.bRot)
+    {
+        wallcycle_start(wcycle, WallCycleCounter::Rot);
+        do_rotation(cr, enforcedRotation, box, x.unpaddedConstArrayRef(), t, step, stepWork.doNeighborSearch);
+        wallcycle_stop(wcycle, WallCycleCounter::Rot);
+    }
+
+    /* We calculate the non-bonded forces, when done on the CPU, here.
+     * We do this before calling do_force_lowlevel, because in that
+     * function, the listed forces are calculated before PME, which
+     * does communication.  With this order, non-bonded and listed
+     * force calculation imbalance can be balanced out by the domain
+     * decomposition load balancing.
+     */
+
+    const bool useOrEmulateGpuNb = simulationWork.useGpuNonbonded || fr->nbv->emulateGpu();
+
+    if (!useOrEmulateGpuNb)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+        do_nb_verlet(fr, ic, enerd, stepWork, InteractionLocality::Local, enbvClearFYes, step, nrnb, wcycle);
+        wallcycle_stop(wcycle, WallCycleCounter::Force);
+    }
+
+    if (stepWork.useGpuXHalo && domainWork.haveCpuNonLocalForceWork)
+    {
+        /* Wait for non-local coordinate data to be copied from device */
+        stateGpu->waitCoordinatesReadyOnHost(AtomLocality::NonLocal);
+    }
+
+    wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+    if (fr->efep != FreeEnergyPerturbationType::No && stepWork.computeNonbondedForces)
+    {
+        /* Calculate the local and non-local free energy interactions here.
+         * Happens here on the CPU both with and without GPU.
+         */
+        nbv->dispatchFreeEnergyKernels(x,
+                                       &forceOutNonbonded->forceWithShiftForces(),
+                                       fr->use_simd_kernels,
+                                       fr->ntype,
+                                       *fr->ic,
+                                       fr->shift_vec,
+                                       fr->nbfp,
+                                       fr->ljpme_c6grid,
+                                       mdatoms->chargeA,
+                                       mdatoms->chargeB,
+                                       mdatoms->typeA,
+                                       mdatoms->typeB,
+                                       lambda,
+                                       enerd,
+                                       stepWork,
+                                       nrnb);
+    }
+
+    if (stepWork.computeNonbondedForces && !useOrEmulateGpuNb)
+    {
+        if (simulationWork.havePpDomainDecomposition)
+        {
+            do_nb_verlet(fr, ic, enerd, stepWork, InteractionLocality::NonLocal, enbvClearFNo, step, nrnb, wcycle);
+        }
+
+        if (stepWork.computeForces)
+        {
+            /* Add all the non-bonded force to the normal force array.
+             * This can be split into a local and a non-local part when overlapping
+             * communication with calculation with domain decomposition.
+             */
+            wallcycle_stop(wcycle, WallCycleCounter::Force);
+            nbv->atomdata_add_nbat_f_to_f(AtomLocality::All,
+                                          forceOutNonbonded->forceWithShiftForces().force());
+            wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+        }
+
+        /* If there are multiple fshift output buffers we need to reduce them */
+        if (stepWork.computeVirial)
+        {
+            /* This is not in a subcounter because it takes a
+               negligible and constant-sized amount of time */
+            nbnxn_atomdata_add_nbat_fshift_to_fshift(
+                    nbv->nbat(), forceOutNonbonded->forceWithShiftForces().shiftForces());
+        }
+    }
+
+    // Compute wall interactions, when present.
+    // Note: should be moved to special forces.
+    if (inputrec.nwall && stepWork.computeNonbondedForces)
+    {
+        /* foreign lambda component for walls */
+        real dvdl_walls = do_walls(inputrec,
+                                   *fr,
+                                   box,
+                                   mdatoms->typeA,
+                                   mdatoms->typeB,
+                                   mdatoms->cENER,
+                                   mdatoms->homenr,
+                                   mdatoms->nPerturbed,
+                                   x.unpaddedConstArrayRef(),
+                                   &forceOutMtsLevel0.forceWithVirial(),
+                                   lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Vdw)],
+                                   enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::LJSR],
+                                   nrnb);
+        enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Vdw] += dvdl_walls;
+    }
+
+    if (stepWork.computeListedForces)
+    {
+        /* Check whether we need to take into account PBC in listed interactions */
+        bool needMolPbc = false;
+        for (const auto& listedForces : fr->listedForces)
+        {
+            if (listedForces.haveCpuListedForces(*fr->fcdata))
+            {
+                needMolPbc = fr->bMolPBC;
+            }
+        }
+
+        t_pbc pbc;
+
+        if (needMolPbc)
+        {
+            /* Since all atoms are in the rectangular or triclinic unit-cell,
+             * only single box vector shifts (2 in x) are required.
+             */
+            set_pbc_dd(&pbc, fr->pbcType, haveDDAtomOrdering(*cr) ? &cr->dd->numCells : nullptr, TRUE, box);
+        }
+
+        for (int mtsIndex = 0; mtsIndex < (simulationWork.useMts && stepWork.computeSlowForces ? 2 : 1);
+             mtsIndex++)
+        {
+            ListedForces& listedForces = fr->listedForces[mtsIndex];
+            ForceOutputs& forceOut     = (mtsIndex == 0 ? forceOutMtsLevel0 : *forceOutMtsLevel1);
+            listedForces.calculate(wcycle,
+                                   box,
+                                   cr,
+                                   ms,
+                                   x,
+                                   xWholeMolecules,
+                                   fr->fcdata.get(),
+                                   hist,
+                                   &forceOut,
+                                   fr,
+                                   &pbc,
+                                   enerd,
+                                   nrnb,
+                                   lambda,
+                                   mdatoms->chargeA,
+                                   mdatoms->chargeB,
+                                   makeConstArrayRef(mdatoms->bPerturbed),
+                                   mdatoms->cENER,
+                                   mdatoms->nPerturbed,
+                                   haveDDAtomOrdering(*cr) ? cr->dd->globalAtomIndices.data() : nullptr,
+                                   stepWork);
+        }
+    }
+
+    if (stepWork.computeSlowForces)
+    {
+        longRangeNonbondeds->calculate(fr->pmedata,
+                                       cr,
+                                       x.unpaddedConstArrayRef(),
+                                       &forceOutMtsLevel1->forceWithVirial(),
+                                       enerd,
+                                       box,
+                                       lambda,
+                                       dipoleData.muStateAB,
+                                       stepWork,
+                                       ddBalanceRegionHandler);
+    }
+
+    wallcycle_stop(wcycle, WallCycleCounter::Force);
+
+    // VdW dispersion correction, only computed on main rank to avoid double counting
+    if ((stepWork.computeEnergy || stepWork.computeVirial) && fr->dispersionCorrection && MAIN(cr))
+    {
+        // Calculate long range corrections to pressure and energy
+        const DispersionCorrection::Correction correction = fr->dispersionCorrection->calculate(
+                box, lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Vdw)]);
+
+        if (stepWork.computeEnergy)
+        {
+            enerd->term[F_DISPCORR] = correction.energy;
+            enerd->term[F_DVDL_VDW] += correction.dvdl;
+            enerd->dvdl_lin[FreeEnergyPerturbationCouplingType::Vdw] += correction.dvdl;
+        }
+        if (stepWork.computeVirial)
+        {
+            correction.correctVirial(vir_force);
+            enerd->term[F_PDISPCORR] = correction.pressure;
+        }
+    }
+
+    const bool needToReceivePmeResultsFromSeparateRank = (PAR(cr) && stepWork.computePmeOnSeparateRank);
+    const bool needToReceivePmeResults =
+            (stepWork.haveGpuPmeOnThisRank || needToReceivePmeResultsFromSeparateRank);
+
+    /* When running free energy perturbations steered by AWH and doing PME calculations on the
+     * GPU we must wait for the PME calculation (dhdl) results to finish before sampling the
+     * FEP dimension with AWH. */
+    const bool needEarlyPmeResults = (awh != nullptr && awh->hasFepLambdaDimension() && needToReceivePmeResults
+                                      && stepWork.computeEnergy && stepWork.computeSlowForces);
+    if (needEarlyPmeResults)
+    {
+        if (stepWork.haveGpuPmeOnThisRank)
+        {
+            pmeGpuWaitAndReduce(fr->pmedata,
+                                stepWork,
+                                wcycle,
+                                &forceOutMtsLevel1->forceWithVirial(),
+                                enerd,
+                                lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)]);
+        }
+        else if (needToReceivePmeResultsFromSeparateRank)
+        {
+            /* In case of node-splitting, the PP nodes receive the long-range
+             * forces, virial and energy from the PME nodes here.
+             */
+            pme_receive_force_ener(fr,
+                                   cr,
+                                   &forceOutMtsLevel1->forceWithVirial(),
+                                   enerd,
+                                   simulationWork.useGpuPmePpCommunication,
+                                   stepWork.useGpuPmeFReduction,
+                                   wcycle);
+        }
+    }
+
+    if (domainWork.haveSpecialForces)
+    {
+        // Communication often happens for special forces, so we should close the balancing region here
+        ddBalanceRegionHandler.closeAfterForceComputationCpu();
+
+        computeSpecialForces(fplog,
+                             cr,
+                             inputrec,
+                             awh,
+                             enforcedRotation,
+                             imdSession,
+                             pull_work,
+                             step,
+                             t,
+                             wcycle,
+                             fr->forceProviders,
+                             box,
+                             x.unpaddedArrayRef(),
+                             mdatoms,
+                             lambda,
+                             stepWork,
+                             &forceOutMtsLevel0.forceWithVirial(),
+                             forceOutMtsLevel1 ? &forceOutMtsLevel1->forceWithVirial() : nullptr,
+                             enerd,
+                             ed,
+                             stepWork.doNeighborSearch);
+    }
+
+    if (simulationWork.havePpDomainDecomposition && stepWork.computeForces && stepWork.useGpuFHalo
+        && domainWork.haveCpuLocalForceWork)
+    {
+        stateGpu->copyForcesToGpu(forceOutMtsLevel0.forceWithShiftForces().force(), AtomLocality::Local);
+    }
+
+    GMX_ASSERT(!(nonbondedAtMtsLevel1 && stepWork.useGpuFBufferOps),
+               "The schedule below does not allow for nonbonded MTS with GPU buffer ops");
+    GMX_ASSERT(!(nonbondedAtMtsLevel1 && stepWork.useGpuFHalo),
+               "The schedule below does not allow for nonbonded MTS with GPU halo exchange");
+    // Will store the amount of cycles spent waiting for the GPU that
+    // will be later used in the DLB accounting.
+    float cycles_wait_gpu = 0;
+    if (useOrEmulateGpuNb && stepWork.computeNonbondedForces)
+    {
+        auto& forceWithShiftForces = forceOutNonbonded->forceWithShiftForces();
+
+        /* wait for non-local forces (or calculate in emulation mode) */
+        if (simulationWork.havePpDomainDecomposition)
+        {
+            if (simulationWork.useGpuNonbonded)
+            {
+                cycles_wait_gpu += gpu_wait_finish_task(
+                        nbv->gpuNbv(),
+                        stepWork,
+                        AtomLocality::NonLocal,
+                        enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::LJSR].data(),
+                        enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::CoulombSR].data(),
+                        forceWithShiftForces.shiftForces(),
+                        wcycle);
+            }
+            else
+            {
+                wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+                do_nb_verlet(
+                        fr, ic, enerd, stepWork, InteractionLocality::NonLocal, enbvClearFYes, step, nrnb, wcycle);
+                wallcycle_stop(wcycle, WallCycleCounter::Force);
+            }
+
+            if (stepWork.useGpuFBufferOps)
+            {
+                if (domainWork.haveCpuNonLocalForceWork)
+                {
+                    stateGpu->copyForcesToGpu(forceOutMtsLevel0.forceWithShiftForces().force(),
+                                              AtomLocality::NonLocal);
+                }
+
+
+                fr->gpuForceReduction[AtomLocality::NonLocal]->execute();
+
+                if (!stepWork.useGpuFHalo)
+                {
+                    /* We don't explicitly wait for the forces to be reduced on device,
+                     * but wait for them to finish copying to CPU instead.
+                     * So, we manually consume the event, see Issue #3988. */
+                    stateGpu->consumeForcesReducedOnDeviceEvent(AtomLocality::NonLocal);
+                    // copy from GPU input for dd_move_f()
+                    stateGpu->copyForcesFromGpu(forceOutMtsLevel0.forceWithShiftForces().force(),
+                                                AtomLocality::NonLocal);
+                }
+            }
+            else
+            {
+                nbv->atomdata_add_nbat_f_to_f(AtomLocality::NonLocal, forceWithShiftForces.force());
+            }
+
+            if (fr->nbv->emulateGpu() && stepWork.computeVirial)
+            {
+                nbnxn_atomdata_add_nbat_fshift_to_fshift(nbv->nbat(), forceWithShiftForces.shiftForces());
+            }
+        }
+    }
+
+    /* Combining the forces for multiple time stepping before the halo exchange, when possible,
+     * avoids an extra halo exchange (when DD is used) and post-processing step.
+     */
+    if (stepWork.combineMtsForcesBeforeHaloExchange)
+    {
+        wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+        combineMtsForces(getLocalAtomCount(cr->dd, *mdatoms, simulationWork.havePpDomainDecomposition),
+                         force.unpaddedArrayRef(),
+                         forceView->forceMtsCombined(),
+                         inputrec.mtsLevels[1].stepFactor);
+        wallcycle_stop(wcycle, WallCycleCounter::Force);
+    }
+
+    // With both nonbonded and PME offloaded a GPU on the same rank, we use
+    // an alternating wait/reduction scheme.
+    // When running free energy perturbations steered by AWH and calculating PME on GPU,
+    // i.e. if needEarlyPmeResults == true, the PME results have already been reduced above.
+    const bool alternateGpuWait = (!c_disableAlternatingWait && stepWork.haveGpuPmeOnThisRank
+                                   && simulationWork.useGpuNonbonded && !simulationWork.havePpDomainDecomposition
+                                   && !stepWork.useGpuFBufferOps && !needEarlyPmeResults);
+
+
+    const int expectedLocalFReadyOnDeviceConsumptionCount = getExpectedLocalFReadyOnDeviceConsumptionCount(
+            simulationWork, domainWork, stepWork, useOrEmulateGpuNb, alternateGpuWait);
+    // If expectedLocalFReadyOnDeviceConsumptionCount == 0, stateGpu can be uninitialized
+    if (expectedLocalFReadyOnDeviceConsumptionCount > 0)
+    {
+        stateGpu->setFReadyOnDeviceEventExpectedConsumptionCount(
+                AtomLocality::Local, expectedLocalFReadyOnDeviceConsumptionCount);
+    }
+
+    if (simulationWork.havePpDomainDecomposition)
+    {
+        /* We are done with the CPU compute.
+         * We will now communicate the non-local forces.
+         * If we use a GPU this will overlap with GPU work, so in that case
+         * we do not close the DD force balancing region here.
+         * With special forces we closed this region already before computing the special forces.
+         */
+        ddBalanceRegionHandler.closeAfterForceComputationCpu();
+
+        if (stepWork.computeForces)
+        {
+
+            if (stepWork.useGpuFHalo)
+            {
+                // If there exist CPU forces, data from halo exchange should accumulate into these
+                bool accumulateForces = domainWork.haveCpuLocalForceWork;
+                FixedCapacityVector<GpuEventSynchronizer*, 2> gpuForceHaloDependencies;
+                // completion of both H2D copy and clearing is signaled by fReadyOnDevice
+                if (domainWork.haveCpuLocalForceWork || stepWork.clearGpuFBufferEarly)
+                {
+                    gpuForceHaloDependencies.push_back(stateGpu->fReadyOnDevice(AtomLocality::Local));
+                }
+                gpuForceHaloDependencies.push_back(stateGpu->fReducedOnDevice(AtomLocality::NonLocal));
+
+                communicateGpuHaloForces(*cr, accumulateForces, &gpuForceHaloDependencies);
+            }
+            else
+            {
+                if (stepWork.useGpuFBufferOps)
+                {
+                    stateGpu->waitForcesReadyOnHost(AtomLocality::NonLocal);
+                }
+
+                // Without MTS or with MTS at slow steps with uncombined forces we need to
+                // communicate the fast forces
+                if (!simulationWork.useMts || !stepWork.combineMtsForcesBeforeHaloExchange)
+                {
+                    dd_move_f(cr->dd, &forceOutMtsLevel0.forceWithShiftForces(), wcycle);
+                }
+                // With MTS we need to communicate the slow or combined (in forceOutMtsLevel1) forces
+                if (simulationWork.useMts && stepWork.computeSlowForces)
+                {
+                    dd_move_f(cr->dd, &forceOutMtsLevel1->forceWithShiftForces(), wcycle);
+                }
+            }
+        }
+    }
+
+    if (alternateGpuWait)
+    {
+        alternatePmeNbGpuWaitReduce(fr->nbv.get(),
+                                    fr->pmedata,
+                                    forceOutNonbonded,
+                                    forceOutMtsLevel1,
+                                    enerd,
+                                    lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)],
+                                    stepWork,
+                                    wcycle);
+    }
+
+    if (!alternateGpuWait && stepWork.haveGpuPmeOnThisRank && !needEarlyPmeResults)
+    {
+        pmeGpuWaitAndReduce(fr->pmedata,
+                            stepWork,
+                            wcycle,
+                            &forceOutMtsLevel1->forceWithVirial(),
+                            enerd,
+                            lambda[static_cast<int>(FreeEnergyPerturbationCouplingType::Coul)]);
+    }
+
+    /* Wait for local GPU NB outputs on the non-alternating wait path */
+    if (!alternateGpuWait && stepWork.computeNonbondedForces && simulationWork.useGpuNonbonded)
+    {
+        /* Measured overhead on CUDA and OpenCL with(out) GPU sharing
+         * is between 0.5 and 1.5 Mcycles. So 2 MCycles is an overestimate,
+         * but even with a step of 0.1 ms the difference is less than 1%
+         * of the step time.
+         */
+        const float gpuWaitApiOverheadMargin = 2e6F; /* cycles */
+        const float waitCycles               = gpu_wait_finish_task(
+                nbv->gpuNbv(),
+                stepWork,
+                AtomLocality::Local,
+                enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::LJSR].data(),
+                enerd->grpp.energyGroupPairTerms[NonBondedEnergyTerms::CoulombSR].data(),
+                forceOutNonbonded->forceWithShiftForces().shiftForces(),
+                wcycle);
+
+        if (ddBalanceRegionHandler.useBalancingRegion())
+        {
+            DdBalanceRegionWaitedForGpu waitedForGpu = DdBalanceRegionWaitedForGpu::yes;
+            if (stepWork.computeForces && waitCycles <= gpuWaitApiOverheadMargin)
+            {
+                /* We measured few cycles, it could be that the kernel
+                 * and transfer finished earlier and there was no actual
+                 * wait time, only API call overhead.
+                 * Then the actual time could be anywhere between 0 and
+                 * cycles_wait_est. We will use half of cycles_wait_est.
+                 */
+                waitedForGpu = DdBalanceRegionWaitedForGpu::no;
+            }
+            ddBalanceRegionHandler.closeAfterForceComputationGpu(cycles_wait_gpu, waitedForGpu);
+        }
+    }
+
+    if (fr->nbv->emulateGpu())
+    {
+        // NOTE: emulation kernel is not included in the balancing region,
+        // but emulation mode does not target performance anyway
+        wallcycle_start_nocount(wcycle, WallCycleCounter::Force);
+        do_nb_verlet(fr,
+                     ic,
+                     enerd,
+                     stepWork,
+                     InteractionLocality::Local,
+                     haveDDAtomOrdering(*cr) ? enbvClearFNo : enbvClearFYes,
+                     step,
+                     nrnb,
+                     wcycle);
+        wallcycle_stop(wcycle, WallCycleCounter::Force);
+    }
+
+    // If on GPU PME-PP comms path, receive forces from PME before GPU buffer ops
+    // TODO refactor this and unify with below default-path call to the same function
+    // When running free energy perturbations steered by AWH and calculating PME on GPU,
+    // i.e. if needEarlyPmeResults == true, the PME results have already been reduced above.
+    if (needToReceivePmeResultsFromSeparateRank && simulationWork.useGpuPmePpCommunication && !needEarlyPmeResults)
+    {
+        /* In case of node-splitting, the PP nodes receive the long-range
+         * forces, virial and energy from the PME nodes here.
+         */
+        pme_receive_force_ener(fr,
+                               cr,
+                               &forceOutMtsLevel1->forceWithVirial(),
+                               enerd,
+                               simulationWork.useGpuPmePpCommunication,
+                               stepWork.useGpuPmeFReduction,
+                               wcycle);
+    }
+
+
+    /* Do the nonbonded GPU (or emulation) force buffer reduction
+     * on the non-alternating path. */
+    GMX_ASSERT(!(nonbondedAtMtsLevel1 && stepWork.useGpuFBufferOps),
+               "The schedule below does not allow for nonbonded MTS with GPU buffer ops");
+    if (useOrEmulateGpuNb && !alternateGpuWait)
+    {
+        if (stepWork.useGpuFBufferOps)
+        {
+            ArrayRef<RVec> forceWithShift = forceOutNonbonded->forceWithShiftForces().force();
+
+            // TODO: move these steps as early as possible:
+            // - CPU f H2D should be as soon as all CPU-side forces are done
+            // - wait for force reduction does not need to block host (at least not here, it's sufficient to wait
+            //   before the next CPU task that consumes the forces: vsite spread or update)
+            // - copy is not performed if GPU force halo exchange is active, because it would overwrite the result
+            //   of the halo exchange. In that case the copy is instead performed above, before the exchange.
+            //   These should be unified.
+            if (domainWork.haveLocalForceContribInCpuBuffer && !stepWork.useGpuFHalo)
+            {
+                stateGpu->copyForcesToGpu(forceWithShift, AtomLocality::Local);
+            }
+
+            if (stepWork.computeNonbondedForces)
+            {
+                fr->gpuForceReduction[AtomLocality::Local]->execute();
+            }
+
+            // Copy forces to host if they are needed for update or if virtual sites are enabled.
+            // If there are vsites, we need to copy forces every step to spread vsite forces on host.
+            // TODO: When the output flags will be included in step workload, this copy can be combined with the
+            //       copy call done in sim_utils(...) for the output.
+            // NOTE: If there are virtual sites, the forces are modified on host after this D2H copy. Hence,
+            //       they should not be copied in do_md(...) for the output.
+            if (!simulationWork.useGpuUpdate
+                || (simulationWork.useGpuUpdate && haveDDAtomOrdering(*cr) && simulationWork.useCpuPmePpCommunication)
+                || vsite)
+            {
+                if (stepWork.computeNonbondedForces)
+                {
+                    /* We have previously issued force reduction on the GPU, but we will
+                     * not use this event, instead relying on the stream being in-order.
+                     * Issue #3988. */
+                    stateGpu->consumeForcesReducedOnDeviceEvent(AtomLocality::Local);
+                }
+                stateGpu->copyForcesFromGpu(forceWithShift, AtomLocality::Local);
+                stateGpu->waitForcesReadyOnHost(AtomLocality::Local);
+            }
+        }
+        else if (stepWork.computeNonbondedForces)
+        {
+            ArrayRef<RVec> forceWithShift = forceOutNonbonded->forceWithShiftForces().force();
+            nbv->atomdata_add_nbat_f_to_f(AtomLocality::Local, forceWithShift);
+        }
+    }
+
+    if (expectedLocalFReadyOnDeviceConsumptionCount > 0)
+    {
+        /* The same fReadyOnDevice device synchronizer is later used to track buffer clearing,
+         * so we reset the expected consumption value back to the default (1). */
+        stateGpu->setFReadyOnDeviceEventExpectedConsumptionCount(AtomLocality::Local, 1);
+    }
+
+    launchGpuEndOfStepTasks(
+            nbv, fr->listedForcesGpu.get(), fr->pmedata, enerd, runScheduleWork, step, wcycle);
+
+    if (haveDDAtomOrdering(*cr))
+    {
+        dd_force_flop_stop(cr->dd, nrnb);
+    }
+
+    const bool haveCombinedMtsForces = (stepWork.computeForces && simulationWork.useMts && stepWork.computeSlowForces
+                                        && stepWork.combineMtsForcesBeforeHaloExchange);
+    if (stepWork.computeForces)
+    {
+        postProcessForceWithShiftForces(
+                nrnb, wcycle, box, x.unpaddedArrayRef(), &forceOutMtsLevel0, vir_force, *mdatoms, *fr, vsite, stepWork);
+
+        if (simulationWork.useMts && stepWork.computeSlowForces && !haveCombinedMtsForces)
+        {
+            postProcessForceWithShiftForces(
+                    nrnb, wcycle, box, x.unpaddedArrayRef(), forceOutMtsLevel1, vir_force, *mdatoms, *fr, vsite, stepWork);
+        }
+    }
+
+    // TODO refactor this and unify with above GPU PME-PP / GPU update path call to the same function
+    // When running free energy perturbations steered by AWH and calculating PME on GPU,
+    // i.e. if needEarlyPmeResults == true, the PME results have already been reduced above.
+    if (needToReceivePmeResultsFromSeparateRank && simulationWork.useCpuPmePpCommunication && !needEarlyPmeResults)
+    {
+        /* In case of node-splitting, the PP nodes receive the long-range
+         * forces, virial and energy from the PME nodes here.
+         */
+        pme_receive_force_ener(fr,
+                               cr,
+                               &forceOutMtsLevel1->forceWithVirial(),
+                               enerd,
+                               simulationWork.useGpuPmePpCommunication,
+                               false,
+                               wcycle);
+    }
+
+    if (stepWork.computeForces)
+    {
+        /* If we don't use MTS or if we already combined the MTS forces before, we only
+         * need to post-process one ForceOutputs object here, called forceOutCombined,
+         * otherwise we have to post-process two outputs and then combine them.
+         */
+        ForceOutputs& forceOutCombined = (haveCombinedMtsForces ? forceOutMts.value() : forceOutMtsLevel0);
+        postProcessForces(
+                cr, step, nrnb, wcycle, box, x.unpaddedArrayRef(), &forceOutCombined, vir_force, mdatoms, fr, vsite, stepWork);
+
+        if (simulationWork.useMts && stepWork.computeSlowForces && !haveCombinedMtsForces)
+        {
+            postProcessForces(
+                    cr, step, nrnb, wcycle, box, x.unpaddedArrayRef(), forceOutMtsLevel1, vir_force, mdatoms, fr, vsite, stepWork);
+
+            combineMtsForces(mdatoms->homenr,
+                             force.unpaddedArrayRef(),
+                             forceView->forceMtsCombined(),
+                             inputrec.mtsLevels[1].stepFactor);
+        }
+    }
+
+    if (stepWork.computeEnergy)
+    {
+        /* Compute the final potential energy terms */
+        accumulatePotentialEnergies(enerd, lambda, inputrec.fepvals.get());
+
+        if (!EI_TPI(inputrec.eI))
+        {
+            checkPotentialEnergyValidity(step, *enerd, inputrec);
+        }
+    }
+
+    /* In case we don't have constraints and are using GPUs, the next balancing
+     * region starts here.
+     * Some "special" work at the end of do_force_cuts?, such as vsite spread,
+     * virial calculation and COM pulling, is not thus not included in
+     * the balance timing, which is ok as most tasks do communication.
+     */
+    ddBalanceRegionHandler.openBeforeForceComputationCpu(DdAllowBalanceRegionReopen::no);
+}
+
+} // namespace gmx

--- a/patches/gromacs-2025.0.diff/src/gromacs/mdrun/md.cpp
+++ b/patches/gromacs-2025.0.diff/src/gromacs/mdrun/md.cpp
@@ -1,0 +1,2226 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 1991- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ *
+ * \brief Implements the integrator for normal molecular dynamics simulations
+ *
+ * \author David van der Spoel <david.vanderspoel@icm.uu.se>
+ * \ingroup module_mdrun
+ */
+#include "gmxpre.h"
+
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gromacs/applied_forces/awh/awh.h"
+#include "gromacs/applied_forces/awh/read_params.h"
+#include "gromacs/commandline/filenm.h"
+#include "gromacs/compat/pointers.h"
+#include "gromacs/domdec/collect.h"
+#include "gromacs/domdec/dlbtiming.h"
+#include "gromacs/domdec/domdec.h"
+#include "gromacs/domdec/domdec_network.h"
+#include "gromacs/domdec/domdec_struct.h"
+#include "gromacs/domdec/gpuhaloexchange.h"
+#include "gromacs/domdec/localtopologychecker.h"
+#include "gromacs/domdec/mdsetup.h"
+#include "gromacs/domdec/partition.h"
+#include "gromacs/essentialdynamics/edsam.h"
+#include "gromacs/ewald/pme_load_balancing.h"
+#include "gromacs/ewald/pme_pp.h"
+#include "gromacs/fileio/enxio.h"
+#include "gromacs/fileio/trxio.h"
+#include "gromacs/gmxlib/network.h"
+#include "gromacs/gmxlib/nrnb.h"
+#include "gromacs/gpu_utils/device_stream_manager.h"
+#include "gromacs/gpu_utils/gpu_utils.h"
+#include "gromacs/gpu_utils/hostallocator.h"
+#include "gromacs/imd/imd.h"
+#include "gromacs/listed_forces/listed_forces.h"
+#include "gromacs/listed_forces/listed_forces_gpu.h"
+#include "gromacs/math/arrayrefwithpadding.h"
+#include "gromacs/math/boxmatrix.h"
+#include "gromacs/math/functions.h"
+#include "gromacs/math/matrix.h"
+#include "gromacs/math/paddedvector.h"
+#include "gromacs/math/vec.h"
+#include "gromacs/math/vectypes.h"
+#include "gromacs/mdlib/checkpointhandler.h"
+#include "gromacs/mdlib/compute_io.h"
+#include "gromacs/mdlib/constr.h"
+#include "gromacs/mdlib/coupling.h"
+#include "gromacs/mdlib/ebin.h"
+#include "gromacs/mdlib/enerdata_utils.h"
+#include "gromacs/mdlib/energyoutput.h"
+#include "gromacs/mdlib/expanded.h"
+#include "gromacs/mdlib/force.h"
+#include "gromacs/mdlib/force_flags.h"
+#include "gromacs/mdlib/forcerec.h"
+#include "gromacs/mdlib/freeenergyparameters.h"
+#include "gromacs/mdlib/md_support.h"
+#include "gromacs/mdlib/mdatoms.h"
+#include "gromacs/mdlib/mdgraph_gpu.h"
+#include "gromacs/mdlib/mdoutf.h"
+#include "gromacs/mdlib/membed.h"
+#include "gromacs/mdlib/resethandler.h"
+#include "gromacs/mdlib/sighandler.h"
+#include "gromacs/mdlib/simulationsignal.h"
+#include "gromacs/mdlib/stat.h"
+#include "gromacs/mdlib/stophandler.h"
+#include "gromacs/mdlib/tgroup.h"
+#include "gromacs/mdlib/trajectory_writing.h"
+#include "gromacs/mdlib/update.h"
+#include "gromacs/mdlib/update_constrain_gpu.h"
+#include "gromacs/mdlib/update_vv.h"
+#include "gromacs/mdlib/vcm.h"
+#include "gromacs/mdlib/vsite.h"
+#include "gromacs/mdrunutility/freeenergy.h"
+#include "gromacs/mdrunutility/handlerestart.h"
+#include "gromacs/mdrunutility/mdmodulesnotifiers.h"
+#include "gromacs/mdrunutility/multisim.h"
+#include "gromacs/mdrunutility/printtime.h"
+#include "gromacs/mdtypes/awh_history.h"
+#include "gromacs/mdtypes/awh_params.h"
+#include "gromacs/mdtypes/commrec.h"
+#include "gromacs/mdtypes/df_history.h"
+#include "gromacs/mdtypes/enerdata.h"
+#include "gromacs/mdtypes/energyhistory.h"
+#include "gromacs/mdtypes/fcdata.h"
+#include "gromacs/mdtypes/forcebuffers.h"
+#include "gromacs/mdtypes/forcerec.h"
+#include "gromacs/mdtypes/group.h"
+#include "gromacs/mdtypes/iforceprovider.h"
+#include "gromacs/mdtypes/inputrec.h"
+#include "gromacs/mdtypes/interaction_const.h"
+#include "gromacs/mdtypes/locality.h"
+#include "gromacs/mdtypes/md_enums.h"
+#include "gromacs/mdtypes/mdatom.h"
+#include "gromacs/mdtypes/mdrunoptions.h"
+#include "gromacs/mdtypes/multipletimestepping.h"
+#include "gromacs/mdtypes/observableshistory.h"
+#include "gromacs/mdtypes/observablesreducer.h"
+#include "gromacs/mdtypes/pull_params.h"
+#include "gromacs/mdtypes/pullhistory.h"
+#include "gromacs/mdtypes/simulation_workload.h"
+#include "gromacs/mdtypes/state.h"
+#include "gromacs/mdtypes/state_propagator_data_gpu.h"
+#include "gromacs/modularsimulator/energydata.h"
+#include "gromacs/nbnxm/gpu_data_mgmt.h"
+#include "gromacs/nbnxm/nbnxm.h"
+#include "gromacs/pbcutil/pbc.h"
+#include "gromacs/pulling/output.h"
+#include "gromacs/pulling/pull.h"
+#include "gromacs/swap/swapcoords.h"
+#include "gromacs/taskassignment/include/gromacs/taskassignment/decidesimulationworkload.h"
+#include "gromacs/timing/wallcycle.h"
+#include "gromacs/timing/walltime_accounting.h"
+#include "gromacs/topology/atoms.h"
+#include "gromacs/topology/idef.h"
+#include "gromacs/topology/ifunc.h"
+#include "gromacs/topology/mtop_util.h"
+#include "gromacs/topology/topology.h"
+#include "gromacs/topology/topology_enums.h"
+#include "gromacs/trajectory/trajectoryframe.h"
+#include "gromacs/utility/arrayref.h"
+#include "gromacs/utility/basedefinitions.h"
+#include "gromacs/utility/cstringutil.h"
+#include "gromacs/utility/enumerationhelpers.h"
+#include "gromacs/utility/fatalerror.h"
+#include "gromacs/utility/gmxassert.h"
+#include "gromacs/utility/logger.h"
+#include "gromacs/utility/real.h"
+#include "gromacs/utility/smalloc.h"
+
+#include "legacysimulator.h"
+#include "replicaexchange.h"
+#include "shellfc.h"
+
+struct gmx_mdoutf;
+struct gmx_shellfc_t;
+struct pme_load_balancing_t;
+
+using gmx::SimulationSignaller;
+
+void gmx::LegacySimulator::do_md()
+{
+    // TODO Historically, the EM and MD "integrators" used different
+    // names for the t_inputrec *parameter, but these must have the
+    // same name, now that it's a member of a struct. We use this ir
+    // alias to avoid a large ripple of nearly useless changes.
+    // t_inputrec is being replaced by IMdpOptionsProvider, so this
+    // will go away eventually.
+    const t_inputrec* ir = inputRec_;
+
+    const double t0  = ir->init_t;
+    gmx_bool     bNS = FALSE, bFirstStep, bInitStep, bLastStep = FALSE;
+    gmx_bool     bDoExpanded = FALSE;
+    tensor    force_vir = { { 0 } }, shake_vir = { { 0 } }, total_vir = { { 0 } }, pres = { { 0 } };
+    rvec      mu_tot;
+    Matrix3x3 pressureCouplingMu{ { 0. } }, parrinelloRahmanM{ { 0. } };
+    gmx_repl_ex_t     repl_ex = nullptr;
+    gmx_bool          bSumEkinhOld, bDoReplEx, bExchanged, bNeedRepartition;
+    real              dvdl_constr;
+    std::vector<RVec> cbuf;
+    matrix            lastbox;
+    int               lamnew = 0;
+    /* for FEP */
+    real      saved_conserved_quantity = 0;
+    real      last_ekin                = 0;
+    t_extmass MassQ;
+    char      sbuf[STEPSTRSIZE], sbuf2[STEPSTRSIZE];
+
+    /* PME load balancing data for GPU kernels */
+    gmx_bool bPMETune         = FALSE;
+    gmx_bool bPMETunePrinting = FALSE;
+
+    bool bInteractiveMDstep = false;
+
+    SimulationSignals signals;
+    // Most global communication stages don't propagate mdrun
+    // signals, and will use this object to achieve that.
+    SimulationSignaller nullSignaller(nullptr, nullptr, nullptr, false, false);
+
+    if (!mdrunOptions_.writeConfout)
+    {
+        // This is on by default, and the main known use case for
+        // turning it off is for convenience in benchmarking, which is
+        // something that should not show up in the general user
+        // interface.
+        GMX_LOG(mdLog_.info)
+                .asParagraph()
+                .appendText(
+                        "The -noconfout functionality is deprecated, and may be removed in a "
+                        "future version.");
+    }
+
+    /* md-vv uses averaged full step velocities for T-control
+       md-vv-avek uses averaged half step velocities for T-control (but full step ekin for P control)
+       md uses averaged half step kinetic energies to determine temperature unless defined otherwise by GMX_EKIN_AVE_VEL; */
+    const bool bTrotter =
+            (EI_VV(ir->eI)
+             && (inputrecNptTrotter(ir) || inputrecNphTrotter(ir) || inputrecNvtTrotter(ir)));
+
+    const bool bRerunMD = false;
+
+    const int  nstglobalcomm   = computeGlobalCommunicationPeriod(mdLog_, ir, cr_);
+    const bool bGStatEveryStep = (nstglobalcomm == 1);
+
+    const SimulationGroups* groups = &topGlobal_.groups;
+
+    std::unique_ptr<EssentialDynamics> ed = nullptr;
+    if (opt2bSet("-ei", nFile_, fnm_))
+    {
+        /* Initialize essential dynamics sampling */
+        ed = init_edsam(mdLog_,
+                        opt2fn_null("-ei", nFile_, fnm_),
+                        opt2fn("-eo", nFile_, fnm_),
+                        topGlobal_,
+                        *ir,
+                        cr_,
+                        constr_,
+                        stateGlobal_,
+                        observablesHistory_,
+                        oenv_,
+                        startingBehavior_);
+    }
+    else if (observablesHistory_->edsamHistory)
+    {
+        gmx_fatal(FARGS,
+                  "The checkpoint is from a run with essential dynamics sampling, "
+                  "but the current run did not specify the -ei option. "
+                  "Either specify the -ei option to mdrun, or do not use this checkpoint file.");
+    }
+
+    int*                fep_state = MAIN(cr_) ? &stateGlobal_->fep_state : nullptr;
+    gmx::ArrayRef<real> lambda    = MAIN(cr_) ? stateGlobal_->lambda : gmx::ArrayRef<real>();
+    initialize_lambdas(
+            fpLog_, ir->efep, ir->bSimTemp, *ir->fepvals, ir->simtempvals->temperatures, ekind_, MAIN(cr_), fep_state, lambda);
+    Update upd(*ir, *ekind_, deform_);
+
+    // Simulated annealing updates the reference temperature.
+    const bool doSimulatedAnnealing = initSimulatedAnnealing(*ir, ekind_, &upd);
+
+    const bool useReplicaExchange = (replExParams_.exchangeInterval > 0);
+
+    t_fcdata& fcdata = *fr_->fcdata;
+
+    // We should let all special algorithms use MDModules, so notifiers tells if we need to share
+    bool simulationsShareState =
+            (ms_ != nullptr)
+            && mdModulesNotifiers_.simulationSetupNotifier_.haveSubscribers<const gmx_multisim_t*>();
+    bool simulationsShareHamiltonian = false;
+    int  nstSignalComm               = nstglobalcomm;
+    {
+        // TODO This implementation of ensemble orientation restraints is nasty because
+        // a user can't just do multi-sim with single-sim orientation restraints.
+        bool usingEnsembleRestraints =
+                (fcdata.disres->nsystems > 1) || ((ms_ != nullptr) && fcdata.orires);
+        bool awhUsesMultiSim = (ir->bDoAwh && ir->awhParams->shareBiasMultisim() && (ms_ != nullptr));
+
+        // Replica exchange, ensemble restraints and AWH need all
+        // simulations to remain synchronized, so they need
+        // checkpoints and stop conditions to act on the same step, so
+        // the propagation of such signals must take place between
+        // simulations, not just within simulations.
+        // TODO: Make algorithm initializers set these flags.
+        simulationsShareState = simulationsShareState || useReplicaExchange
+                                || usingEnsembleRestraints || awhUsesMultiSim;
+
+        // With AWH with bias sharing each simulation uses an non-shared, but identical, Hamiltonian
+        simulationsShareHamiltonian = useReplicaExchange || usingEnsembleRestraints;
+
+        if (simulationsShareState)
+        {
+            // Inter-simulation signal communication does not need to happen
+            // often, so we use a minimum of 200 steps to reduce overhead.
+            const int c_minimumInterSimulationSignallingInterval = 200;
+            nstSignalComm = gmx::divideRoundUp(c_minimumInterSimulationSignallingInterval, nstglobalcomm)
+                            * nstglobalcomm;
+        }
+    }
+
+    if (startingBehavior_ != StartingBehavior::RestartWithAppending)
+    {
+        pleaseCiteCouplingAlgorithms(fpLog_, *ir);
+    }
+    gmx_mdoutf*       outf = init_mdoutf(fpLog_,
+                                   nFile_,
+                                   fnm_,
+                                   mdrunOptions_,
+                                   cr_,
+                                   outputProvider_,
+                                   mdModulesNotifiers_,
+                                   ir,
+                                   topGlobal_,
+                                   oenv_,
+                                   wallCycleCounters_,
+                                   startingBehavior_,
+                                   simulationsShareState,
+                                   ms_);
+    gmx::EnergyOutput energyOutput(mdoutf_get_fp_ene(outf),
+                                   topGlobal_,
+                                   *ir,
+                                   pullWork_,
+                                   mdoutf_get_fp_dhdl(outf),
+                                   false,
+                                   startingBehavior_,
+                                   simulationsShareHamiltonian,
+                                   mdModulesNotifiers_);
+
+    gmx_global_stat_t gstat = global_stat_init(ir);
+
+    const auto& simulationWork     = runScheduleWork_->simulationWork;
+    const bool  useGpuForPme       = simulationWork.useGpuPme;
+    const bool  useGpuForNonbonded = simulationWork.useGpuNonbonded;
+    const bool  useGpuForUpdate    = simulationWork.useGpuUpdate;
+
+    /* Check for polarizable models and flexible constraints */
+    gmx_shellfc_t* shellfc = init_shell_flexcon(fpLog_,
+                                                topGlobal_,
+                                                constr_ ? constr_->numFlexibleConstraints() : 0,
+                                                ir->nstcalcenergy,
+                                                haveDDAtomOrdering(*cr_),
+                                                useGpuForPme);
+
+    {
+        double io = compute_io(ir, topGlobal_.natoms, *groups, energyOutput.numEnergyTerms(), 1);
+        if ((io > 2000) && MAIN(cr_))
+        {
+            fprintf(stderr, "\nWARNING: This run will generate roughly %.0f Mb of data\n\n", io);
+        }
+    }
+
+    ObservablesReducer observablesReducer = observablesReducerBuilder_->build();
+
+    ForceBuffers     f(simulationWork.useMts,
+                   (simulationWork.useGpuFBufferOpsWhenAllowed || useGpuForUpdate)
+                               ? PinningPolicy::PinnedIfSupported
+                               : PinningPolicy::CannotBePinned);
+    const t_mdatoms* md = mdAtoms_->mdatoms();
+    if (haveDDAtomOrdering(*cr_))
+    {
+        // Local state only becomes valid now.
+        dd_init_local_state(*cr_->dd, stateGlobal_, state_);
+
+        /* Distribute the charge groups over the nodes from the main node */
+        dd_partition_system(fpLog_,
+                            mdLog_,
+                            ir->init_step,
+                            cr_,
+                            TRUE,
+                            stateGlobal_,
+                            topGlobal_,
+                            *ir,
+                            mdModulesNotifiers_,
+                            imdSession_,
+                            pullWork_,
+                            state_,
+                            &f,
+                            mdAtoms_,
+                            top_,
+                            fr_,
+                            virtualSites_,
+                            constr_,
+                            nrnb_,
+                            nullptr,
+                            FALSE);
+        upd.updateAfterPartition(state_->numAtoms(), md->cFREEZE, md->cTC, md->cACC);
+        fr_->longRangeNonbondeds->updateAfterPartition(*md);
+    }
+    else
+    {
+        /* Generate and initialize new topology */
+        mdAlgorithmsSetupAtomData(
+                cr_, *ir, topGlobal_, top_, fr_, &f, mdAtoms_, constr_, virtualSites_, shellfc);
+
+        upd.updateAfterPartition(state_->numAtoms(), md->cFREEZE, md->cTC, md->cACC);
+        fr_->longRangeNonbondeds->updateAfterPartition(*md);
+    }
+
+    // Now that the state is valid we can set up Parrinello-Rahman
+    init_parrinellorahman(ir->pressureCouplingOptions,
+                          ir->deform,
+                          ir->delta_t * ir->pressureCouplingOptions.nstpcouple,
+                          state_->box,
+                          state_->box_rel,
+                          state_->boxv,
+                          &parrinelloRahmanM,
+                          &pressureCouplingMu);
+
+    std::unique_ptr<UpdateConstrainGpu> integrator;
+
+    StatePropagatorDataGpu* stateGpu = fr_->stateGpu;
+
+    // TODO: the assertions below should be handled by UpdateConstraintsBuilder.
+    if (useGpuForUpdate)
+    {
+        GMX_RELEASE_ASSERT(!haveDDAtomOrdering(*cr_) || ddUsesUpdateGroups(*cr_->dd)
+                                   || constr_ == nullptr || constr_->numConstraintsTotal() == 0,
+                           "Constraints in domain decomposition are only supported with update "
+                           "groups if using GPU update.\n");
+        GMX_RELEASE_ASSERT(ir->eConstrAlg != ConstraintAlgorithm::Shake || constr_ == nullptr
+                                   || constr_->numConstraintsTotal() == 0,
+                           "SHAKE is not supported with GPU update.");
+        GMX_RELEASE_ASSERT(useGpuForPme || (useGpuForNonbonded && simulationWork.useGpuXBufferOpsWhenAllowed),
+                           "Either PME or short-ranged non-bonded interaction tasks must run on "
+                           "the GPU to use GPU update.\n");
+        GMX_RELEASE_ASSERT(ir->eI == IntegrationAlgorithm::MD,
+                           "Only the md integrator is supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(
+                ir->etc != TemperatureCoupling::NoseHoover,
+                "Nose-Hoover temperature coupling is not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(
+                ir->pressureCouplingOptions.epc == PressureCoupling::No
+                        || ir->pressureCouplingOptions.epc == PressureCoupling::ParrinelloRahman
+                        || ir->pressureCouplingOptions.epc == PressureCoupling::Berendsen
+                        || ir->pressureCouplingOptions.epc == PressureCoupling::CRescale,
+                "Only Parrinello-Rahman, Berendsen, and C-rescale pressure coupling are supported "
+                "with the GPU update.\n");
+        GMX_RELEASE_ASSERT(!md->haveVsites,
+                           "Virtual sites are not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(ed == nullptr,
+                           "Essential dynamics is not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(!ir->bPull || !pull_have_constraint(*ir->pull),
+                           "Constraints pulling is not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(fcdata.orires == nullptr,
+                           "Orientation restraints are not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(
+                ir->efep == FreeEnergyPerturbationType::No
+                        || (!haveFepPerturbedMasses(topGlobal_) && !havePerturbedConstraints(topGlobal_)),
+                "Free energy perturbation of masses and constraints are not supported with the GPU "
+                "update.");
+
+        if (constr_ != nullptr && constr_->numConstraintsTotal() > 0)
+        {
+            GMX_LOG(mdLog_.info)
+                    .asParagraph()
+                    .appendText("Updating coordinates and applying constraints on the GPU.");
+        }
+        else
+        {
+            GMX_LOG(mdLog_.info).asParagraph().appendText("Updating coordinates on the GPU.");
+        }
+        GMX_RELEASE_ASSERT(fr_->deviceStreamManager != nullptr,
+                           "Device stream manager should be initialized in order to use GPU "
+                           "update-constraints.");
+        GMX_RELEASE_ASSERT(
+                fr_->deviceStreamManager->streamIsValid(gmx::DeviceStreamType::UpdateAndConstraints),
+                "Update stream should be initialized in order to use GPU "
+                "update-constraints.");
+        integrator = std::make_unique<UpdateConstrainGpu>(
+                *ir,
+                topGlobal_,
+                ekind_->numTemperatureCouplingGroups(),
+                fr_->deviceStreamManager->context(),
+                fr_->deviceStreamManager->stream(gmx::DeviceStreamType::UpdateAndConstraints),
+                wallCycleCounters_);
+
+        stateGpu->setXUpdatedOnDeviceEvent(integrator->xUpdatedOnDeviceEvent());
+
+        integrator->setPbc(PbcType::Xyz, state_->box);
+    }
+
+    if (useGpuForPme || simulationWork.useGpuXBufferOpsWhenAllowed || useGpuForUpdate)
+    {
+        changePinningPolicy(&state_->x, PinningPolicy::PinnedIfSupported);
+    }
+    if (useGpuForUpdate)
+    {
+        changePinningPolicy(&state_->v, PinningPolicy::PinnedIfSupported);
+    }
+
+    // NOTE: The global state is no longer used at this point.
+    // But state_global is still used as temporary storage space for writing
+    // the global state to file and potentially for replica exchange.
+    // (Global topology should persist.)
+
+    update_mdatoms(mdAtoms_->mdatoms(), state_->lambda[FreeEnergyPerturbationCouplingType::Mass]);
+
+    if (ir->bExpanded)
+    {
+        /* Check nstexpanded here, because the grompp check was broken */
+        if (ir->expandedvals->nstexpanded % ir->nstcalcenergy != 0)
+        {
+            gmx_fatal(FARGS,
+                      "With expanded ensemble, nstexpanded should be a multiple of nstcalcenergy");
+        }
+        init_expanded_ensemble(startingBehavior_ != StartingBehavior::NewSimulation, ir, state_->dfhist);
+    }
+
+    if (MAIN(cr_))
+    {
+        EnergyData::initializeEnergyHistory(startingBehavior_, observablesHistory_, &energyOutput);
+    }
+
+    preparePrevStepPullCom(
+            ir, pullWork_, md->massT, state_, stateGlobal_, cr_, startingBehavior_ != StartingBehavior::NewSimulation);
+
+    // TODO: Remove this by converting AWH into a ForceProvider
+    auto awh = prepareAwhModule(fpLog_,
+                                *ir,
+                                stateGlobal_,
+                                cr_,
+                                ms_,
+                                startingBehavior_ != StartingBehavior::NewSimulation,
+                                shellfc != nullptr,
+                                opt2fn("-awh", nFile_, fnm_),
+                                pullWork_);
+
+    if (useReplicaExchange && MAIN(cr_))
+    {
+        repl_ex = init_replica_exchange(fpLog_, ms_, topGlobal_.natoms, ir, replExParams_);
+    }
+    /* PME tuning is only supported in the Verlet scheme, with PME for
+     * Coulomb. It is not supported with only LJ PME.
+     * Disable PME tuning with GPU PME decomposition */
+    bPMETune = (mdrunOptions_.tunePme && usingPme(fr_->ic->eeltype) && !mdrunOptions_.reproducible
+                && ir->cutoff_scheme != CutoffScheme::Group && !simulationWork.useGpuPmeDecomposition);
+
+    pme_load_balancing_t* pme_loadbal = nullptr;
+    if (bPMETune)
+    {
+        pme_loadbal_init(
+                &pme_loadbal, cr_, mdLog_, *ir, state_->box, *fr_->ic, *fr_->nbv, fr_->pmedata, fr_->nbv->useGpu());
+    }
+
+    if (!ir->bContinuation)
+    {
+        if (state_->hasEntry(StateEntry::V))
+        {
+            auto v = makeArrayRef(state_->v);
+            /* Set the velocities of vsites, shells and frozen atoms to zero */
+            for (int i = 0; i < md->homenr; i++)
+            {
+                if (md->ptype[i] == ParticleType::Shell)
+                {
+                    clear_rvec(v[i]);
+                }
+                else if (!md->cFREEZE.empty())
+                {
+                    for (int m = 0; m < DIM; m++)
+                    {
+                        if (ir->opts.nFreeze[md->cFREEZE[i]][m])
+                        {
+                            v[i][m] = 0;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (constr_)
+        {
+            /* Constrain the initial coordinates and velocities */
+            do_constrain_first(fpLog_,
+                               constr_,
+                               *ir,
+                               md->homenr,
+                               state_->x.arrayRefWithPadding(),
+                               state_->v.arrayRefWithPadding(),
+                               state_->box,
+                               state_->lambda[FreeEnergyPerturbationCouplingType::Bonded]);
+        }
+    }
+
+    const int nstfep = computeFepPeriod(*ir, replExParams_);
+
+    /* Be REALLY careful about what flags you set here. You CANNOT assume
+     * this is the first step, since we might be restarting from a checkpoint,
+     * and in that case we should not do any modifications to the state.
+     */
+    const bool stopCenterOfMassMovementBeforeFirstStep =
+            (ir->comm_mode != ComRemovalAlgorithm::No && !ir->bContinuation);
+
+    // When restarting from a checkpoint, it can be appropriate to
+    // initialize ekind from quantities in the checkpoint. Otherwise,
+    // compute_globals must initialize ekind before the simulation
+    // starts/restarts. However, only the main rank knows what was
+    // found in the checkpoint file, so we have to communicate in
+    // order to coordinate the restart.
+    //
+    // TODO Consider removing this communication if/when checkpoint
+    // reading directly follows .tpr reading, because all ranks can
+    // agree on hasReadEkinState at that time.
+    bool hasReadEkinState = MAIN(cr_) ? stateGlobal_->ekinstate.hasReadEkinState : false;
+    if (PAR(cr_))
+    {
+        gmx_bcast(sizeof(hasReadEkinState), &hasReadEkinState, cr_->mpi_comm_mygroup);
+    }
+    if (hasReadEkinState)
+    {
+        restore_ekinstate_from_state(cr_, ekind_, MAIN(cr_) ? &stateGlobal_->ekinstate : nullptr);
+    }
+
+    unsigned int cglo_flags =
+            (CGLO_TEMPERATURE | CGLO_GSTAT | (EI_VV(ir->eI) ? CGLO_PRESSURE : 0)
+             | (EI_VV(ir->eI) ? CGLO_CONSTRAINT : 0) | (hasReadEkinState ? CGLO_READEKIN : 0));
+
+    bSumEkinhOld = FALSE;
+
+    t_vcm vcm(topGlobal_.groups, *ir, topGlobal_.natoms);
+    reportComRemovalInfo(fpLog_, vcm);
+
+    int64_t step     = ir->init_step;
+    int64_t step_rel = 0;
+
+    /* To minimize communication, compute_globals computes the COM velocity
+     * and the kinetic energy for the velocities without COM motion removed.
+     * Thus to get the kinetic energy without the COM contribution, we need
+     * to call compute_globals twice.
+     */
+    for (int cgloIteration = 0; cgloIteration < (stopCenterOfMassMovementBeforeFirstStep ? 2 : 1);
+         cgloIteration++)
+    {
+        unsigned int cglo_flags_iteration = cglo_flags;
+        if (stopCenterOfMassMovementBeforeFirstStep && cgloIteration == 0)
+        {
+            cglo_flags_iteration |= CGLO_STOPCM;
+            cglo_flags_iteration &= ~CGLO_TEMPERATURE;
+        }
+        compute_globals(gstat,
+                        cr_,
+                        ir,
+                        fr_,
+                        ekind_,
+                        makeConstArrayRef(state_->x),
+                        makeConstArrayRef(state_->v),
+                        state_->box,
+                        md,
+                        nrnb_,
+                        &vcm,
+                        nullptr,
+                        enerd_,
+                        force_vir,
+                        shake_vir,
+                        total_vir,
+                        pres,
+                        &nullSignaller,
+                        state_->box,
+                        &bSumEkinhOld,
+                        cglo_flags_iteration,
+                        step,
+                        &observablesReducer);
+        // Clean up after pre-step use of compute_globals()
+        observablesReducer.markAsReadyToReduce();
+
+        if (cglo_flags_iteration & CGLO_STOPCM)
+        {
+            /* At initialization, do not pass x with acceleration-correction mode
+             * to avoid (incorrect) correction of the initial coordinates.
+             */
+            auto x = (vcm.mode == ComRemovalAlgorithm::LinearAccelerationCorrection)
+                             ? ArrayRef<RVec>()
+                             : makeArrayRef(state_->x);
+            process_and_stopcm_grp(fpLog_, &vcm, *md, x, makeArrayRef(state_->v));
+            inc_nrnb(nrnb_, eNR_STOPCM, md->homenr);
+        }
+    }
+    if (ir->eI == IntegrationAlgorithm::VVAK)
+    {
+        /* a second call to get the half step temperature initialized as well */
+        /* we do the same call as above, but turn the pressure off -- internally to
+           compute_globals, this is recognized as a velocity verlet half-step
+           kinetic energy calculation.  This minimized excess variables, but
+           perhaps loses some logic?*/
+
+        compute_globals(gstat,
+                        cr_,
+                        ir,
+                        fr_,
+                        ekind_,
+                        makeConstArrayRef(state_->x),
+                        makeConstArrayRef(state_->v),
+                        state_->box,
+                        md,
+                        nrnb_,
+                        &vcm,
+                        nullptr,
+                        enerd_,
+                        force_vir,
+                        shake_vir,
+                        total_vir,
+                        pres,
+                        &nullSignaller,
+                        state_->box,
+                        &bSumEkinhOld,
+                        cglo_flags & ~CGLO_PRESSURE,
+                        step,
+                        &observablesReducer);
+        // Clean up after pre-step use of compute_globals()
+        observablesReducer.markAsReadyToReduce();
+    }
+
+    /* Calculate the initial half step temperature, and save the ekinh_old */
+    if (startingBehavior_ == StartingBehavior::NewSimulation)
+    {
+        for (int i = 0; (i < ir->opts.ngtc); i++)
+        {
+            copy_mat(ekind_->tcstat[i].ekinh, ekind_->tcstat[i].ekinh_old);
+        }
+    }
+
+    /* need to make an initiation call to get the Trotter variables set, as well as other constants
+       for non-trotter temperature control */
+    auto trotter_seq = init_npt_vars(ir, *ekind_, state_, &MassQ, bTrotter);
+
+    if (MAIN(cr_))
+    {
+        if (!ir->bContinuation)
+        {
+            if (constr_ && ir->eConstrAlg == ConstraintAlgorithm::Lincs)
+            {
+                fprintf(fpLog_,
+                        "RMS relative constraint deviation after constraining: %.2e\n",
+                        constr_->rmsd());
+            }
+            if (EI_STATE_VELOCITY(ir->eI))
+            {
+                real temp = enerd_->term[F_TEMP];
+                if (ir->eI != IntegrationAlgorithm::VV)
+                {
+                    /* Result of Ekin averaged over velocities of -half
+                     * and +half step, while we only have -half step here.
+                     */
+                    temp *= 2;
+                }
+                fprintf(fpLog_, "Initial temperature: %g K\n", temp);
+            }
+        }
+
+        char tbuf[20];
+        fprintf(stderr, "starting mdrun '%s'\n", *(topGlobal_.name));
+        if (ir->nsteps >= 0)
+        {
+            sprintf(tbuf, "%8.1f", (ir->init_step + ir->nsteps) * ir->delta_t);
+        }
+        else
+        {
+            sprintf(tbuf, "%s", "infinite");
+        }
+        if (ir->init_step > 0)
+        {
+            fprintf(stderr,
+                    "%s steps, %s ps (continuing from step %s, %8.1f ps).\n",
+                    gmx_step_str(ir->init_step + ir->nsteps, sbuf),
+                    tbuf,
+                    gmx_step_str(ir->init_step, sbuf2),
+                    ir->init_step * ir->delta_t);
+        }
+        else
+        {
+            fprintf(stderr, "%s steps, %s ps.\n", gmx_step_str(ir->nsteps, sbuf), tbuf);
+        }
+        fprintf(fpLog_, "\n");
+    }
+
+    walltime_accounting_start_time(wallTimeAccounting_);
+    wallcycle_start(wallCycleCounters_, WallCycleCounter::Run);
+    print_start(fpLog_, cr_, wallTimeAccounting_, "mdrun");
+
+    /***********************************************************
+     *
+     *             Loop over MD steps
+     *
+     ************************************************************/
+
+    bFirstStep = TRUE;
+    /* Skip the first Nose-Hoover integration when we get the state from tpx */
+    bInitStep        = startingBehavior_ == StartingBehavior::NewSimulation || EI_VV(ir->eI);
+    bSumEkinhOld     = FALSE;
+    bExchanged       = FALSE;
+    bNeedRepartition = FALSE;
+
+    auto stopHandler = stopHandlerBuilder_->getStopHandlerMD(
+            compat::not_null<SimulationSignal*>(&signals[eglsSTOPCOND]),
+            simulationsShareState,
+            MAIN(cr_),
+            ir->nstlist,
+            mdrunOptions_.reproducible,
+            nstSignalComm,
+            mdrunOptions_.maximumHoursToRun,
+            ir->nstlist == 0,
+            fpLog_,
+            step,
+            bNS,
+            wallTimeAccounting_);
+
+    real checkpointPeriod = mdrunOptions_.checkpointOptions.period;
+    if (ir->bExpanded)
+    {
+        GMX_LOG(mdLog_.info)
+                .asParagraph()
+                .appendText(
+                        "Expanded ensemble with the legacy simulator does not always "
+                        "checkpoint correctly, so checkpointing is disabled. You will "
+                        "not be able to do a checkpoint restart of this simulation. "
+                        "If you use the modular simulator (e.g. by choosing md-vv integrator) "
+                        "then checkpointing is enabled. See "
+                        "https://gitlab.com/gromacs/gromacs/-/issues/4629 for details.");
+        // Use a negative period to disable checkpointing.
+        checkpointPeriod = -1;
+    }
+    auto checkpointHandler = std::make_unique<CheckpointHandler>(
+            compat::make_not_null<SimulationSignal*>(&signals[eglsCHKPT]),
+            simulationsShareState,
+            ir->nstlist == 0,
+            MAIN(cr_),
+            mdrunOptions_.writeConfout,
+            checkpointPeriod);
+
+    const bool resetCountersIsLocal = true;
+    auto       resetHandler         = std::make_unique<ResetHandler>(
+            compat::make_not_null<SimulationSignal*>(&signals[eglsRESETCOUNTERS]),
+            !resetCountersIsLocal,
+            ir->nsteps,
+            MAIN(cr_),
+            mdrunOptions_.timingOptions.resetHalfway,
+            mdrunOptions_.maximumHoursToRun,
+            mdLog_,
+            wallCycleCounters_,
+            wallTimeAccounting_);
+
+    const DDBalanceRegionHandler ddBalanceRegionHandler(cr_);
+
+    if (MAIN(cr_) && isMultiSim(ms_) && !useReplicaExchange)
+    {
+        logInitialMultisimStatus(ms_, cr_, mdLog_, simulationsShareState, ir->nsteps, ir->init_step);
+    }
+
+    bool usedMdGpuGraphLastStep = false;
+    /* and stop now if we should */
+    bLastStep = (bLastStep || (ir->nsteps >= 0 && step_rel > ir->nsteps));
+    while (!bLastStep)
+    {
+        /* Determine if this is a neighbor search step */
+        const bool bNStList = (ir->nstlist > 0 && step % ir->nstlist == 0);
+
+        if (bPMETune && bNStList)
+        {
+            // This has to be here because PME load balancing is called so early.
+            // TODO: Move to after all booleans are defined.
+            if (useGpuForUpdate && !bFirstStep)
+            {
+                stateGpu->copyCoordinatesFromGpu(state_->x, AtomLocality::Local);
+                stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+            }
+            /* PME grid + cut-off optimization with GPUs or PME nodes */
+            pme_loadbal_do(pme_loadbal,
+                           cr_,
+                           (mdrunOptions_.verbose && MAIN(cr_)) ? stderr : nullptr,
+                           fpLog_,
+                           mdLog_,
+                           *ir,
+                           fr_,
+                           state_->box,
+                           state_->x,
+                           wallCycleCounters_,
+                           step,
+                           step_rel,
+                           &bPMETunePrinting,
+                           simulationWork.useGpuPmePpCommunication);
+        }
+
+        wallcycle_start(wallCycleCounters_, WallCycleCounter::Step);
+
+        bLastStep      = (step_rel == ir->nsteps);
+        const double t = t0 + step * ir->delta_t;
+
+        // TODO Refactor this, so that nstfep does not need a default value of zero
+        if (ir->efep != FreeEnergyPerturbationType::No || ir->bSimTemp)
+        {
+            /* find and set the current lambdas */
+            state_->lambda = currentLambdas(step, *(ir->fepvals), state_->fep_state);
+
+            bDoExpanded = (do_per_step(step, ir->expandedvals->nstexpanded) && (ir->bExpanded)
+                           && (!bFirstStep));
+        }
+
+        bDoReplEx = (useReplicaExchange && (step > 0) && !bLastStep
+                     && do_per_step(step, replExParams_.exchangeInterval));
+
+        if (doSimulatedAnnealing)
+        {
+            // Simulated annealing updates the reference temperature.
+            update_annealing_target_temp(*ir, t, ekind_, &upd);
+        }
+
+        /* Stop Center of Mass motion */
+        const bool bStopCM = (ir->comm_mode != ComRemovalAlgorithm::No && do_per_step(step, ir->nstcomm));
+
+        /* Determine whether or not to do Neighbour Searching */
+        bNS = (bFirstStep || bNStList || bExchanged || bNeedRepartition);
+
+        /* Note that the stopHandler will cause termination at nstglobalcomm
+         * steps. Since this concides with nstcalcenergy, nsttcouple and/or
+         * nstpcouple steps, we have computed the half-step kinetic energy
+         * of the previous step and can always output energies at the last step.
+         */
+        bLastStep = bLastStep || stopHandler->stoppingAfterCurrentStep(bNS);
+
+        /* do_log triggers energy and virial calculation. Because this leads
+         * to different code paths, forces can be different. Thus for exact
+         * continuation we should avoid extra log output.
+         * Note that the || bLastStep can result in non-exact continuation
+         * beyond the last step. But we don't consider that to be an issue.
+         */
+        const bool do_log = (do_per_step(step, ir->nstlog)
+                             || (bFirstStep && startingBehavior_ == StartingBehavior::NewSimulation)
+                             || bLastStep);
+        const bool do_verbose =
+                mdrunOptions_.verbose
+                && (step % mdrunOptions_.verboseStepPrintInterval == 0 || bFirstStep || bLastStep);
+
+        // On search steps, when doing the update on the GPU, copy
+        // the coordinates and velocities to the host unless they are
+        // already there (ie on the first step and after replica
+        // exchange).
+        if (useGpuForUpdate && bNS && !bFirstStep && !bExchanged)
+        {
+            if (usedMdGpuGraphLastStep)
+            {
+                // Wait on coordinates produced from GPU graph
+                stateGpu->waitCoordinatesUpdatedOnDevice();
+            }
+            stateGpu->copyVelocitiesFromGpu(state_->v, AtomLocality::Local);
+            stateGpu->copyCoordinatesFromGpu(state_->x, AtomLocality::Local);
+            stateGpu->waitVelocitiesReadyOnHost(AtomLocality::Local);
+            stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+        }
+
+        // We need to calculate virtual velocities if we are writing them in the current step.
+        // They also need to be periodically updated. Every 1000 steps is arbitrary, but a reasonable number.
+        // The reason why the velocities need to be updated regularly is that the virtual site coordinates
+        // are updated using these velocities during integration. Those coordinates are used for, e.g., domain
+        // decomposition. Before computing any forces the positions of the virtual sites are recalculated.
+        // This fixes a bug, #4879, which was introduced in MR !979.
+        const int  c_virtualSiteVelocityUpdateInterval = 1000;
+        const bool needVirtualVelocitiesThisStep =
+                (virtualSites_ != nullptr)
+                && (do_per_step(step, ir->nstvout) || checkpointHandler->isCheckpointingStep()
+                    || do_per_step(step, c_virtualSiteVelocityUpdateInterval));
+
+        if (virtualSites_ != nullptr)
+        {
+            // Virtual sites need to be updated before domain decomposition and forces are calculated
+            wallcycle_start(wallCycleCounters_, WallCycleCounter::VsiteConstr);
+            // md-vv calculates virtual velocities once it has full-step real velocities
+            virtualSites_->construct(state_->x,
+                                     state_->v,
+                                     state_->box,
+                                     (!EI_VV(inputRec_->eI) && needVirtualVelocitiesThisStep)
+                                             ? VSiteOperation::PositionsAndVelocities
+                                             : VSiteOperation::Positions);
+            wallcycle_stop(wallCycleCounters_, WallCycleCounter::VsiteConstr);
+        }
+
+        if (bNS && !(bFirstStep && ir->bContinuation))
+        {
+            /* Correct the new box if it is too skewed */
+            const bool bMainState = inputrecDynamicBox(ir) && correct_box(fpLog_, step, state_->box);
+            // If update is offloaded, and the box was changed either
+            // above or in a replica exchange on the previous step,
+            // the GPU Update object should be informed
+            if (useGpuForUpdate && (bMainState || bExchanged))
+            {
+                integrator->setPbc(PbcType::Xyz, state_->box);
+            }
+            if (haveDDAtomOrdering(*cr_) && bMainState)
+            {
+                dd_collect_state(cr_->dd, state_, stateGlobal_);
+            }
+
+            if (haveDDAtomOrdering(*cr_))
+            {
+                /* Repartition the domain decomposition */
+                dd_partition_system(fpLog_,
+                                    mdLog_,
+                                    step,
+                                    cr_,
+                                    bMainState,
+                                    stateGlobal_,
+                                    topGlobal_,
+                                    *ir,
+                                    mdModulesNotifiers_,
+                                    imdSession_,
+                                    pullWork_,
+                                    state_,
+                                    &f,
+                                    mdAtoms_,
+                                    top_,
+                                    fr_,
+                                    virtualSites_,
+                                    constr_,
+                                    nrnb_,
+                                    wallCycleCounters_,
+                                    do_verbose && !bPMETunePrinting);
+                upd.updateAfterPartition(state_->numAtoms(), md->cFREEZE, md->cTC, md->cACC);
+                fr_->longRangeNonbondeds->updateAfterPartition(*md);
+            }
+        }
+
+        // Allocate or re-size GPU halo exchange object, if necessary
+        if (bNS && simulationWork.havePpDomainDecomposition && simulationWork.useGpuHaloExchange)
+        {
+            GMX_RELEASE_ASSERT(fr_->deviceStreamManager != nullptr,
+                               "GPU device manager has to be initialized to use GPU "
+                               "version of halo exchange.");
+            constructGpuHaloExchange(*cr_, *fr_->deviceStreamManager, wallCycleCounters_);
+        }
+
+        if (MAIN(cr_) && do_log)
+        {
+            gmx::EnergyOutput::printHeader(fpLog_, step, t); /* can we improve the information printed here? */
+        }
+
+        if (ir->efep != FreeEnergyPerturbationType::No)
+        {
+            update_mdatoms(mdAtoms_->mdatoms(), state_->lambda[FreeEnergyPerturbationCouplingType::Mass]);
+        }
+
+        if (bExchanged)
+        {
+            /* We need the kinetic energy at minus the half step for determining
+             * the full step kinetic energy and possibly for T-coupling.*/
+            /* This may not be quite working correctly yet . . . . */
+            int cglo_flags = CGLO_GSTAT | CGLO_TEMPERATURE;
+            compute_globals(gstat,
+                            cr_,
+                            ir,
+                            fr_,
+                            ekind_,
+                            makeConstArrayRef(state_->x),
+                            makeConstArrayRef(state_->v),
+                            state_->box,
+                            md,
+                            nrnb_,
+                            &vcm,
+                            wallCycleCounters_,
+                            enerd_,
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            &nullSignaller,
+                            state_->box,
+                            &bSumEkinhOld,
+                            cglo_flags,
+                            step,
+                            &observablesReducer);
+        }
+        clear_mat(force_vir);
+
+        checkpointHandler->decideIfCheckpointingThisStep(bNS, bFirstStep, bLastStep);
+
+        /* Determine the energy and pressure:
+         * at nstcalcenergy steps and at energy output steps (set below).
+         */
+
+        const bool do_ene              = (do_per_step(step, ir->nstenergy) || bLastStep);
+        const bool needEnergyAndVirial = do_ene || do_log || bDoReplEx;
+
+        const bool bCalcEnerStep = do_per_step(step, ir->nstcalcenergy);
+        const bool bCalcVir      = [&]() -> bool
+        {
+            auto doPressureCoupling = [ir](int64_t s) -> bool
+            {
+                return ir->pressureCouplingOptions.epc != PressureCoupling::No
+                       && do_per_step(s, ir->pressureCouplingOptions.nstpcouple);
+            };
+            if (EI_VV(ir->eI) && (!bInitStep))
+            {
+                return bCalcEnerStep || needEnergyAndVirial || doPressureCoupling(step)
+                       || doPressureCoupling(step - 1);
+            }
+            else
+            {
+                return bCalcEnerStep || needEnergyAndVirial || doPressureCoupling(step);
+            }
+        }();
+
+        const bool bCalcEner = bCalcEnerStep || needEnergyAndVirial;
+
+        // bCalcEner is only here for when the last step is not a multiple of nstfep
+        const bool computeDHDL = ((ir->efep != FreeEnergyPerturbationType::No || ir->bSimTemp)
+                                  && (do_per_step(step, nstfep) || bCalcEner));
+
+        /* Do we need global communication ? */
+        const bool bGStat =
+                (bCalcVir || bCalcEner || bStopCM || do_per_step(step, nstglobalcomm)
+                 || (EI_VV(ir->eI) && inputrecNvtTrotter(ir) && do_per_step(step - 1, nstglobalcomm)));
+
+        unsigned int force_flags =
+                (GMX_FORCE_STATECHANGED | ((inputrecDynamicBox(ir)) ? GMX_FORCE_DYNAMICBOX : 0)
+                 | GMX_FORCE_ALLFORCES | (bCalcVir ? GMX_FORCE_VIRIAL : 0)
+                 | (bCalcEner ? GMX_FORCE_ENERGY : 0) | (computeDHDL ? GMX_FORCE_DHDL : 0));
+        /* PLUMED */
+        if (fr_->forceProviders != nullptr && fr_->forceProviders->requestsPotentialEnergy(step))
+        {
+            /* setupStepWorkload() snapshots force_flags below, so PLUMED has to be
+               asked for the potential energy before that, not from within do_force(). */
+            force_flags |= GMX_FORCE_ENERGY | GMX_FORCE_VIRIAL;
+        }
+        /* END PLUMED */
+        if (simulationWork.useMts && !do_per_step(step, ir->nstfout))
+        {
+            // TODO: merge this with stepWork.useOnlyMtsCombinedForceBuffer
+            force_flags |= GMX_FORCE_DO_NOT_NEED_NORMAL_FORCE;
+        }
+
+        if (bNS)
+        {
+            if (fr_->listedForcesGpu)
+            {
+                fr_->listedForcesGpu->updateHaveInteractions(top_->idef);
+            }
+            runScheduleWork_->domainWork = setupDomainLifetimeWorkload(
+                    *ir, *fr_, pullWork_, ed ? ed->getLegacyED() : nullptr, *md, simulationWork);
+        }
+
+        const int shellfcFlags = force_flags | (mdrunOptions_.verbose ? GMX_FORCE_ENERGY : 0);
+        const int legacyForceFlags = ((shellfc) ? shellfcFlags : force_flags) | (bNS ? GMX_FORCE_NS : 0);
+
+        runScheduleWork_->stepWork = setupStepWorkload(
+                legacyForceFlags, ir->mtsLevels, step, runScheduleWork_->domainWork, simulationWork);
+
+        const bool doTemperatureScaling = (ir->etc != TemperatureCoupling::No
+                                           && do_per_step(step + ir->nsttcouple - 1, ir->nsttcouple));
+
+        /* With leap-frog type integrators we compute the kinetic energy
+         * at a whole time step as the average of the half-time step kinetic
+         * energies of two subsequent steps. Therefore we need to compute the
+         * half step kinetic energy also if we need energies at the next step.
+         */
+        const bool needHalfStepKineticEnergy =
+                (!EI_VV(ir->eI) && (do_per_step(step + 1, nstglobalcomm) || step_rel + 1 == ir->nsteps));
+
+        // Parrinello-Rahman requires the pressure to be availible before the update to compute
+        // the velocity scaling matrix. Hence, it runs one step after the nstpcouple step.
+        const bool doParrinelloRahman =
+                (ir->pressureCouplingOptions.epc == PressureCoupling::ParrinelloRahman
+                 && do_per_step(step + ir->pressureCouplingOptions.nstpcouple - 1,
+                                ir->pressureCouplingOptions.nstpcouple));
+
+        MdGpuGraph* mdGraph = simulationWork.useMdGpuGraph ? fr_->mdGraph[step % 2].get() : nullptr;
+
+        if (simulationWork.useMdGpuGraph)
+        {
+            // Reset graph on search step (due to changing neighbour list etc)
+            // or virial step (due to changing shifts and box).
+            if (bNS || bCalcVir)
+            {
+                fr_->mdGraph[MdGraphEvenOrOddStep::EvenStep]->reset();
+                fr_->mdGraph[MdGraphEvenOrOddStep::OddStep]->reset();
+            }
+            else
+            {
+                mdGraph->setUsedGraphLastStep(usedMdGpuGraphLastStep);
+                bool canUseMdGpuGraphThisStep =
+                        !bNS && !bCalcVir && !doTemperatureScaling && !doParrinelloRahman && !bGStat
+                        && !needHalfStepKineticEnergy && !do_per_step(step, ir->nstxout)
+                        && !do_per_step(step, ir->nstxout_compressed)
+                        && !do_per_step(step, ir->nstvout) && !do_per_step(step, ir->nstfout)
+                        && !checkpointHandler->isCheckpointingStep();
+                if (mdGraph->captureThisStep(canUseMdGpuGraphThisStep))
+                {
+                    mdGraph->startRecord(stateGpu->getCoordinatesReadyOnDeviceEvent(
+                            AtomLocality::Local, simulationWork, runScheduleWork_->stepWork));
+                }
+            }
+        }
+        if (!simulationWork.useMdGpuGraph || mdGraph->graphIsCapturingThisStep()
+            || !mdGraph->useGraphThisStep())
+        {
+
+            if (shellfc)
+            {
+                /* Now is the time to relax the shells */
+                relax_shell_flexcon(fpLog_,
+                                    cr_,
+                                    ms_,
+                                    mdrunOptions_.verbose,
+                                    enforcedRotation_,
+                                    step,
+                                    ir,
+                                    mdModulesNotifiers_,
+                                    imdSession_,
+                                    pullWork_,
+                                    bNS,
+                                    top_,
+                                    constr_,
+                                    enerd_,
+                                    state_->numAtoms(),
+                                    state_->x.arrayRefWithPadding(),
+                                    state_->v.arrayRefWithPadding(),
+                                    state_->box,
+                                    state_->lambda,
+                                    &state_->hist,
+                                    &f.view(),
+                                    force_vir,
+                                    *md,
+                                    fr_->longRangeNonbondeds.get(),
+                                    nrnb_,
+                                    wallCycleCounters_,
+                                    shellfc,
+                                    fr_,
+                                    *runScheduleWork_,
+                                    t,
+                                    mu_tot,
+                                    virtualSites_,
+                                    ddBalanceRegionHandler);
+            }
+            else
+            {
+                /* The AWH history need to be saved _before_ doing force calculations where the AWH bias
+                   is updated (or the AWH update will be performed twice for one step when continuing).
+                   It would be best to call this update function from do_md_trajectory_writing but that
+                   would occur after do_force. One would have to divide the update_awh function into one
+                   function applying the AWH force and one doing the AWH bias update. The update AWH
+                   bias function could then be called after do_md_trajectory_writing (then containing
+                   update_awh_history). The checkpointing will in the future probably moved to the start
+                   of the md loop which will rid of this issue. */
+                if (awh && checkpointHandler->isCheckpointingStep() && MAIN(cr_))
+                {
+                    awh->updateHistory(stateGlobal_->awhHistory.get());
+                }
+
+                /* The coordinates (x) are shifted (to get whole molecules)
+                 * in do_force.
+                 * This is parallellized as well, and does communication too.
+                 * Check comments in sim_util.c
+                 */
+                do_force(fpLog_,
+                         cr_,
+                         ms_,
+                         *ir,
+                         mdModulesNotifiers_,
+                         awh.get(),
+                         enforcedRotation_,
+                         imdSession_,
+                         pullWork_,
+                         step,
+                         nrnb_,
+                         wallCycleCounters_,
+                         top_,
+                         state_->box,
+                         state_->x.arrayRefWithPadding(),
+                         state_->v.arrayRefWithPadding().unpaddedArrayRef(),
+                         &state_->hist,
+                         &f.view(),
+                         force_vir,
+                         md,
+                         enerd_,
+                         state_->lambda,
+                         fr_,
+                         *runScheduleWork_,
+                         virtualSites_,
+                         mu_tot,
+                         t,
+                         ed ? ed->getLegacyED() : nullptr,
+                         fr_->longRangeNonbondeds.get(),
+                         ddBalanceRegionHandler);
+            }
+
+            // VV integrators do not need the following velocity half step
+            // if it is the first step after starting from a checkpoint.
+            // That is, the half step is needed on all other steps, and
+            // also the first step when starting from a .tpr file.
+            if (EI_VV(ir->eI))
+            {
+                integrateVVFirstStep(step,
+                                     bFirstStep,
+                                     bInitStep,
+                                     startingBehavior_,
+                                     nstglobalcomm,
+                                     ir,
+                                     fr_,
+                                     cr_,
+                                     state_,
+                                     mdAtoms_->mdatoms(),
+                                     &fcdata,
+                                     &MassQ,
+                                     &vcm,
+                                     enerd_,
+                                     &observablesReducer,
+                                     ekind_,
+                                     gstat,
+                                     &last_ekin,
+                                     bCalcVir,
+                                     total_vir,
+                                     shake_vir,
+                                     force_vir,
+                                     pres,
+                                     do_log,
+                                     do_ene,
+                                     bCalcEner,
+                                     bGStat,
+                                     bStopCM,
+                                     bTrotter,
+                                     bExchanged,
+                                     &bSumEkinhOld,
+                                     &saved_conserved_quantity,
+                                     &f,
+                                     &upd,
+                                     constr_,
+                                     &nullSignaller,
+                                     trotter_seq,
+                                     nrnb_,
+                                     fpLog_,
+                                     wallCycleCounters_);
+                if (virtualSites_ != nullptr && needVirtualVelocitiesThisStep)
+                {
+                    // Positions were calculated earlier
+                    wallcycle_start(wallCycleCounters_, WallCycleCounter::VsiteConstr);
+                    virtualSites_->construct(state_->x, state_->v, state_->box, VSiteOperation::Velocities);
+                    wallcycle_stop(wallCycleCounters_, WallCycleCounter::VsiteConstr);
+                }
+            }
+
+            /* ########  END FIRST UPDATE STEP  ############## */
+            /* ########  If doing VV, we now have v(dt) ###### */
+            if (bDoExpanded)
+            {
+                /* perform extended ensemble sampling in lambda - we don't
+                   actually move to the new state before outputting
+                   statistics, but if performing simulated tempering, we
+                   do update the velocities and the tau_t. */
+                lamnew = ExpandedEnsembleDynamics(fpLog_,
+                                                  *inputRec_,
+                                                  *enerd_,
+                                                  ekind_,
+                                                  state_,
+                                                  &MassQ,
+                                                  state_->fep_state,
+                                                  state_->dfhist,
+                                                  step,
+                                                  state_->v.rvec_array(),
+                                                  md->homenr,
+                                                  md->cTC);
+                /* history is maintained in state->dfhist, but state_global is what is sent to trajectory and log output */
+                if (MAIN(cr_))
+                {
+                    copy_df_history(stateGlobal_->dfhist, state_->dfhist);
+                }
+            }
+
+            // Copy coordinate from the GPU for the output/checkpointing if the update is offloaded
+            // and coordinates have not already been copied for i) search or ii) CPU force tasks.
+            if (useGpuForUpdate && !bNS && !runScheduleWork_->domainWork.haveCpuLocalForceWork
+                && (do_per_step(step, ir->nstxout) || do_per_step(step, ir->nstxout_compressed)
+                    || checkpointHandler->isCheckpointingStep()))
+            {
+                stateGpu->copyCoordinatesFromGpu(state_->x, AtomLocality::Local);
+                stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+            }
+            // Copy velocities if needed for the output/checkpointing.
+            // NOTE: Copy on the search steps is done at the beginning of the step.
+            if (useGpuForUpdate && !bNS
+                && (do_per_step(step, ir->nstvout) || checkpointHandler->isCheckpointingStep()))
+            {
+                stateGpu->copyVelocitiesFromGpu(state_->v, AtomLocality::Local);
+                stateGpu->waitVelocitiesReadyOnHost(AtomLocality::Local);
+            }
+            // Copy forces for the output if the forces were reduced on the GPU (not the case on virial steps)
+            // and update is offloaded hence forces are kept on the GPU for update and have not been
+            // already transferred in do_force().
+            // TODO: There should be an improved, explicit mechanism that ensures this copy is only executed
+            //       when the forces are ready on the GPU -- the same synchronizer should be used as the one
+            //       prior to GPU update.
+            // TODO: When the output flags will be included in step workload, this copy can be combined with the
+            //       copy call in do_force(...).
+            // NOTE: The forces should not be copied here if the vsites are present, since they were modified
+            //       on host after the D2H copy in do_force(...).
+            if (runScheduleWork_->stepWork.useGpuFBufferOps
+                && (simulationWork.useGpuUpdate && !virtualSites_) && do_per_step(step, ir->nstfout))
+            {
+                stateGpu->copyForcesFromGpu(f.view().force(), AtomLocality::Local);
+                stateGpu->waitForcesReadyOnHost(AtomLocality::Local);
+            }
+            /* Now we have the energies and forces corresponding to the
+             * coordinates at time t. We must output all of this before
+             * the update.
+             */
+            const EkindataState ekindataState =
+                    bGStat ? (bSumEkinhOld ? EkindataState::UsedNeedToReduce
+                                           : EkindataState::UsedDoNotNeedToReduce)
+                           : EkindataState::NotUsed;
+            do_md_trajectory_writing(fpLog_,
+                                     cr_,
+                                     nFile_,
+                                     fnm_,
+                                     step,
+                                     step_rel,
+                                     t,
+                                     ir,
+                                     state_,
+                                     stateGlobal_,
+                                     observablesHistory_,
+                                     topGlobal_,
+                                     fr_,
+                                     outf,
+                                     energyOutput,
+                                     ekind_,
+                                     f.view().force(),
+                                     checkpointHandler->isCheckpointingStep(),
+                                     bRerunMD,
+                                     bLastStep,
+                                     mdrunOptions_.writeConfout,
+                                     ekindataState);
+            /* Check if IMD step and do IMD communication, if bIMD is TRUE. */
+            bInteractiveMDstep = imdSession_->run(step, bNS, state_->box, state_->x, t);
+
+            /* kludge -- virial is lost with restart for MTTK NPT control. Must reload (saved earlier). */
+            if (startingBehavior_ != StartingBehavior::NewSimulation && bFirstStep
+                && (inputrecNptTrotter(ir) || inputrecNphTrotter(ir)))
+            {
+                copy_mat(state_->svir_prev, shake_vir);
+                copy_mat(state_->fvir_prev, force_vir);
+            }
+
+            stopHandler->setSignal();
+            resetHandler->setSignal(wallTimeAccounting_);
+
+            if (bGStat || !PAR(cr_))
+            {
+                /* In parallel we only have to check for checkpointing in steps
+                 * where we do global communication,
+                 *  otherwise the other nodes don't know.
+                 */
+                checkpointHandler->setSignal(wallTimeAccounting_);
+            }
+
+            /* #########   START SECOND UPDATE STEP ################# */
+
+            /* at the start of step, randomize or scale the velocities ((if vv. Restriction of
+               Andersen controlled in preprocessing */
+
+            if (ETC_ANDERSEN(ir->etc)) /* keep this outside of update_tcouple because of the extra info required to pass */
+            {
+                gmx_bool bIfRandomize;
+                bIfRandomize = update_randomize_velocities(
+                        ir, step, cr_, md->homenr, md->cTC, md->invmass, state_->v, &upd, constr_);
+                /* if we have constraints, we have to remove the kinetic energy parallel to the bonds */
+                if (constr_ && bIfRandomize)
+                {
+                    constrain_velocities(constr_, do_log || do_ene, step, state_, nullptr, false, nullptr);
+                }
+            }
+            /* Box is changed in update() when we do pressure coupling,
+             * but we should still use the old box for energy corrections and when
+             * writing it to the energy file, so it matches the trajectory files for
+             * the same timestep above. Make a copy in a separate array.
+             */
+            copy_mat(state_->box, lastbox);
+
+            dvdl_constr = 0;
+
+            if (!useGpuForUpdate)
+            {
+                wallcycle_start(wallCycleCounters_, WallCycleCounter::Update);
+            }
+            /* UPDATE PRESSURE VARIABLES IN TROTTER FORMULATION WITH CONSTRAINTS */
+            if (bTrotter)
+            {
+                trotter_update(ir,
+                               step,
+                               ekind_,
+                               state_,
+                               total_vir,
+                               md->homenr,
+                               md->cTC,
+                               md->invmass,
+                               &MassQ,
+                               trotter_seq,
+                               TrotterSequence::Three);
+                /* We can only do Berendsen coupling after we have summed
+                 * the kinetic energy or virial. Since the happens
+                 * in global_state after update, we should only do it at
+                 * step % nstlist = 1 with bGStatEveryStep=FALSE.
+                 */
+            }
+            else
+            {
+                update_tcouple(step, ir, state_, ekind_, &MassQ, md->homenr, md->cTC);
+                update_pcouple_before_coordinates(mdLog_,
+                                                  step,
+                                                  ir->pressureCouplingOptions,
+                                                  ir->deform,
+                                                  ir->delta_t,
+                                                  state_,
+                                                  &pressureCouplingMu,
+                                                  &parrinelloRahmanM);
+            }
+
+            if (EI_VV(ir->eI))
+            {
+                GMX_ASSERT(!useGpuForUpdate, "GPU update is not supported with VVAK integrator.");
+
+                integrateVVSecondStep(step,
+                                      ir,
+                                      fr_,
+                                      cr_,
+                                      state_,
+                                      mdAtoms_->mdatoms(),
+                                      &fcdata,
+                                      &MassQ,
+                                      &vcm,
+                                      pullWork_,
+                                      enerd_,
+                                      &observablesReducer,
+                                      ekind_,
+                                      gstat,
+                                      &dvdl_constr,
+                                      bCalcVir,
+                                      total_vir,
+                                      shake_vir,
+                                      force_vir,
+                                      pres,
+                                      lastbox,
+                                      do_log,
+                                      do_ene,
+                                      bGStat,
+                                      &bSumEkinhOld,
+                                      &f,
+                                      &cbuf,
+                                      &upd,
+                                      constr_,
+                                      &nullSignaller,
+                                      trotter_seq,
+                                      nrnb_,
+                                      wallCycleCounters_);
+            }
+            else
+            {
+                if (useGpuForUpdate)
+                {
+                    // On search steps, update handles to device vectors
+                    // TODO: this condition has redundant / unnecessary clauses
+                    if (bNS && (bFirstStep || haveDDAtomOrdering(*cr_) || bExchanged))
+                    {
+                        integrator->set(stateGpu->getCoordinates(),
+                                        stateGpu->getVelocities(),
+                                        stateGpu->getForces(),
+                                        top_->idef,
+                                        *md);
+
+                        // Copy data to the GPU after buffers might have been reinitialized
+                        /* The velocity copy is redundant if we had Center-of-Mass motion removed on
+                         * the previous step. We don't check that now. */
+                        stateGpu->copyVelocitiesToGpu(state_->v, AtomLocality::Local);
+                    }
+
+                    // Copy x to the GPU unless we have already transferred in do_force().
+                    // We transfer in do_force() if a GPU force task requires x (PME or x buffer ops).
+                    if (!(runScheduleWork_->stepWork.haveGpuPmeOnThisRank
+                          || runScheduleWork_->stepWork.useGpuXBufferOps))
+                    {
+                        stateGpu->copyCoordinatesToGpu(state_->x, AtomLocality::Local);
+                        // Coordinates are later used by the integrator running in the same stream.
+                        stateGpu->consumeCoordinatesCopiedToDeviceEvent(AtomLocality::Local);
+                    }
+
+                    if ((simulationWork.useGpuPme && simulationWork.useCpuPmePpCommunication)
+                        || (!runScheduleWork_->stepWork.useGpuFBufferOps))
+                    {
+                        // The PME forces were recieved to the host, and reduced on the CPU with the
+                        // rest of the forces computed on the GPU, so the final forces have to be
+                        // copied back to the GPU. Or the buffer ops were not offloaded this step,
+                        // so the forces are on the host and have to be copied
+                        stateGpu->copyForcesToGpu(f.view().force(), AtomLocality::Local);
+                    }
+                    const bool doTemperatureScaling =
+                            (ir->etc != TemperatureCoupling::No
+                             && do_per_step(step + ir->nsttcouple - 1, ir->nsttcouple));
+
+                    // This applies Leap-Frog, LINCS and SETTLE in succession
+                    integrator->integrate(
+                            stateGpu->getLocalForcesReadyOnDeviceEvent(
+                                    runScheduleWork_->stepWork, runScheduleWork_->simulationWork),
+                            ir->delta_t,
+                            true,
+                            bCalcVir,
+                            shake_vir,
+                            doTemperatureScaling,
+                            ekind_->tcstat,
+                            doParrinelloRahman,
+                            ir->pressureCouplingOptions.nstpcouple * ir->delta_t,
+                            parrinelloRahmanM);
+                }
+                else
+                {
+                    /* With multiple time stepping we need to do an additional normal
+                     * update step to obtain the virial and dH/dl, as the actual MTS integration
+                     * using an acceleration where the slow forces are multiplied by mtsFactor.
+                     * Using that acceleration would result in a virial with the slow
+                     * force contribution would be a factor mtsFactor too large.
+                     */
+                    const bool separateVirialConstraining =
+                            (simulationWork.useMts && (bCalcVir || computeDHDL) && constr_ != nullptr);
+                    if (separateVirialConstraining)
+                    {
+                        upd.update_for_constraint_virial(*ir,
+                                                         md->homenr,
+                                                         md->havePartiallyFrozenAtoms,
+                                                         md->invmass,
+                                                         md->invMassPerDim,
+                                                         *state_,
+                                                         f.view().forceWithPadding(),
+                                                         *ekind_);
+
+                        // Call apply() directly so we can avoid constraining the velocities
+                        constr_->apply(false,
+                                       step,
+                                       1,
+                                       1.0,
+                                       state_->x.arrayRefWithPadding(),
+                                       upd.xp()->arrayRefWithPadding(),
+                                       {},
+                                       state_->box,
+                                       state_->lambda[FreeEnergyPerturbationCouplingType::Bonded],
+                                       &dvdl_constr,
+                                       {},
+                                       bCalcVir,
+                                       shake_vir,
+                                       ConstraintVariable::Positions);
+                    }
+
+                    ArrayRefWithPadding<const RVec> forceCombined =
+                            (simulationWork.useMts && step % ir->mtsLevels[1].stepFactor == 0)
+                                    ? f.view().forceMtsCombinedWithPadding()
+                                    : f.view().forceWithPadding();
+                    upd.update_coords(*ir,
+                                      step,
+                                      md->homenr,
+                                      md->havePartiallyFrozenAtoms,
+                                      md->ptype,
+                                      md->invmass,
+                                      md->invMassPerDim,
+                                      state_,
+                                      forceCombined,
+                                      &fcdata,
+                                      ekind_,
+                                      parrinelloRahmanM,
+                                      etrtPOSITION,
+                                      cr_,
+                                      constr_ != nullptr);
+
+                    wallcycle_stop(wallCycleCounters_, WallCycleCounter::Update);
+
+                    constrain_coordinates(constr_,
+                                          do_log || do_ene,
+                                          step,
+                                          state_,
+                                          upd.xp()->arrayRefWithPadding(),
+                                          separateVirialConstraining ? nullptr : &dvdl_constr,
+                                          bCalcVir && !separateVirialConstraining,
+                                          shake_vir);
+
+                    upd.update_sd_second_half(*ir,
+                                              step,
+                                              &dvdl_constr,
+                                              md->homenr,
+                                              md->ptype,
+                                              md->invmass,
+                                              state_,
+                                              cr_,
+                                              nrnb_,
+                                              wallCycleCounters_,
+                                              constr_,
+                                              do_log,
+                                              do_ene);
+                    upd.finish_update(*ir,
+                                      md->havePartiallyFrozenAtoms,
+                                      md->homenr,
+                                      state_,
+                                      wallCycleCounters_,
+                                      constr_ != nullptr);
+                }
+
+                if (ir->bPull && ir->pull->bSetPbcRefToPrevStepCOM)
+                {
+                    updatePrevStepPullCom(pullWork_, state_->pull_com_prev_step);
+                }
+
+                enerd_->term[F_DVDL_CONSTR] += dvdl_constr;
+            }
+        }
+
+        if (simulationWork.useMdGpuGraph)
+        {
+            GMX_ASSERT((mdGraph != nullptr), "MD GPU graph does not exist.");
+            if (mdGraph->graphIsCapturingThisStep())
+            {
+                mdGraph->endRecord();
+                // Force graph reinstantiation (instead of graph exec
+                // update): with PME tuning, since the GPU kernels
+                // chosen by the FFT library can vary with grid size;
+                // or with an odd nstlist, since the odd/even step
+                // pruning pattern will change
+                bool forceGraphReinstantiation =
+                        pme_loadbal_is_active(pme_loadbal) || ((ir->nstlist % 2) == 1);
+                mdGraph->createExecutableGraph(forceGraphReinstantiation);
+            }
+            if (mdGraph->useGraphThisStep())
+            {
+                mdGraph->launchGraphMdStep(integrator->xUpdatedOnDeviceEvent());
+            }
+            if (bNS)
+            {
+                // TODO: merge disableForDomainIfAnyPpRankHasCpuForces() back into reset() when
+                // domainWork initialization is moved out of do_force().
+                fr_->mdGraph[MdGraphEvenOrOddStep::EvenStep]->disableForDomainIfAnyPpRankHasCpuForces(
+                        runScheduleWork_->domainWork.haveCpuLocalForceWork);
+                fr_->mdGraph[MdGraphEvenOrOddStep::OddStep]->disableForDomainIfAnyPpRankHasCpuForces(
+                        runScheduleWork_->domainWork.haveCpuLocalForceWork);
+            }
+            usedMdGpuGraphLastStep = mdGraph->useGraphThisStep();
+        }
+
+        /* ############## IF NOT VV, Calculate globals HERE  ############ */
+        /* With Leap-Frog we can skip compute_globals at
+         * non-communication steps, but we need to calculate
+         * the kinetic energy one step before communication.
+         */
+        {
+            // Organize to do inter-simulation signalling on steps if
+            // and when algorithms require it.
+            const bool doInterSimSignal = (simulationsShareState && do_per_step(step, nstSignalComm));
+
+            if (useGpuForUpdate)
+            {
+                const bool coordinatesRequiredForStopCM =
+                        bStopCM && (bGStat || needHalfStepKineticEnergy || doInterSimSignal)
+                        && !EI_VV(ir->eI);
+
+                // Copy coordinates when needed to stop the CM motion or for replica exchange
+                if (coordinatesRequiredForStopCM || bDoReplEx)
+                {
+                    stateGpu->copyCoordinatesFromGpu(state_->x, AtomLocality::Local);
+                    stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+                }
+
+                // Copy velocities back to the host if:
+                // - Globals are computed this step (includes the energy output steps).
+                // - Temperature is needed for the next step.
+                // - This is a replica exchange step (even though we will only need
+                //     the velocities if an exchange succeeds)
+                if (bGStat || needHalfStepKineticEnergy || bDoReplEx)
+                {
+                    stateGpu->copyVelocitiesFromGpu(state_->v, AtomLocality::Local);
+                    stateGpu->waitVelocitiesReadyOnHost(AtomLocality::Local);
+                }
+            }
+
+            if (bGStat || needHalfStepKineticEnergy || doInterSimSignal)
+            {
+                // Since we're already communicating at this step, we
+                // can propagate intra-simulation signals. Note that
+                // check_nstglobalcomm has the responsibility for
+                // choosing the value of nstglobalcomm that is one way
+                // bGStat becomes true, so we can't get into a
+                // situation where e.g. checkpointing can't be
+                // signalled.
+                bool doIntraSimSignal = true;
+                SimulationSignaller signaller(&signals, cr_, ms_, doInterSimSignal, doIntraSimSignal);
+
+                compute_globals(gstat,
+                                cr_,
+                                ir,
+                                fr_,
+                                ekind_,
+                                makeConstArrayRef(state_->x),
+                                makeConstArrayRef(state_->v),
+                                state_->box,
+                                md,
+                                nrnb_,
+                                &vcm,
+                                wallCycleCounters_,
+                                enerd_,
+                                force_vir,
+                                shake_vir,
+                                total_vir,
+                                pres,
+                                &signaller,
+                                lastbox,
+                                &bSumEkinhOld,
+                                (bGStat ? CGLO_GSTAT : 0) | (!EI_VV(ir->eI) && bCalcEner ? CGLO_ENERGY : 0)
+                                        | (!EI_VV(ir->eI) && bStopCM ? CGLO_STOPCM : 0)
+                                        | (!EI_VV(ir->eI) ? CGLO_TEMPERATURE : 0)
+                                        | (!EI_VV(ir->eI) ? CGLO_PRESSURE : 0) | CGLO_CONSTRAINT,
+                                step,
+                                &observablesReducer);
+                if (!EI_VV(ir->eI) && bStopCM)
+                {
+                    process_and_stopcm_grp(
+                            fpLog_, &vcm, *md, makeArrayRef(state_->x), makeArrayRef(state_->v));
+                    inc_nrnb(nrnb_, eNR_STOPCM, md->homenr);
+
+                    // TODO: The special case of removing CM motion should be dealt more gracefully
+                    if (useGpuForUpdate)
+                    {
+                        // Issue #3988, #4106.
+                        stateGpu->resetCoordinatesCopiedToDeviceEvent(AtomLocality::Local);
+                        stateGpu->copyCoordinatesToGpu(state_->x, AtomLocality::Local);
+                        // Here we block until the H2D copy completes because event sync with the
+                        // force kernels that use the coordinates on the next steps is not implemented
+                        // (not because of a race on state->x being modified on the CPU while H2D is in progress).
+                        stateGpu->waitCoordinatesCopiedToDevice(AtomLocality::Local);
+                        // If the COM removal changed the velocities on the CPU, this has to be accounted for.
+                        if (vcm.mode != ComRemovalAlgorithm::No)
+                        {
+                            stateGpu->copyVelocitiesToGpu(state_->v, AtomLocality::Local);
+                        }
+                    }
+                }
+            }
+        }
+
+        /* #############  END CALC EKIN AND PRESSURE ################# */
+
+        /* Note: this is OK, but there are some numerical precision issues with using the convergence of
+           the virial that should probably be addressed eventually. state->veta has better properies,
+           but what we actually need entering the new cycle is the new shake_vir value. Ideally, we could
+           generate the new shake_vir, but test the veta value for convergence.  This will take some thought. */
+
+        if (ir->efep != FreeEnergyPerturbationType::No && !EI_VV(ir->eI))
+        {
+            /* Sum up the foreign energy and dK/dl terms for md and sd.
+               Currently done every step so that dH/dl is correct in the .edr */
+            accumulateKineticLambdaComponents(enerd_, state_->lambda, *ir->fepvals);
+        }
+
+        const real currentSystemRefT =
+                (haveEnsembleTemperature(*ir) ? ekind_->currentEnsembleTemperature() : 0.0_real);
+        const bool scaleCoordinates = !useGpuForUpdate || bDoReplEx;
+        update_pcouple_after_coordinates(fpLog_,
+                                         step,
+                                         ir->pressureCouplingOptions,
+                                         ir->ld_seed,
+                                         currentSystemRefT,
+                                         ir->opts.nFreeze,
+                                         ir->deform,
+                                         ir->delta_t,
+                                         md->homenr,
+                                         md->cFREEZE,
+                                         pres,
+                                         force_vir,
+                                         shake_vir,
+                                         &pressureCouplingMu,
+                                         state_,
+                                         nrnb_,
+                                         upd.deform(),
+                                         scaleCoordinates);
+
+        const bool doBerendsenPressureCoupling =
+                (inputRec_->pressureCouplingOptions.epc == PressureCoupling::Berendsen
+                 && do_per_step(step, inputRec_->pressureCouplingOptions.nstpcouple));
+        const bool doCRescalePressureCoupling =
+                (inputRec_->pressureCouplingOptions.epc == PressureCoupling::CRescale
+                 && do_per_step(step, inputRec_->pressureCouplingOptions.nstpcouple));
+        if (useGpuForUpdate
+            && (doBerendsenPressureCoupling || doCRescalePressureCoupling || doParrinelloRahman))
+        {
+            integrator->scaleCoordinates(pressureCouplingMu);
+            if (doCRescalePressureCoupling)
+            {
+                integrator->scaleVelocities(invertBoxMatrix(pressureCouplingMu));
+            }
+            integrator->setPbc(PbcType::Xyz, state_->box);
+        }
+
+        /* ################# END UPDATE STEP 2 ################# */
+        /* #### We now have r(t+dt) and v(t+dt/2)  ############# */
+
+        /* The coordinates (x) were unshifted in update */
+        if (!bGStat)
+        {
+            /* We will not sum ekinh_old,
+             * so signal that we still have to do it.
+             */
+            bSumEkinhOld = TRUE;
+        }
+
+        if (bCalcEner)
+        {
+            /* #########  BEGIN PREPARING EDR OUTPUT  ###########  */
+
+            /* use the directly determined last velocity, not actually the averaged half steps */
+            if (bTrotter && ir->eI == IntegrationAlgorithm::VV)
+            {
+                enerd_->term[F_EKIN] = last_ekin;
+            }
+            enerd_->term[F_ETOT] = enerd_->term[F_EPOT] + enerd_->term[F_EKIN];
+
+            if (integratorHasConservedEnergyQuantity(ir))
+            {
+                if (EI_VV(ir->eI))
+                {
+                    enerd_->term[F_ECONSERVED] = enerd_->term[F_ETOT] + saved_conserved_quantity;
+                }
+                else
+                {
+                    enerd_->term[F_ECONSERVED] =
+                            enerd_->term[F_ETOT]
+                            + NPT_energy(ir->pressureCouplingOptions,
+                                         ir->etc,
+                                         gmx::constArrayRefFromArray(ir->opts.nrdf, ir->opts.ngtc),
+                                         *ekind_,
+                                         inputrecNvtTrotter(ir) || inputrecNptTrotter(ir),
+                                         state_,
+                                         &MassQ);
+                }
+            }
+            /* #########  END PREPARING EDR OUTPUT  ###########  */
+        }
+
+        /* Output stuff */
+        if (MAIN(cr_))
+        {
+            if (fpLog_ && do_log && bDoExpanded)
+            {
+                /* only needed if doing expanded ensemble */
+                PrintFreeEnergyInfoToFile(fpLog_,
+                                          ir->fepvals.get(),
+                                          ir->expandedvals.get(),
+                                          ir->bSimTemp ? ir->simtempvals.get() : nullptr,
+                                          stateGlobal_->dfhist,
+                                          state_->fep_state,
+                                          ir->nstlog,
+                                          step);
+            }
+            if (bCalcEner)
+            {
+                const bool outputDHDL = (computeDHDL && do_per_step(step, ir->fepvals->nstdhdl));
+
+                energyOutput.addDataAtEnergyStep(outputDHDL,
+                                                 bCalcEnerStep,
+                                                 t,
+                                                 md->tmass,
+                                                 enerd_,
+                                                 ir->fepvals.get(),
+                                                 lastbox,
+                                                 PTCouplingArrays{ state_->boxv,
+                                                                   state_->nosehoover_xi,
+                                                                   state_->nosehoover_vxi,
+                                                                   state_->nhpres_xi,
+                                                                   state_->nhpres_vxi },
+                                                 state_->fep_state,
+                                                 total_vir,
+                                                 pres,
+                                                 ekind_,
+                                                 mu_tot,
+                                                 constr_);
+            }
+            else
+            {
+                energyOutput.recordNonEnergyStep();
+            }
+
+            gmx_bool do_dr = do_per_step(step, ir->nstdisreout);
+            gmx_bool do_or = do_per_step(step, ir->nstorireout);
+
+            if (doSimulatedAnnealing)
+            {
+                gmx::EnergyOutput::printAnnealingTemperatures(
+                        do_log ? fpLog_ : nullptr, *groups, ir->opts, *ekind_);
+            }
+            if (do_log || do_ene || do_dr || do_or)
+            {
+                energyOutput.printStepToEnergyFile(mdoutf_get_fp_ene(outf),
+                                                   do_ene,
+                                                   do_dr,
+                                                   do_or,
+                                                   do_log ? fpLog_ : nullptr,
+                                                   step,
+                                                   t,
+                                                   fr_->fcdata.get(),
+                                                   awh.get());
+            }
+            if (do_log && ((ir->bDoAwh && awh->hasFepLambdaDimension()) || ir->fepvals->delta_lambda != 0))
+            {
+                const bool isInitialOutput = false;
+                printLambdaStateToLog(fpLog_, state_->lambda, isInitialOutput);
+            }
+
+            if (ir->bPull)
+            {
+                pull_print_output(pullWork_, step, t);
+            }
+
+            if (do_per_step(step, ir->nstlog))
+            {
+                if (fflush(fpLog_) != 0)
+                {
+                    gmx_fatal(FARGS, "Cannot flush logfile - maybe you are out of disk space?");
+                }
+            }
+        }
+        if (bDoExpanded)
+        {
+            /* Have to do this part _after_ outputting the logfile and the edr file */
+            /* Gets written into the state at the beginning of next loop*/
+            state_->fep_state = lamnew;
+        }
+        else if (ir->bDoAwh && awh->needForeignEnergyDifferences(step))
+        {
+            state_->fep_state = awh->fepLambdaState();
+        }
+        /* Print the remaining wall clock time for the run */
+        if (isMainSimMainRank(ms_, MAIN(cr_)) && (do_verbose || gmx_got_usr_signal()) && !bPMETunePrinting)
+        {
+            if (shellfc)
+            {
+                fprintf(stderr, "\n");
+            }
+            print_time(stderr, wallTimeAccounting_, step, ir, cr_);
+        }
+
+        /* Ion/water position swapping.
+         * Not done in last step since trajectory writing happens before this call
+         * in the MD loop and exchanges would be lost anyway. */
+        bNeedRepartition = FALSE;
+        if ((ir->eSwapCoords != SwapType::No) && (step > 0) && !bLastStep
+            && do_per_step(step, ir->swap->nstswap))
+        {
+            bNeedRepartition = do_swapcoords(cr_,
+                                             step,
+                                             t,
+                                             ir,
+                                             swap_,
+                                             wallCycleCounters_,
+                                             as_rvec_array(state_->x.data()),
+                                             state_->box,
+                                             MAIN(cr_) && mdrunOptions_.verbose,
+                                             bRerunMD);
+
+            if (bNeedRepartition && haveDDAtomOrdering(*cr_))
+            {
+                dd_collect_state(cr_->dd, state_, stateGlobal_);
+            }
+        }
+
+        /* Replica exchange */
+        bExchanged = FALSE;
+        if (bDoReplEx)
+        {
+            bExchanged =
+                    replica_exchange(fpLog_, cr_, ms_, repl_ex, stateGlobal_, enerd_, state_, step, t);
+        }
+
+        if ((bExchanged || bNeedRepartition) && haveDDAtomOrdering(*cr_))
+        {
+            dd_partition_system(fpLog_,
+                                mdLog_,
+                                step,
+                                cr_,
+                                TRUE,
+                                stateGlobal_,
+                                topGlobal_,
+                                *ir,
+                                mdModulesNotifiers_,
+                                imdSession_,
+                                pullWork_,
+                                state_,
+                                &f,
+                                mdAtoms_,
+                                top_,
+                                fr_,
+                                virtualSites_,
+                                constr_,
+                                nrnb_,
+                                wallCycleCounters_,
+                                FALSE);
+            upd.updateAfterPartition(state_->numAtoms(), md->cFREEZE, md->cTC, md->cACC);
+            fr_->longRangeNonbondeds->updateAfterPartition(*md);
+        }
+
+        bFirstStep = FALSE;
+        bInitStep  = FALSE;
+
+        /* #######  SET VARIABLES FOR NEXT ITERATION IF THEY STILL NEED IT ###### */
+        /* With all integrators, except VV, we need to retain the pressure
+         * at the current step for coupling at the next step.
+         */
+        if (state_->hasEntry(StateEntry::PressurePrevious)
+            && (bGStatEveryStep
+                || (ir->pressureCouplingOptions.nstpcouple > 0
+                    && step % ir->pressureCouplingOptions.nstpcouple == 0)))
+        {
+            /* Store the pressure in t_state for pressure coupling
+             * at the next MD step.
+             */
+            copy_mat(pres, state_->pres_prev);
+        }
+
+        /* #######  END SET VARIABLES FOR NEXT ITERATION ###### */
+
+        if ((membed_ != nullptr) && (!bLastStep))
+        {
+            rescale_membed(step_rel, membed_, as_rvec_array(stateGlobal_->x.data()));
+        }
+
+        const double cycles = wallcycle_stop(wallCycleCounters_, WallCycleCounter::Step);
+        if (haveDDAtomOrdering(*cr_) && wallCycleCounters_)
+        {
+            dd_cycles_add(cr_->dd, cycles, ddCyclStep);
+        }
+
+        /* increase the MD step number */
+        step++;
+        step_rel++;
+        observablesReducer.markAsReadyToReduce();
+
+#if GMX_FAHCORE
+        if (MAIN(cr))
+        {
+            fcReportProgress(ir->nsteps + ir->init_step, step);
+        }
+#endif
+
+        resetHandler->resetCounters(
+                step, step_rel, mdLog_, fpLog_, cr_, fr_->nbv.get(), nrnb_, fr_->pmedata, pme_loadbal, wallCycleCounters_, wallTimeAccounting_);
+
+        /* If bIMD is TRUE, the main updates the IMD energy record and sends positions to VMD client */
+        imdSession_->updateEnergyRecordAndSendPositionsAndEnergies(bInteractiveMDstep, step, bCalcEner);
+
+        // any run that uses GPUs must be at least offloading nonbondeds
+        const bool usingGpu = simulationWork.useGpuNonbonded;
+        if (usingGpu)
+        {
+            // ensure that GPU errors do not propagate between MD steps
+            checkPendingDeviceErrorBetweenSteps();
+        }
+    }
+    /* End of main MD loop */
+
+    /* Closing TNG files can include compressing data. Therefore it is good to do that
+     * before stopping the time measurements. */
+    mdoutf_tng_close(outf);
+
+    /* Stop measuring walltime */
+    walltime_accounting_end_time(wallTimeAccounting_);
+
+    if (simulationWork.haveSeparatePmeRank)
+    {
+        /* Tell the PME only node to finish */
+        gmx_pme_send_finish(cr_);
+    }
+
+    // This is to free PP ranks gpuhaloexchange symmetric buffer `d_recvBuf_`
+    // as calling its destruction happens very late causing hang as this is a collective
+    // call, the PME side free of the same buffer happens quite early.
+    if (PAR(cr_) && simulationWork.useNvshmem)
+    {
+        destroyGpuHaloExchangeNvshmemBuf(*cr_);
+    }
+
+    if (MAIN(cr_))
+    {
+        if (ir->nstcalcenergy > 0)
+        {
+            energyOutput.printEnergyConservation(fpLog_, ir->simulation_part, EI_MD(ir->eI));
+
+            gmx::EnergyOutput::printAnnealingTemperatures(fpLog_, *groups, ir->opts, *ekind_);
+            energyOutput.printAverages(fpLog_, groups);
+        }
+    }
+    done_mdoutf(outf);
+
+    if (bPMETune)
+    {
+        pme_loadbal_done(pme_loadbal, fpLog_, mdLog_, fr_->nbv->useGpu());
+    }
+
+    done_shellfc(fpLog_, shellfc, step_rel);
+
+    if (useReplicaExchange && MAIN(cr_))
+    {
+        print_replica_exchange_statistics(fpLog_, repl_ex);
+    }
+
+    walltime_accounting_set_nsteps_done(wallTimeAccounting_, step_rel);
+
+    global_stat_destroy(gstat);
+}

--- a/patches/gromacs-2025.0.diff/src/gromacs/mdrun/md.cpp.preplumed
+++ b/patches/gromacs-2025.0.diff/src/gromacs/mdrun/md.cpp.preplumed
@@ -1,0 +1,2218 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 1991- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ *
+ * \brief Implements the integrator for normal molecular dynamics simulations
+ *
+ * \author David van der Spoel <david.vanderspoel@icm.uu.se>
+ * \ingroup module_mdrun
+ */
+#include "gmxpre.h"
+
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gromacs/applied_forces/awh/awh.h"
+#include "gromacs/applied_forces/awh/read_params.h"
+#include "gromacs/commandline/filenm.h"
+#include "gromacs/compat/pointers.h"
+#include "gromacs/domdec/collect.h"
+#include "gromacs/domdec/dlbtiming.h"
+#include "gromacs/domdec/domdec.h"
+#include "gromacs/domdec/domdec_network.h"
+#include "gromacs/domdec/domdec_struct.h"
+#include "gromacs/domdec/gpuhaloexchange.h"
+#include "gromacs/domdec/localtopologychecker.h"
+#include "gromacs/domdec/mdsetup.h"
+#include "gromacs/domdec/partition.h"
+#include "gromacs/essentialdynamics/edsam.h"
+#include "gromacs/ewald/pme_load_balancing.h"
+#include "gromacs/ewald/pme_pp.h"
+#include "gromacs/fileio/enxio.h"
+#include "gromacs/fileio/trxio.h"
+#include "gromacs/gmxlib/network.h"
+#include "gromacs/gmxlib/nrnb.h"
+#include "gromacs/gpu_utils/device_stream_manager.h"
+#include "gromacs/gpu_utils/gpu_utils.h"
+#include "gromacs/gpu_utils/hostallocator.h"
+#include "gromacs/imd/imd.h"
+#include "gromacs/listed_forces/listed_forces.h"
+#include "gromacs/listed_forces/listed_forces_gpu.h"
+#include "gromacs/math/arrayrefwithpadding.h"
+#include "gromacs/math/boxmatrix.h"
+#include "gromacs/math/functions.h"
+#include "gromacs/math/matrix.h"
+#include "gromacs/math/paddedvector.h"
+#include "gromacs/math/vec.h"
+#include "gromacs/math/vectypes.h"
+#include "gromacs/mdlib/checkpointhandler.h"
+#include "gromacs/mdlib/compute_io.h"
+#include "gromacs/mdlib/constr.h"
+#include "gromacs/mdlib/coupling.h"
+#include "gromacs/mdlib/ebin.h"
+#include "gromacs/mdlib/enerdata_utils.h"
+#include "gromacs/mdlib/energyoutput.h"
+#include "gromacs/mdlib/expanded.h"
+#include "gromacs/mdlib/force.h"
+#include "gromacs/mdlib/force_flags.h"
+#include "gromacs/mdlib/forcerec.h"
+#include "gromacs/mdlib/freeenergyparameters.h"
+#include "gromacs/mdlib/md_support.h"
+#include "gromacs/mdlib/mdatoms.h"
+#include "gromacs/mdlib/mdgraph_gpu.h"
+#include "gromacs/mdlib/mdoutf.h"
+#include "gromacs/mdlib/membed.h"
+#include "gromacs/mdlib/resethandler.h"
+#include "gromacs/mdlib/sighandler.h"
+#include "gromacs/mdlib/simulationsignal.h"
+#include "gromacs/mdlib/stat.h"
+#include "gromacs/mdlib/stophandler.h"
+#include "gromacs/mdlib/tgroup.h"
+#include "gromacs/mdlib/trajectory_writing.h"
+#include "gromacs/mdlib/update.h"
+#include "gromacs/mdlib/update_constrain_gpu.h"
+#include "gromacs/mdlib/update_vv.h"
+#include "gromacs/mdlib/vcm.h"
+#include "gromacs/mdlib/vsite.h"
+#include "gromacs/mdrunutility/freeenergy.h"
+#include "gromacs/mdrunutility/handlerestart.h"
+#include "gromacs/mdrunutility/mdmodulesnotifiers.h"
+#include "gromacs/mdrunutility/multisim.h"
+#include "gromacs/mdrunutility/printtime.h"
+#include "gromacs/mdtypes/awh_history.h"
+#include "gromacs/mdtypes/awh_params.h"
+#include "gromacs/mdtypes/commrec.h"
+#include "gromacs/mdtypes/df_history.h"
+#include "gromacs/mdtypes/enerdata.h"
+#include "gromacs/mdtypes/energyhistory.h"
+#include "gromacs/mdtypes/fcdata.h"
+#include "gromacs/mdtypes/forcebuffers.h"
+#include "gromacs/mdtypes/forcerec.h"
+#include "gromacs/mdtypes/group.h"
+#include "gromacs/mdtypes/iforceprovider.h"
+#include "gromacs/mdtypes/inputrec.h"
+#include "gromacs/mdtypes/interaction_const.h"
+#include "gromacs/mdtypes/locality.h"
+#include "gromacs/mdtypes/md_enums.h"
+#include "gromacs/mdtypes/mdatom.h"
+#include "gromacs/mdtypes/mdrunoptions.h"
+#include "gromacs/mdtypes/multipletimestepping.h"
+#include "gromacs/mdtypes/observableshistory.h"
+#include "gromacs/mdtypes/observablesreducer.h"
+#include "gromacs/mdtypes/pull_params.h"
+#include "gromacs/mdtypes/pullhistory.h"
+#include "gromacs/mdtypes/simulation_workload.h"
+#include "gromacs/mdtypes/state.h"
+#include "gromacs/mdtypes/state_propagator_data_gpu.h"
+#include "gromacs/modularsimulator/energydata.h"
+#include "gromacs/nbnxm/gpu_data_mgmt.h"
+#include "gromacs/nbnxm/nbnxm.h"
+#include "gromacs/pbcutil/pbc.h"
+#include "gromacs/pulling/output.h"
+#include "gromacs/pulling/pull.h"
+#include "gromacs/swap/swapcoords.h"
+#include "gromacs/taskassignment/include/gromacs/taskassignment/decidesimulationworkload.h"
+#include "gromacs/timing/wallcycle.h"
+#include "gromacs/timing/walltime_accounting.h"
+#include "gromacs/topology/atoms.h"
+#include "gromacs/topology/idef.h"
+#include "gromacs/topology/ifunc.h"
+#include "gromacs/topology/mtop_util.h"
+#include "gromacs/topology/topology.h"
+#include "gromacs/topology/topology_enums.h"
+#include "gromacs/trajectory/trajectoryframe.h"
+#include "gromacs/utility/arrayref.h"
+#include "gromacs/utility/basedefinitions.h"
+#include "gromacs/utility/cstringutil.h"
+#include "gromacs/utility/enumerationhelpers.h"
+#include "gromacs/utility/fatalerror.h"
+#include "gromacs/utility/gmxassert.h"
+#include "gromacs/utility/logger.h"
+#include "gromacs/utility/real.h"
+#include "gromacs/utility/smalloc.h"
+
+#include "legacysimulator.h"
+#include "replicaexchange.h"
+#include "shellfc.h"
+
+struct gmx_mdoutf;
+struct gmx_shellfc_t;
+struct pme_load_balancing_t;
+
+using gmx::SimulationSignaller;
+
+void gmx::LegacySimulator::do_md()
+{
+    // TODO Historically, the EM and MD "integrators" used different
+    // names for the t_inputrec *parameter, but these must have the
+    // same name, now that it's a member of a struct. We use this ir
+    // alias to avoid a large ripple of nearly useless changes.
+    // t_inputrec is being replaced by IMdpOptionsProvider, so this
+    // will go away eventually.
+    const t_inputrec* ir = inputRec_;
+
+    const double t0  = ir->init_t;
+    gmx_bool     bNS = FALSE, bFirstStep, bInitStep, bLastStep = FALSE;
+    gmx_bool     bDoExpanded = FALSE;
+    tensor    force_vir = { { 0 } }, shake_vir = { { 0 } }, total_vir = { { 0 } }, pres = { { 0 } };
+    rvec      mu_tot;
+    Matrix3x3 pressureCouplingMu{ { 0. } }, parrinelloRahmanM{ { 0. } };
+    gmx_repl_ex_t     repl_ex = nullptr;
+    gmx_bool          bSumEkinhOld, bDoReplEx, bExchanged, bNeedRepartition;
+    real              dvdl_constr;
+    std::vector<RVec> cbuf;
+    matrix            lastbox;
+    int               lamnew = 0;
+    /* for FEP */
+    real      saved_conserved_quantity = 0;
+    real      last_ekin                = 0;
+    t_extmass MassQ;
+    char      sbuf[STEPSTRSIZE], sbuf2[STEPSTRSIZE];
+
+    /* PME load balancing data for GPU kernels */
+    gmx_bool bPMETune         = FALSE;
+    gmx_bool bPMETunePrinting = FALSE;
+
+    bool bInteractiveMDstep = false;
+
+    SimulationSignals signals;
+    // Most global communication stages don't propagate mdrun
+    // signals, and will use this object to achieve that.
+    SimulationSignaller nullSignaller(nullptr, nullptr, nullptr, false, false);
+
+    if (!mdrunOptions_.writeConfout)
+    {
+        // This is on by default, and the main known use case for
+        // turning it off is for convenience in benchmarking, which is
+        // something that should not show up in the general user
+        // interface.
+        GMX_LOG(mdLog_.info)
+                .asParagraph()
+                .appendText(
+                        "The -noconfout functionality is deprecated, and may be removed in a "
+                        "future version.");
+    }
+
+    /* md-vv uses averaged full step velocities for T-control
+       md-vv-avek uses averaged half step velocities for T-control (but full step ekin for P control)
+       md uses averaged half step kinetic energies to determine temperature unless defined otherwise by GMX_EKIN_AVE_VEL; */
+    const bool bTrotter =
+            (EI_VV(ir->eI)
+             && (inputrecNptTrotter(ir) || inputrecNphTrotter(ir) || inputrecNvtTrotter(ir)));
+
+    const bool bRerunMD = false;
+
+    const int  nstglobalcomm   = computeGlobalCommunicationPeriod(mdLog_, ir, cr_);
+    const bool bGStatEveryStep = (nstglobalcomm == 1);
+
+    const SimulationGroups* groups = &topGlobal_.groups;
+
+    std::unique_ptr<EssentialDynamics> ed = nullptr;
+    if (opt2bSet("-ei", nFile_, fnm_))
+    {
+        /* Initialize essential dynamics sampling */
+        ed = init_edsam(mdLog_,
+                        opt2fn_null("-ei", nFile_, fnm_),
+                        opt2fn("-eo", nFile_, fnm_),
+                        topGlobal_,
+                        *ir,
+                        cr_,
+                        constr_,
+                        stateGlobal_,
+                        observablesHistory_,
+                        oenv_,
+                        startingBehavior_);
+    }
+    else if (observablesHistory_->edsamHistory)
+    {
+        gmx_fatal(FARGS,
+                  "The checkpoint is from a run with essential dynamics sampling, "
+                  "but the current run did not specify the -ei option. "
+                  "Either specify the -ei option to mdrun, or do not use this checkpoint file.");
+    }
+
+    int*                fep_state = MAIN(cr_) ? &stateGlobal_->fep_state : nullptr;
+    gmx::ArrayRef<real> lambda    = MAIN(cr_) ? stateGlobal_->lambda : gmx::ArrayRef<real>();
+    initialize_lambdas(
+            fpLog_, ir->efep, ir->bSimTemp, *ir->fepvals, ir->simtempvals->temperatures, ekind_, MAIN(cr_), fep_state, lambda);
+    Update upd(*ir, *ekind_, deform_);
+
+    // Simulated annealing updates the reference temperature.
+    const bool doSimulatedAnnealing = initSimulatedAnnealing(*ir, ekind_, &upd);
+
+    const bool useReplicaExchange = (replExParams_.exchangeInterval > 0);
+
+    t_fcdata& fcdata = *fr_->fcdata;
+
+    // We should let all special algorithms use MDModules, so notifiers tells if we need to share
+    bool simulationsShareState =
+            (ms_ != nullptr)
+            && mdModulesNotifiers_.simulationSetupNotifier_.haveSubscribers<const gmx_multisim_t*>();
+    bool simulationsShareHamiltonian = false;
+    int  nstSignalComm               = nstglobalcomm;
+    {
+        // TODO This implementation of ensemble orientation restraints is nasty because
+        // a user can't just do multi-sim with single-sim orientation restraints.
+        bool usingEnsembleRestraints =
+                (fcdata.disres->nsystems > 1) || ((ms_ != nullptr) && fcdata.orires);
+        bool awhUsesMultiSim = (ir->bDoAwh && ir->awhParams->shareBiasMultisim() && (ms_ != nullptr));
+
+        // Replica exchange, ensemble restraints and AWH need all
+        // simulations to remain synchronized, so they need
+        // checkpoints and stop conditions to act on the same step, so
+        // the propagation of such signals must take place between
+        // simulations, not just within simulations.
+        // TODO: Make algorithm initializers set these flags.
+        simulationsShareState = simulationsShareState || useReplicaExchange
+                                || usingEnsembleRestraints || awhUsesMultiSim;
+
+        // With AWH with bias sharing each simulation uses an non-shared, but identical, Hamiltonian
+        simulationsShareHamiltonian = useReplicaExchange || usingEnsembleRestraints;
+
+        if (simulationsShareState)
+        {
+            // Inter-simulation signal communication does not need to happen
+            // often, so we use a minimum of 200 steps to reduce overhead.
+            const int c_minimumInterSimulationSignallingInterval = 200;
+            nstSignalComm = gmx::divideRoundUp(c_minimumInterSimulationSignallingInterval, nstglobalcomm)
+                            * nstglobalcomm;
+        }
+    }
+
+    if (startingBehavior_ != StartingBehavior::RestartWithAppending)
+    {
+        pleaseCiteCouplingAlgorithms(fpLog_, *ir);
+    }
+    gmx_mdoutf*       outf = init_mdoutf(fpLog_,
+                                   nFile_,
+                                   fnm_,
+                                   mdrunOptions_,
+                                   cr_,
+                                   outputProvider_,
+                                   mdModulesNotifiers_,
+                                   ir,
+                                   topGlobal_,
+                                   oenv_,
+                                   wallCycleCounters_,
+                                   startingBehavior_,
+                                   simulationsShareState,
+                                   ms_);
+    gmx::EnergyOutput energyOutput(mdoutf_get_fp_ene(outf),
+                                   topGlobal_,
+                                   *ir,
+                                   pullWork_,
+                                   mdoutf_get_fp_dhdl(outf),
+                                   false,
+                                   startingBehavior_,
+                                   simulationsShareHamiltonian,
+                                   mdModulesNotifiers_);
+
+    gmx_global_stat_t gstat = global_stat_init(ir);
+
+    const auto& simulationWork     = runScheduleWork_->simulationWork;
+    const bool  useGpuForPme       = simulationWork.useGpuPme;
+    const bool  useGpuForNonbonded = simulationWork.useGpuNonbonded;
+    const bool  useGpuForUpdate    = simulationWork.useGpuUpdate;
+
+    /* Check for polarizable models and flexible constraints */
+    gmx_shellfc_t* shellfc = init_shell_flexcon(fpLog_,
+                                                topGlobal_,
+                                                constr_ ? constr_->numFlexibleConstraints() : 0,
+                                                ir->nstcalcenergy,
+                                                haveDDAtomOrdering(*cr_),
+                                                useGpuForPme);
+
+    {
+        double io = compute_io(ir, topGlobal_.natoms, *groups, energyOutput.numEnergyTerms(), 1);
+        if ((io > 2000) && MAIN(cr_))
+        {
+            fprintf(stderr, "\nWARNING: This run will generate roughly %.0f Mb of data\n\n", io);
+        }
+    }
+
+    ObservablesReducer observablesReducer = observablesReducerBuilder_->build();
+
+    ForceBuffers     f(simulationWork.useMts,
+                   (simulationWork.useGpuFBufferOpsWhenAllowed || useGpuForUpdate)
+                               ? PinningPolicy::PinnedIfSupported
+                               : PinningPolicy::CannotBePinned);
+    const t_mdatoms* md = mdAtoms_->mdatoms();
+    if (haveDDAtomOrdering(*cr_))
+    {
+        // Local state only becomes valid now.
+        dd_init_local_state(*cr_->dd, stateGlobal_, state_);
+
+        /* Distribute the charge groups over the nodes from the main node */
+        dd_partition_system(fpLog_,
+                            mdLog_,
+                            ir->init_step,
+                            cr_,
+                            TRUE,
+                            stateGlobal_,
+                            topGlobal_,
+                            *ir,
+                            mdModulesNotifiers_,
+                            imdSession_,
+                            pullWork_,
+                            state_,
+                            &f,
+                            mdAtoms_,
+                            top_,
+                            fr_,
+                            virtualSites_,
+                            constr_,
+                            nrnb_,
+                            nullptr,
+                            FALSE);
+        upd.updateAfterPartition(state_->numAtoms(), md->cFREEZE, md->cTC, md->cACC);
+        fr_->longRangeNonbondeds->updateAfterPartition(*md);
+    }
+    else
+    {
+        /* Generate and initialize new topology */
+        mdAlgorithmsSetupAtomData(
+                cr_, *ir, topGlobal_, top_, fr_, &f, mdAtoms_, constr_, virtualSites_, shellfc);
+
+        upd.updateAfterPartition(state_->numAtoms(), md->cFREEZE, md->cTC, md->cACC);
+        fr_->longRangeNonbondeds->updateAfterPartition(*md);
+    }
+
+    // Now that the state is valid we can set up Parrinello-Rahman
+    init_parrinellorahman(ir->pressureCouplingOptions,
+                          ir->deform,
+                          ir->delta_t * ir->pressureCouplingOptions.nstpcouple,
+                          state_->box,
+                          state_->box_rel,
+                          state_->boxv,
+                          &parrinelloRahmanM,
+                          &pressureCouplingMu);
+
+    std::unique_ptr<UpdateConstrainGpu> integrator;
+
+    StatePropagatorDataGpu* stateGpu = fr_->stateGpu;
+
+    // TODO: the assertions below should be handled by UpdateConstraintsBuilder.
+    if (useGpuForUpdate)
+    {
+        GMX_RELEASE_ASSERT(!haveDDAtomOrdering(*cr_) || ddUsesUpdateGroups(*cr_->dd)
+                                   || constr_ == nullptr || constr_->numConstraintsTotal() == 0,
+                           "Constraints in domain decomposition are only supported with update "
+                           "groups if using GPU update.\n");
+        GMX_RELEASE_ASSERT(ir->eConstrAlg != ConstraintAlgorithm::Shake || constr_ == nullptr
+                                   || constr_->numConstraintsTotal() == 0,
+                           "SHAKE is not supported with GPU update.");
+        GMX_RELEASE_ASSERT(useGpuForPme || (useGpuForNonbonded && simulationWork.useGpuXBufferOpsWhenAllowed),
+                           "Either PME or short-ranged non-bonded interaction tasks must run on "
+                           "the GPU to use GPU update.\n");
+        GMX_RELEASE_ASSERT(ir->eI == IntegrationAlgorithm::MD,
+                           "Only the md integrator is supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(
+                ir->etc != TemperatureCoupling::NoseHoover,
+                "Nose-Hoover temperature coupling is not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(
+                ir->pressureCouplingOptions.epc == PressureCoupling::No
+                        || ir->pressureCouplingOptions.epc == PressureCoupling::ParrinelloRahman
+                        || ir->pressureCouplingOptions.epc == PressureCoupling::Berendsen
+                        || ir->pressureCouplingOptions.epc == PressureCoupling::CRescale,
+                "Only Parrinello-Rahman, Berendsen, and C-rescale pressure coupling are supported "
+                "with the GPU update.\n");
+        GMX_RELEASE_ASSERT(!md->haveVsites,
+                           "Virtual sites are not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(ed == nullptr,
+                           "Essential dynamics is not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(!ir->bPull || !pull_have_constraint(*ir->pull),
+                           "Constraints pulling is not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(fcdata.orires == nullptr,
+                           "Orientation restraints are not supported with the GPU update.\n");
+        GMX_RELEASE_ASSERT(
+                ir->efep == FreeEnergyPerturbationType::No
+                        || (!haveFepPerturbedMasses(topGlobal_) && !havePerturbedConstraints(topGlobal_)),
+                "Free energy perturbation of masses and constraints are not supported with the GPU "
+                "update.");
+
+        if (constr_ != nullptr && constr_->numConstraintsTotal() > 0)
+        {
+            GMX_LOG(mdLog_.info)
+                    .asParagraph()
+                    .appendText("Updating coordinates and applying constraints on the GPU.");
+        }
+        else
+        {
+            GMX_LOG(mdLog_.info).asParagraph().appendText("Updating coordinates on the GPU.");
+        }
+        GMX_RELEASE_ASSERT(fr_->deviceStreamManager != nullptr,
+                           "Device stream manager should be initialized in order to use GPU "
+                           "update-constraints.");
+        GMX_RELEASE_ASSERT(
+                fr_->deviceStreamManager->streamIsValid(gmx::DeviceStreamType::UpdateAndConstraints),
+                "Update stream should be initialized in order to use GPU "
+                "update-constraints.");
+        integrator = std::make_unique<UpdateConstrainGpu>(
+                *ir,
+                topGlobal_,
+                ekind_->numTemperatureCouplingGroups(),
+                fr_->deviceStreamManager->context(),
+                fr_->deviceStreamManager->stream(gmx::DeviceStreamType::UpdateAndConstraints),
+                wallCycleCounters_);
+
+        stateGpu->setXUpdatedOnDeviceEvent(integrator->xUpdatedOnDeviceEvent());
+
+        integrator->setPbc(PbcType::Xyz, state_->box);
+    }
+
+    if (useGpuForPme || simulationWork.useGpuXBufferOpsWhenAllowed || useGpuForUpdate)
+    {
+        changePinningPolicy(&state_->x, PinningPolicy::PinnedIfSupported);
+    }
+    if (useGpuForUpdate)
+    {
+        changePinningPolicy(&state_->v, PinningPolicy::PinnedIfSupported);
+    }
+
+    // NOTE: The global state is no longer used at this point.
+    // But state_global is still used as temporary storage space for writing
+    // the global state to file and potentially for replica exchange.
+    // (Global topology should persist.)
+
+    update_mdatoms(mdAtoms_->mdatoms(), state_->lambda[FreeEnergyPerturbationCouplingType::Mass]);
+
+    if (ir->bExpanded)
+    {
+        /* Check nstexpanded here, because the grompp check was broken */
+        if (ir->expandedvals->nstexpanded % ir->nstcalcenergy != 0)
+        {
+            gmx_fatal(FARGS,
+                      "With expanded ensemble, nstexpanded should be a multiple of nstcalcenergy");
+        }
+        init_expanded_ensemble(startingBehavior_ != StartingBehavior::NewSimulation, ir, state_->dfhist);
+    }
+
+    if (MAIN(cr_))
+    {
+        EnergyData::initializeEnergyHistory(startingBehavior_, observablesHistory_, &energyOutput);
+    }
+
+    preparePrevStepPullCom(
+            ir, pullWork_, md->massT, state_, stateGlobal_, cr_, startingBehavior_ != StartingBehavior::NewSimulation);
+
+    // TODO: Remove this by converting AWH into a ForceProvider
+    auto awh = prepareAwhModule(fpLog_,
+                                *ir,
+                                stateGlobal_,
+                                cr_,
+                                ms_,
+                                startingBehavior_ != StartingBehavior::NewSimulation,
+                                shellfc != nullptr,
+                                opt2fn("-awh", nFile_, fnm_),
+                                pullWork_);
+
+    if (useReplicaExchange && MAIN(cr_))
+    {
+        repl_ex = init_replica_exchange(fpLog_, ms_, topGlobal_.natoms, ir, replExParams_);
+    }
+    /* PME tuning is only supported in the Verlet scheme, with PME for
+     * Coulomb. It is not supported with only LJ PME.
+     * Disable PME tuning with GPU PME decomposition */
+    bPMETune = (mdrunOptions_.tunePme && usingPme(fr_->ic->eeltype) && !mdrunOptions_.reproducible
+                && ir->cutoff_scheme != CutoffScheme::Group && !simulationWork.useGpuPmeDecomposition);
+
+    pme_load_balancing_t* pme_loadbal = nullptr;
+    if (bPMETune)
+    {
+        pme_loadbal_init(
+                &pme_loadbal, cr_, mdLog_, *ir, state_->box, *fr_->ic, *fr_->nbv, fr_->pmedata, fr_->nbv->useGpu());
+    }
+
+    if (!ir->bContinuation)
+    {
+        if (state_->hasEntry(StateEntry::V))
+        {
+            auto v = makeArrayRef(state_->v);
+            /* Set the velocities of vsites, shells and frozen atoms to zero */
+            for (int i = 0; i < md->homenr; i++)
+            {
+                if (md->ptype[i] == ParticleType::Shell)
+                {
+                    clear_rvec(v[i]);
+                }
+                else if (!md->cFREEZE.empty())
+                {
+                    for (int m = 0; m < DIM; m++)
+                    {
+                        if (ir->opts.nFreeze[md->cFREEZE[i]][m])
+                        {
+                            v[i][m] = 0;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (constr_)
+        {
+            /* Constrain the initial coordinates and velocities */
+            do_constrain_first(fpLog_,
+                               constr_,
+                               *ir,
+                               md->homenr,
+                               state_->x.arrayRefWithPadding(),
+                               state_->v.arrayRefWithPadding(),
+                               state_->box,
+                               state_->lambda[FreeEnergyPerturbationCouplingType::Bonded]);
+        }
+    }
+
+    const int nstfep = computeFepPeriod(*ir, replExParams_);
+
+    /* Be REALLY careful about what flags you set here. You CANNOT assume
+     * this is the first step, since we might be restarting from a checkpoint,
+     * and in that case we should not do any modifications to the state.
+     */
+    const bool stopCenterOfMassMovementBeforeFirstStep =
+            (ir->comm_mode != ComRemovalAlgorithm::No && !ir->bContinuation);
+
+    // When restarting from a checkpoint, it can be appropriate to
+    // initialize ekind from quantities in the checkpoint. Otherwise,
+    // compute_globals must initialize ekind before the simulation
+    // starts/restarts. However, only the main rank knows what was
+    // found in the checkpoint file, so we have to communicate in
+    // order to coordinate the restart.
+    //
+    // TODO Consider removing this communication if/when checkpoint
+    // reading directly follows .tpr reading, because all ranks can
+    // agree on hasReadEkinState at that time.
+    bool hasReadEkinState = MAIN(cr_) ? stateGlobal_->ekinstate.hasReadEkinState : false;
+    if (PAR(cr_))
+    {
+        gmx_bcast(sizeof(hasReadEkinState), &hasReadEkinState, cr_->mpi_comm_mygroup);
+    }
+    if (hasReadEkinState)
+    {
+        restore_ekinstate_from_state(cr_, ekind_, MAIN(cr_) ? &stateGlobal_->ekinstate : nullptr);
+    }
+
+    unsigned int cglo_flags =
+            (CGLO_TEMPERATURE | CGLO_GSTAT | (EI_VV(ir->eI) ? CGLO_PRESSURE : 0)
+             | (EI_VV(ir->eI) ? CGLO_CONSTRAINT : 0) | (hasReadEkinState ? CGLO_READEKIN : 0));
+
+    bSumEkinhOld = FALSE;
+
+    t_vcm vcm(topGlobal_.groups, *ir, topGlobal_.natoms);
+    reportComRemovalInfo(fpLog_, vcm);
+
+    int64_t step     = ir->init_step;
+    int64_t step_rel = 0;
+
+    /* To minimize communication, compute_globals computes the COM velocity
+     * and the kinetic energy for the velocities without COM motion removed.
+     * Thus to get the kinetic energy without the COM contribution, we need
+     * to call compute_globals twice.
+     */
+    for (int cgloIteration = 0; cgloIteration < (stopCenterOfMassMovementBeforeFirstStep ? 2 : 1);
+         cgloIteration++)
+    {
+        unsigned int cglo_flags_iteration = cglo_flags;
+        if (stopCenterOfMassMovementBeforeFirstStep && cgloIteration == 0)
+        {
+            cglo_flags_iteration |= CGLO_STOPCM;
+            cglo_flags_iteration &= ~CGLO_TEMPERATURE;
+        }
+        compute_globals(gstat,
+                        cr_,
+                        ir,
+                        fr_,
+                        ekind_,
+                        makeConstArrayRef(state_->x),
+                        makeConstArrayRef(state_->v),
+                        state_->box,
+                        md,
+                        nrnb_,
+                        &vcm,
+                        nullptr,
+                        enerd_,
+                        force_vir,
+                        shake_vir,
+                        total_vir,
+                        pres,
+                        &nullSignaller,
+                        state_->box,
+                        &bSumEkinhOld,
+                        cglo_flags_iteration,
+                        step,
+                        &observablesReducer);
+        // Clean up after pre-step use of compute_globals()
+        observablesReducer.markAsReadyToReduce();
+
+        if (cglo_flags_iteration & CGLO_STOPCM)
+        {
+            /* At initialization, do not pass x with acceleration-correction mode
+             * to avoid (incorrect) correction of the initial coordinates.
+             */
+            auto x = (vcm.mode == ComRemovalAlgorithm::LinearAccelerationCorrection)
+                             ? ArrayRef<RVec>()
+                             : makeArrayRef(state_->x);
+            process_and_stopcm_grp(fpLog_, &vcm, *md, x, makeArrayRef(state_->v));
+            inc_nrnb(nrnb_, eNR_STOPCM, md->homenr);
+        }
+    }
+    if (ir->eI == IntegrationAlgorithm::VVAK)
+    {
+        /* a second call to get the half step temperature initialized as well */
+        /* we do the same call as above, but turn the pressure off -- internally to
+           compute_globals, this is recognized as a velocity verlet half-step
+           kinetic energy calculation.  This minimized excess variables, but
+           perhaps loses some logic?*/
+
+        compute_globals(gstat,
+                        cr_,
+                        ir,
+                        fr_,
+                        ekind_,
+                        makeConstArrayRef(state_->x),
+                        makeConstArrayRef(state_->v),
+                        state_->box,
+                        md,
+                        nrnb_,
+                        &vcm,
+                        nullptr,
+                        enerd_,
+                        force_vir,
+                        shake_vir,
+                        total_vir,
+                        pres,
+                        &nullSignaller,
+                        state_->box,
+                        &bSumEkinhOld,
+                        cglo_flags & ~CGLO_PRESSURE,
+                        step,
+                        &observablesReducer);
+        // Clean up after pre-step use of compute_globals()
+        observablesReducer.markAsReadyToReduce();
+    }
+
+    /* Calculate the initial half step temperature, and save the ekinh_old */
+    if (startingBehavior_ == StartingBehavior::NewSimulation)
+    {
+        for (int i = 0; (i < ir->opts.ngtc); i++)
+        {
+            copy_mat(ekind_->tcstat[i].ekinh, ekind_->tcstat[i].ekinh_old);
+        }
+    }
+
+    /* need to make an initiation call to get the Trotter variables set, as well as other constants
+       for non-trotter temperature control */
+    auto trotter_seq = init_npt_vars(ir, *ekind_, state_, &MassQ, bTrotter);
+
+    if (MAIN(cr_))
+    {
+        if (!ir->bContinuation)
+        {
+            if (constr_ && ir->eConstrAlg == ConstraintAlgorithm::Lincs)
+            {
+                fprintf(fpLog_,
+                        "RMS relative constraint deviation after constraining: %.2e\n",
+                        constr_->rmsd());
+            }
+            if (EI_STATE_VELOCITY(ir->eI))
+            {
+                real temp = enerd_->term[F_TEMP];
+                if (ir->eI != IntegrationAlgorithm::VV)
+                {
+                    /* Result of Ekin averaged over velocities of -half
+                     * and +half step, while we only have -half step here.
+                     */
+                    temp *= 2;
+                }
+                fprintf(fpLog_, "Initial temperature: %g K\n", temp);
+            }
+        }
+
+        char tbuf[20];
+        fprintf(stderr, "starting mdrun '%s'\n", *(topGlobal_.name));
+        if (ir->nsteps >= 0)
+        {
+            sprintf(tbuf, "%8.1f", (ir->init_step + ir->nsteps) * ir->delta_t);
+        }
+        else
+        {
+            sprintf(tbuf, "%s", "infinite");
+        }
+        if (ir->init_step > 0)
+        {
+            fprintf(stderr,
+                    "%s steps, %s ps (continuing from step %s, %8.1f ps).\n",
+                    gmx_step_str(ir->init_step + ir->nsteps, sbuf),
+                    tbuf,
+                    gmx_step_str(ir->init_step, sbuf2),
+                    ir->init_step * ir->delta_t);
+        }
+        else
+        {
+            fprintf(stderr, "%s steps, %s ps.\n", gmx_step_str(ir->nsteps, sbuf), tbuf);
+        }
+        fprintf(fpLog_, "\n");
+    }
+
+    walltime_accounting_start_time(wallTimeAccounting_);
+    wallcycle_start(wallCycleCounters_, WallCycleCounter::Run);
+    print_start(fpLog_, cr_, wallTimeAccounting_, "mdrun");
+
+    /***********************************************************
+     *
+     *             Loop over MD steps
+     *
+     ************************************************************/
+
+    bFirstStep = TRUE;
+    /* Skip the first Nose-Hoover integration when we get the state from tpx */
+    bInitStep        = startingBehavior_ == StartingBehavior::NewSimulation || EI_VV(ir->eI);
+    bSumEkinhOld     = FALSE;
+    bExchanged       = FALSE;
+    bNeedRepartition = FALSE;
+
+    auto stopHandler = stopHandlerBuilder_->getStopHandlerMD(
+            compat::not_null<SimulationSignal*>(&signals[eglsSTOPCOND]),
+            simulationsShareState,
+            MAIN(cr_),
+            ir->nstlist,
+            mdrunOptions_.reproducible,
+            nstSignalComm,
+            mdrunOptions_.maximumHoursToRun,
+            ir->nstlist == 0,
+            fpLog_,
+            step,
+            bNS,
+            wallTimeAccounting_);
+
+    real checkpointPeriod = mdrunOptions_.checkpointOptions.period;
+    if (ir->bExpanded)
+    {
+        GMX_LOG(mdLog_.info)
+                .asParagraph()
+                .appendText(
+                        "Expanded ensemble with the legacy simulator does not always "
+                        "checkpoint correctly, so checkpointing is disabled. You will "
+                        "not be able to do a checkpoint restart of this simulation. "
+                        "If you use the modular simulator (e.g. by choosing md-vv integrator) "
+                        "then checkpointing is enabled. See "
+                        "https://gitlab.com/gromacs/gromacs/-/issues/4629 for details.");
+        // Use a negative period to disable checkpointing.
+        checkpointPeriod = -1;
+    }
+    auto checkpointHandler = std::make_unique<CheckpointHandler>(
+            compat::make_not_null<SimulationSignal*>(&signals[eglsCHKPT]),
+            simulationsShareState,
+            ir->nstlist == 0,
+            MAIN(cr_),
+            mdrunOptions_.writeConfout,
+            checkpointPeriod);
+
+    const bool resetCountersIsLocal = true;
+    auto       resetHandler         = std::make_unique<ResetHandler>(
+            compat::make_not_null<SimulationSignal*>(&signals[eglsRESETCOUNTERS]),
+            !resetCountersIsLocal,
+            ir->nsteps,
+            MAIN(cr_),
+            mdrunOptions_.timingOptions.resetHalfway,
+            mdrunOptions_.maximumHoursToRun,
+            mdLog_,
+            wallCycleCounters_,
+            wallTimeAccounting_);
+
+    const DDBalanceRegionHandler ddBalanceRegionHandler(cr_);
+
+    if (MAIN(cr_) && isMultiSim(ms_) && !useReplicaExchange)
+    {
+        logInitialMultisimStatus(ms_, cr_, mdLog_, simulationsShareState, ir->nsteps, ir->init_step);
+    }
+
+    bool usedMdGpuGraphLastStep = false;
+    /* and stop now if we should */
+    bLastStep = (bLastStep || (ir->nsteps >= 0 && step_rel > ir->nsteps));
+    while (!bLastStep)
+    {
+        /* Determine if this is a neighbor search step */
+        const bool bNStList = (ir->nstlist > 0 && step % ir->nstlist == 0);
+
+        if (bPMETune && bNStList)
+        {
+            // This has to be here because PME load balancing is called so early.
+            // TODO: Move to after all booleans are defined.
+            if (useGpuForUpdate && !bFirstStep)
+            {
+                stateGpu->copyCoordinatesFromGpu(state_->x, AtomLocality::Local);
+                stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+            }
+            /* PME grid + cut-off optimization with GPUs or PME nodes */
+            pme_loadbal_do(pme_loadbal,
+                           cr_,
+                           (mdrunOptions_.verbose && MAIN(cr_)) ? stderr : nullptr,
+                           fpLog_,
+                           mdLog_,
+                           *ir,
+                           fr_,
+                           state_->box,
+                           state_->x,
+                           wallCycleCounters_,
+                           step,
+                           step_rel,
+                           &bPMETunePrinting,
+                           simulationWork.useGpuPmePpCommunication);
+        }
+
+        wallcycle_start(wallCycleCounters_, WallCycleCounter::Step);
+
+        bLastStep      = (step_rel == ir->nsteps);
+        const double t = t0 + step * ir->delta_t;
+
+        // TODO Refactor this, so that nstfep does not need a default value of zero
+        if (ir->efep != FreeEnergyPerturbationType::No || ir->bSimTemp)
+        {
+            /* find and set the current lambdas */
+            state_->lambda = currentLambdas(step, *(ir->fepvals), state_->fep_state);
+
+            bDoExpanded = (do_per_step(step, ir->expandedvals->nstexpanded) && (ir->bExpanded)
+                           && (!bFirstStep));
+        }
+
+        bDoReplEx = (useReplicaExchange && (step > 0) && !bLastStep
+                     && do_per_step(step, replExParams_.exchangeInterval));
+
+        if (doSimulatedAnnealing)
+        {
+            // Simulated annealing updates the reference temperature.
+            update_annealing_target_temp(*ir, t, ekind_, &upd);
+        }
+
+        /* Stop Center of Mass motion */
+        const bool bStopCM = (ir->comm_mode != ComRemovalAlgorithm::No && do_per_step(step, ir->nstcomm));
+
+        /* Determine whether or not to do Neighbour Searching */
+        bNS = (bFirstStep || bNStList || bExchanged || bNeedRepartition);
+
+        /* Note that the stopHandler will cause termination at nstglobalcomm
+         * steps. Since this concides with nstcalcenergy, nsttcouple and/or
+         * nstpcouple steps, we have computed the half-step kinetic energy
+         * of the previous step and can always output energies at the last step.
+         */
+        bLastStep = bLastStep || stopHandler->stoppingAfterCurrentStep(bNS);
+
+        /* do_log triggers energy and virial calculation. Because this leads
+         * to different code paths, forces can be different. Thus for exact
+         * continuation we should avoid extra log output.
+         * Note that the || bLastStep can result in non-exact continuation
+         * beyond the last step. But we don't consider that to be an issue.
+         */
+        const bool do_log = (do_per_step(step, ir->nstlog)
+                             || (bFirstStep && startingBehavior_ == StartingBehavior::NewSimulation)
+                             || bLastStep);
+        const bool do_verbose =
+                mdrunOptions_.verbose
+                && (step % mdrunOptions_.verboseStepPrintInterval == 0 || bFirstStep || bLastStep);
+
+        // On search steps, when doing the update on the GPU, copy
+        // the coordinates and velocities to the host unless they are
+        // already there (ie on the first step and after replica
+        // exchange).
+        if (useGpuForUpdate && bNS && !bFirstStep && !bExchanged)
+        {
+            if (usedMdGpuGraphLastStep)
+            {
+                // Wait on coordinates produced from GPU graph
+                stateGpu->waitCoordinatesUpdatedOnDevice();
+            }
+            stateGpu->copyVelocitiesFromGpu(state_->v, AtomLocality::Local);
+            stateGpu->copyCoordinatesFromGpu(state_->x, AtomLocality::Local);
+            stateGpu->waitVelocitiesReadyOnHost(AtomLocality::Local);
+            stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+        }
+
+        // We need to calculate virtual velocities if we are writing them in the current step.
+        // They also need to be periodically updated. Every 1000 steps is arbitrary, but a reasonable number.
+        // The reason why the velocities need to be updated regularly is that the virtual site coordinates
+        // are updated using these velocities during integration. Those coordinates are used for, e.g., domain
+        // decomposition. Before computing any forces the positions of the virtual sites are recalculated.
+        // This fixes a bug, #4879, which was introduced in MR !979.
+        const int  c_virtualSiteVelocityUpdateInterval = 1000;
+        const bool needVirtualVelocitiesThisStep =
+                (virtualSites_ != nullptr)
+                && (do_per_step(step, ir->nstvout) || checkpointHandler->isCheckpointingStep()
+                    || do_per_step(step, c_virtualSiteVelocityUpdateInterval));
+
+        if (virtualSites_ != nullptr)
+        {
+            // Virtual sites need to be updated before domain decomposition and forces are calculated
+            wallcycle_start(wallCycleCounters_, WallCycleCounter::VsiteConstr);
+            // md-vv calculates virtual velocities once it has full-step real velocities
+            virtualSites_->construct(state_->x,
+                                     state_->v,
+                                     state_->box,
+                                     (!EI_VV(inputRec_->eI) && needVirtualVelocitiesThisStep)
+                                             ? VSiteOperation::PositionsAndVelocities
+                                             : VSiteOperation::Positions);
+            wallcycle_stop(wallCycleCounters_, WallCycleCounter::VsiteConstr);
+        }
+
+        if (bNS && !(bFirstStep && ir->bContinuation))
+        {
+            /* Correct the new box if it is too skewed */
+            const bool bMainState = inputrecDynamicBox(ir) && correct_box(fpLog_, step, state_->box);
+            // If update is offloaded, and the box was changed either
+            // above or in a replica exchange on the previous step,
+            // the GPU Update object should be informed
+            if (useGpuForUpdate && (bMainState || bExchanged))
+            {
+                integrator->setPbc(PbcType::Xyz, state_->box);
+            }
+            if (haveDDAtomOrdering(*cr_) && bMainState)
+            {
+                dd_collect_state(cr_->dd, state_, stateGlobal_);
+            }
+
+            if (haveDDAtomOrdering(*cr_))
+            {
+                /* Repartition the domain decomposition */
+                dd_partition_system(fpLog_,
+                                    mdLog_,
+                                    step,
+                                    cr_,
+                                    bMainState,
+                                    stateGlobal_,
+                                    topGlobal_,
+                                    *ir,
+                                    mdModulesNotifiers_,
+                                    imdSession_,
+                                    pullWork_,
+                                    state_,
+                                    &f,
+                                    mdAtoms_,
+                                    top_,
+                                    fr_,
+                                    virtualSites_,
+                                    constr_,
+                                    nrnb_,
+                                    wallCycleCounters_,
+                                    do_verbose && !bPMETunePrinting);
+                upd.updateAfterPartition(state_->numAtoms(), md->cFREEZE, md->cTC, md->cACC);
+                fr_->longRangeNonbondeds->updateAfterPartition(*md);
+            }
+        }
+
+        // Allocate or re-size GPU halo exchange object, if necessary
+        if (bNS && simulationWork.havePpDomainDecomposition && simulationWork.useGpuHaloExchange)
+        {
+            GMX_RELEASE_ASSERT(fr_->deviceStreamManager != nullptr,
+                               "GPU device manager has to be initialized to use GPU "
+                               "version of halo exchange.");
+            constructGpuHaloExchange(*cr_, *fr_->deviceStreamManager, wallCycleCounters_);
+        }
+
+        if (MAIN(cr_) && do_log)
+        {
+            gmx::EnergyOutput::printHeader(fpLog_, step, t); /* can we improve the information printed here? */
+        }
+
+        if (ir->efep != FreeEnergyPerturbationType::No)
+        {
+            update_mdatoms(mdAtoms_->mdatoms(), state_->lambda[FreeEnergyPerturbationCouplingType::Mass]);
+        }
+
+        if (bExchanged)
+        {
+            /* We need the kinetic energy at minus the half step for determining
+             * the full step kinetic energy and possibly for T-coupling.*/
+            /* This may not be quite working correctly yet . . . . */
+            int cglo_flags = CGLO_GSTAT | CGLO_TEMPERATURE;
+            compute_globals(gstat,
+                            cr_,
+                            ir,
+                            fr_,
+                            ekind_,
+                            makeConstArrayRef(state_->x),
+                            makeConstArrayRef(state_->v),
+                            state_->box,
+                            md,
+                            nrnb_,
+                            &vcm,
+                            wallCycleCounters_,
+                            enerd_,
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            &nullSignaller,
+                            state_->box,
+                            &bSumEkinhOld,
+                            cglo_flags,
+                            step,
+                            &observablesReducer);
+        }
+        clear_mat(force_vir);
+
+        checkpointHandler->decideIfCheckpointingThisStep(bNS, bFirstStep, bLastStep);
+
+        /* Determine the energy and pressure:
+         * at nstcalcenergy steps and at energy output steps (set below).
+         */
+
+        const bool do_ene              = (do_per_step(step, ir->nstenergy) || bLastStep);
+        const bool needEnergyAndVirial = do_ene || do_log || bDoReplEx;
+
+        const bool bCalcEnerStep = do_per_step(step, ir->nstcalcenergy);
+        const bool bCalcVir      = [&]() -> bool
+        {
+            auto doPressureCoupling = [ir](int64_t s) -> bool
+            {
+                return ir->pressureCouplingOptions.epc != PressureCoupling::No
+                       && do_per_step(s, ir->pressureCouplingOptions.nstpcouple);
+            };
+            if (EI_VV(ir->eI) && (!bInitStep))
+            {
+                return bCalcEnerStep || needEnergyAndVirial || doPressureCoupling(step)
+                       || doPressureCoupling(step - 1);
+            }
+            else
+            {
+                return bCalcEnerStep || needEnergyAndVirial || doPressureCoupling(step);
+            }
+        }();
+
+        const bool bCalcEner = bCalcEnerStep || needEnergyAndVirial;
+
+        // bCalcEner is only here for when the last step is not a multiple of nstfep
+        const bool computeDHDL = ((ir->efep != FreeEnergyPerturbationType::No || ir->bSimTemp)
+                                  && (do_per_step(step, nstfep) || bCalcEner));
+
+        /* Do we need global communication ? */
+        const bool bGStat =
+                (bCalcVir || bCalcEner || bStopCM || do_per_step(step, nstglobalcomm)
+                 || (EI_VV(ir->eI) && inputrecNvtTrotter(ir) && do_per_step(step - 1, nstglobalcomm)));
+
+        unsigned int force_flags =
+                (GMX_FORCE_STATECHANGED | ((inputrecDynamicBox(ir)) ? GMX_FORCE_DYNAMICBOX : 0)
+                 | GMX_FORCE_ALLFORCES | (bCalcVir ? GMX_FORCE_VIRIAL : 0)
+                 | (bCalcEner ? GMX_FORCE_ENERGY : 0) | (computeDHDL ? GMX_FORCE_DHDL : 0));
+        if (simulationWork.useMts && !do_per_step(step, ir->nstfout))
+        {
+            // TODO: merge this with stepWork.useOnlyMtsCombinedForceBuffer
+            force_flags |= GMX_FORCE_DO_NOT_NEED_NORMAL_FORCE;
+        }
+
+        if (bNS)
+        {
+            if (fr_->listedForcesGpu)
+            {
+                fr_->listedForcesGpu->updateHaveInteractions(top_->idef);
+            }
+            runScheduleWork_->domainWork = setupDomainLifetimeWorkload(
+                    *ir, *fr_, pullWork_, ed ? ed->getLegacyED() : nullptr, *md, simulationWork);
+        }
+
+        const int shellfcFlags = force_flags | (mdrunOptions_.verbose ? GMX_FORCE_ENERGY : 0);
+        const int legacyForceFlags = ((shellfc) ? shellfcFlags : force_flags) | (bNS ? GMX_FORCE_NS : 0);
+
+        runScheduleWork_->stepWork = setupStepWorkload(
+                legacyForceFlags, ir->mtsLevels, step, runScheduleWork_->domainWork, simulationWork);
+
+        const bool doTemperatureScaling = (ir->etc != TemperatureCoupling::No
+                                           && do_per_step(step + ir->nsttcouple - 1, ir->nsttcouple));
+
+        /* With leap-frog type integrators we compute the kinetic energy
+         * at a whole time step as the average of the half-time step kinetic
+         * energies of two subsequent steps. Therefore we need to compute the
+         * half step kinetic energy also if we need energies at the next step.
+         */
+        const bool needHalfStepKineticEnergy =
+                (!EI_VV(ir->eI) && (do_per_step(step + 1, nstglobalcomm) || step_rel + 1 == ir->nsteps));
+
+        // Parrinello-Rahman requires the pressure to be availible before the update to compute
+        // the velocity scaling matrix. Hence, it runs one step after the nstpcouple step.
+        const bool doParrinelloRahman =
+                (ir->pressureCouplingOptions.epc == PressureCoupling::ParrinelloRahman
+                 && do_per_step(step + ir->pressureCouplingOptions.nstpcouple - 1,
+                                ir->pressureCouplingOptions.nstpcouple));
+
+        MdGpuGraph* mdGraph = simulationWork.useMdGpuGraph ? fr_->mdGraph[step % 2].get() : nullptr;
+
+        if (simulationWork.useMdGpuGraph)
+        {
+            // Reset graph on search step (due to changing neighbour list etc)
+            // or virial step (due to changing shifts and box).
+            if (bNS || bCalcVir)
+            {
+                fr_->mdGraph[MdGraphEvenOrOddStep::EvenStep]->reset();
+                fr_->mdGraph[MdGraphEvenOrOddStep::OddStep]->reset();
+            }
+            else
+            {
+                mdGraph->setUsedGraphLastStep(usedMdGpuGraphLastStep);
+                bool canUseMdGpuGraphThisStep =
+                        !bNS && !bCalcVir && !doTemperatureScaling && !doParrinelloRahman && !bGStat
+                        && !needHalfStepKineticEnergy && !do_per_step(step, ir->nstxout)
+                        && !do_per_step(step, ir->nstxout_compressed)
+                        && !do_per_step(step, ir->nstvout) && !do_per_step(step, ir->nstfout)
+                        && !checkpointHandler->isCheckpointingStep();
+                if (mdGraph->captureThisStep(canUseMdGpuGraphThisStep))
+                {
+                    mdGraph->startRecord(stateGpu->getCoordinatesReadyOnDeviceEvent(
+                            AtomLocality::Local, simulationWork, runScheduleWork_->stepWork));
+                }
+            }
+        }
+        if (!simulationWork.useMdGpuGraph || mdGraph->graphIsCapturingThisStep()
+            || !mdGraph->useGraphThisStep())
+        {
+
+            if (shellfc)
+            {
+                /* Now is the time to relax the shells */
+                relax_shell_flexcon(fpLog_,
+                                    cr_,
+                                    ms_,
+                                    mdrunOptions_.verbose,
+                                    enforcedRotation_,
+                                    step,
+                                    ir,
+                                    mdModulesNotifiers_,
+                                    imdSession_,
+                                    pullWork_,
+                                    bNS,
+                                    top_,
+                                    constr_,
+                                    enerd_,
+                                    state_->numAtoms(),
+                                    state_->x.arrayRefWithPadding(),
+                                    state_->v.arrayRefWithPadding(),
+                                    state_->box,
+                                    state_->lambda,
+                                    &state_->hist,
+                                    &f.view(),
+                                    force_vir,
+                                    *md,
+                                    fr_->longRangeNonbondeds.get(),
+                                    nrnb_,
+                                    wallCycleCounters_,
+                                    shellfc,
+                                    fr_,
+                                    *runScheduleWork_,
+                                    t,
+                                    mu_tot,
+                                    virtualSites_,
+                                    ddBalanceRegionHandler);
+            }
+            else
+            {
+                /* The AWH history need to be saved _before_ doing force calculations where the AWH bias
+                   is updated (or the AWH update will be performed twice for one step when continuing).
+                   It would be best to call this update function from do_md_trajectory_writing but that
+                   would occur after do_force. One would have to divide the update_awh function into one
+                   function applying the AWH force and one doing the AWH bias update. The update AWH
+                   bias function could then be called after do_md_trajectory_writing (then containing
+                   update_awh_history). The checkpointing will in the future probably moved to the start
+                   of the md loop which will rid of this issue. */
+                if (awh && checkpointHandler->isCheckpointingStep() && MAIN(cr_))
+                {
+                    awh->updateHistory(stateGlobal_->awhHistory.get());
+                }
+
+                /* The coordinates (x) are shifted (to get whole molecules)
+                 * in do_force.
+                 * This is parallellized as well, and does communication too.
+                 * Check comments in sim_util.c
+                 */
+                do_force(fpLog_,
+                         cr_,
+                         ms_,
+                         *ir,
+                         mdModulesNotifiers_,
+                         awh.get(),
+                         enforcedRotation_,
+                         imdSession_,
+                         pullWork_,
+                         step,
+                         nrnb_,
+                         wallCycleCounters_,
+                         top_,
+                         state_->box,
+                         state_->x.arrayRefWithPadding(),
+                         state_->v.arrayRefWithPadding().unpaddedArrayRef(),
+                         &state_->hist,
+                         &f.view(),
+                         force_vir,
+                         md,
+                         enerd_,
+                         state_->lambda,
+                         fr_,
+                         *runScheduleWork_,
+                         virtualSites_,
+                         mu_tot,
+                         t,
+                         ed ? ed->getLegacyED() : nullptr,
+                         fr_->longRangeNonbondeds.get(),
+                         ddBalanceRegionHandler);
+            }
+
+            // VV integrators do not need the following velocity half step
+            // if it is the first step after starting from a checkpoint.
+            // That is, the half step is needed on all other steps, and
+            // also the first step when starting from a .tpr file.
+            if (EI_VV(ir->eI))
+            {
+                integrateVVFirstStep(step,
+                                     bFirstStep,
+                                     bInitStep,
+                                     startingBehavior_,
+                                     nstglobalcomm,
+                                     ir,
+                                     fr_,
+                                     cr_,
+                                     state_,
+                                     mdAtoms_->mdatoms(),
+                                     &fcdata,
+                                     &MassQ,
+                                     &vcm,
+                                     enerd_,
+                                     &observablesReducer,
+                                     ekind_,
+                                     gstat,
+                                     &last_ekin,
+                                     bCalcVir,
+                                     total_vir,
+                                     shake_vir,
+                                     force_vir,
+                                     pres,
+                                     do_log,
+                                     do_ene,
+                                     bCalcEner,
+                                     bGStat,
+                                     bStopCM,
+                                     bTrotter,
+                                     bExchanged,
+                                     &bSumEkinhOld,
+                                     &saved_conserved_quantity,
+                                     &f,
+                                     &upd,
+                                     constr_,
+                                     &nullSignaller,
+                                     trotter_seq,
+                                     nrnb_,
+                                     fpLog_,
+                                     wallCycleCounters_);
+                if (virtualSites_ != nullptr && needVirtualVelocitiesThisStep)
+                {
+                    // Positions were calculated earlier
+                    wallcycle_start(wallCycleCounters_, WallCycleCounter::VsiteConstr);
+                    virtualSites_->construct(state_->x, state_->v, state_->box, VSiteOperation::Velocities);
+                    wallcycle_stop(wallCycleCounters_, WallCycleCounter::VsiteConstr);
+                }
+            }
+
+            /* ########  END FIRST UPDATE STEP  ############## */
+            /* ########  If doing VV, we now have v(dt) ###### */
+            if (bDoExpanded)
+            {
+                /* perform extended ensemble sampling in lambda - we don't
+                   actually move to the new state before outputting
+                   statistics, but if performing simulated tempering, we
+                   do update the velocities and the tau_t. */
+                lamnew = ExpandedEnsembleDynamics(fpLog_,
+                                                  *inputRec_,
+                                                  *enerd_,
+                                                  ekind_,
+                                                  state_,
+                                                  &MassQ,
+                                                  state_->fep_state,
+                                                  state_->dfhist,
+                                                  step,
+                                                  state_->v.rvec_array(),
+                                                  md->homenr,
+                                                  md->cTC);
+                /* history is maintained in state->dfhist, but state_global is what is sent to trajectory and log output */
+                if (MAIN(cr_))
+                {
+                    copy_df_history(stateGlobal_->dfhist, state_->dfhist);
+                }
+            }
+
+            // Copy coordinate from the GPU for the output/checkpointing if the update is offloaded
+            // and coordinates have not already been copied for i) search or ii) CPU force tasks.
+            if (useGpuForUpdate && !bNS && !runScheduleWork_->domainWork.haveCpuLocalForceWork
+                && (do_per_step(step, ir->nstxout) || do_per_step(step, ir->nstxout_compressed)
+                    || checkpointHandler->isCheckpointingStep()))
+            {
+                stateGpu->copyCoordinatesFromGpu(state_->x, AtomLocality::Local);
+                stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+            }
+            // Copy velocities if needed for the output/checkpointing.
+            // NOTE: Copy on the search steps is done at the beginning of the step.
+            if (useGpuForUpdate && !bNS
+                && (do_per_step(step, ir->nstvout) || checkpointHandler->isCheckpointingStep()))
+            {
+                stateGpu->copyVelocitiesFromGpu(state_->v, AtomLocality::Local);
+                stateGpu->waitVelocitiesReadyOnHost(AtomLocality::Local);
+            }
+            // Copy forces for the output if the forces were reduced on the GPU (not the case on virial steps)
+            // and update is offloaded hence forces are kept on the GPU for update and have not been
+            // already transferred in do_force().
+            // TODO: There should be an improved, explicit mechanism that ensures this copy is only executed
+            //       when the forces are ready on the GPU -- the same synchronizer should be used as the one
+            //       prior to GPU update.
+            // TODO: When the output flags will be included in step workload, this copy can be combined with the
+            //       copy call in do_force(...).
+            // NOTE: The forces should not be copied here if the vsites are present, since they were modified
+            //       on host after the D2H copy in do_force(...).
+            if (runScheduleWork_->stepWork.useGpuFBufferOps
+                && (simulationWork.useGpuUpdate && !virtualSites_) && do_per_step(step, ir->nstfout))
+            {
+                stateGpu->copyForcesFromGpu(f.view().force(), AtomLocality::Local);
+                stateGpu->waitForcesReadyOnHost(AtomLocality::Local);
+            }
+            /* Now we have the energies and forces corresponding to the
+             * coordinates at time t. We must output all of this before
+             * the update.
+             */
+            const EkindataState ekindataState =
+                    bGStat ? (bSumEkinhOld ? EkindataState::UsedNeedToReduce
+                                           : EkindataState::UsedDoNotNeedToReduce)
+                           : EkindataState::NotUsed;
+            do_md_trajectory_writing(fpLog_,
+                                     cr_,
+                                     nFile_,
+                                     fnm_,
+                                     step,
+                                     step_rel,
+                                     t,
+                                     ir,
+                                     state_,
+                                     stateGlobal_,
+                                     observablesHistory_,
+                                     topGlobal_,
+                                     fr_,
+                                     outf,
+                                     energyOutput,
+                                     ekind_,
+                                     f.view().force(),
+                                     checkpointHandler->isCheckpointingStep(),
+                                     bRerunMD,
+                                     bLastStep,
+                                     mdrunOptions_.writeConfout,
+                                     ekindataState);
+            /* Check if IMD step and do IMD communication, if bIMD is TRUE. */
+            bInteractiveMDstep = imdSession_->run(step, bNS, state_->box, state_->x, t);
+
+            /* kludge -- virial is lost with restart for MTTK NPT control. Must reload (saved earlier). */
+            if (startingBehavior_ != StartingBehavior::NewSimulation && bFirstStep
+                && (inputrecNptTrotter(ir) || inputrecNphTrotter(ir)))
+            {
+                copy_mat(state_->svir_prev, shake_vir);
+                copy_mat(state_->fvir_prev, force_vir);
+            }
+
+            stopHandler->setSignal();
+            resetHandler->setSignal(wallTimeAccounting_);
+
+            if (bGStat || !PAR(cr_))
+            {
+                /* In parallel we only have to check for checkpointing in steps
+                 * where we do global communication,
+                 *  otherwise the other nodes don't know.
+                 */
+                checkpointHandler->setSignal(wallTimeAccounting_);
+            }
+
+            /* #########   START SECOND UPDATE STEP ################# */
+
+            /* at the start of step, randomize or scale the velocities ((if vv. Restriction of
+               Andersen controlled in preprocessing */
+
+            if (ETC_ANDERSEN(ir->etc)) /* keep this outside of update_tcouple because of the extra info required to pass */
+            {
+                gmx_bool bIfRandomize;
+                bIfRandomize = update_randomize_velocities(
+                        ir, step, cr_, md->homenr, md->cTC, md->invmass, state_->v, &upd, constr_);
+                /* if we have constraints, we have to remove the kinetic energy parallel to the bonds */
+                if (constr_ && bIfRandomize)
+                {
+                    constrain_velocities(constr_, do_log || do_ene, step, state_, nullptr, false, nullptr);
+                }
+            }
+            /* Box is changed in update() when we do pressure coupling,
+             * but we should still use the old box for energy corrections and when
+             * writing it to the energy file, so it matches the trajectory files for
+             * the same timestep above. Make a copy in a separate array.
+             */
+            copy_mat(state_->box, lastbox);
+
+            dvdl_constr = 0;
+
+            if (!useGpuForUpdate)
+            {
+                wallcycle_start(wallCycleCounters_, WallCycleCounter::Update);
+            }
+            /* UPDATE PRESSURE VARIABLES IN TROTTER FORMULATION WITH CONSTRAINTS */
+            if (bTrotter)
+            {
+                trotter_update(ir,
+                               step,
+                               ekind_,
+                               state_,
+                               total_vir,
+                               md->homenr,
+                               md->cTC,
+                               md->invmass,
+                               &MassQ,
+                               trotter_seq,
+                               TrotterSequence::Three);
+                /* We can only do Berendsen coupling after we have summed
+                 * the kinetic energy or virial. Since the happens
+                 * in global_state after update, we should only do it at
+                 * step % nstlist = 1 with bGStatEveryStep=FALSE.
+                 */
+            }
+            else
+            {
+                update_tcouple(step, ir, state_, ekind_, &MassQ, md->homenr, md->cTC);
+                update_pcouple_before_coordinates(mdLog_,
+                                                  step,
+                                                  ir->pressureCouplingOptions,
+                                                  ir->deform,
+                                                  ir->delta_t,
+                                                  state_,
+                                                  &pressureCouplingMu,
+                                                  &parrinelloRahmanM);
+            }
+
+            if (EI_VV(ir->eI))
+            {
+                GMX_ASSERT(!useGpuForUpdate, "GPU update is not supported with VVAK integrator.");
+
+                integrateVVSecondStep(step,
+                                      ir,
+                                      fr_,
+                                      cr_,
+                                      state_,
+                                      mdAtoms_->mdatoms(),
+                                      &fcdata,
+                                      &MassQ,
+                                      &vcm,
+                                      pullWork_,
+                                      enerd_,
+                                      &observablesReducer,
+                                      ekind_,
+                                      gstat,
+                                      &dvdl_constr,
+                                      bCalcVir,
+                                      total_vir,
+                                      shake_vir,
+                                      force_vir,
+                                      pres,
+                                      lastbox,
+                                      do_log,
+                                      do_ene,
+                                      bGStat,
+                                      &bSumEkinhOld,
+                                      &f,
+                                      &cbuf,
+                                      &upd,
+                                      constr_,
+                                      &nullSignaller,
+                                      trotter_seq,
+                                      nrnb_,
+                                      wallCycleCounters_);
+            }
+            else
+            {
+                if (useGpuForUpdate)
+                {
+                    // On search steps, update handles to device vectors
+                    // TODO: this condition has redundant / unnecessary clauses
+                    if (bNS && (bFirstStep || haveDDAtomOrdering(*cr_) || bExchanged))
+                    {
+                        integrator->set(stateGpu->getCoordinates(),
+                                        stateGpu->getVelocities(),
+                                        stateGpu->getForces(),
+                                        top_->idef,
+                                        *md);
+
+                        // Copy data to the GPU after buffers might have been reinitialized
+                        /* The velocity copy is redundant if we had Center-of-Mass motion removed on
+                         * the previous step. We don't check that now. */
+                        stateGpu->copyVelocitiesToGpu(state_->v, AtomLocality::Local);
+                    }
+
+                    // Copy x to the GPU unless we have already transferred in do_force().
+                    // We transfer in do_force() if a GPU force task requires x (PME or x buffer ops).
+                    if (!(runScheduleWork_->stepWork.haveGpuPmeOnThisRank
+                          || runScheduleWork_->stepWork.useGpuXBufferOps))
+                    {
+                        stateGpu->copyCoordinatesToGpu(state_->x, AtomLocality::Local);
+                        // Coordinates are later used by the integrator running in the same stream.
+                        stateGpu->consumeCoordinatesCopiedToDeviceEvent(AtomLocality::Local);
+                    }
+
+                    if ((simulationWork.useGpuPme && simulationWork.useCpuPmePpCommunication)
+                        || (!runScheduleWork_->stepWork.useGpuFBufferOps))
+                    {
+                        // The PME forces were recieved to the host, and reduced on the CPU with the
+                        // rest of the forces computed on the GPU, so the final forces have to be
+                        // copied back to the GPU. Or the buffer ops were not offloaded this step,
+                        // so the forces are on the host and have to be copied
+                        stateGpu->copyForcesToGpu(f.view().force(), AtomLocality::Local);
+                    }
+                    const bool doTemperatureScaling =
+                            (ir->etc != TemperatureCoupling::No
+                             && do_per_step(step + ir->nsttcouple - 1, ir->nsttcouple));
+
+                    // This applies Leap-Frog, LINCS and SETTLE in succession
+                    integrator->integrate(
+                            stateGpu->getLocalForcesReadyOnDeviceEvent(
+                                    runScheduleWork_->stepWork, runScheduleWork_->simulationWork),
+                            ir->delta_t,
+                            true,
+                            bCalcVir,
+                            shake_vir,
+                            doTemperatureScaling,
+                            ekind_->tcstat,
+                            doParrinelloRahman,
+                            ir->pressureCouplingOptions.nstpcouple * ir->delta_t,
+                            parrinelloRahmanM);
+                }
+                else
+                {
+                    /* With multiple time stepping we need to do an additional normal
+                     * update step to obtain the virial and dH/dl, as the actual MTS integration
+                     * using an acceleration where the slow forces are multiplied by mtsFactor.
+                     * Using that acceleration would result in a virial with the slow
+                     * force contribution would be a factor mtsFactor too large.
+                     */
+                    const bool separateVirialConstraining =
+                            (simulationWork.useMts && (bCalcVir || computeDHDL) && constr_ != nullptr);
+                    if (separateVirialConstraining)
+                    {
+                        upd.update_for_constraint_virial(*ir,
+                                                         md->homenr,
+                                                         md->havePartiallyFrozenAtoms,
+                                                         md->invmass,
+                                                         md->invMassPerDim,
+                                                         *state_,
+                                                         f.view().forceWithPadding(),
+                                                         *ekind_);
+
+                        // Call apply() directly so we can avoid constraining the velocities
+                        constr_->apply(false,
+                                       step,
+                                       1,
+                                       1.0,
+                                       state_->x.arrayRefWithPadding(),
+                                       upd.xp()->arrayRefWithPadding(),
+                                       {},
+                                       state_->box,
+                                       state_->lambda[FreeEnergyPerturbationCouplingType::Bonded],
+                                       &dvdl_constr,
+                                       {},
+                                       bCalcVir,
+                                       shake_vir,
+                                       ConstraintVariable::Positions);
+                    }
+
+                    ArrayRefWithPadding<const RVec> forceCombined =
+                            (simulationWork.useMts && step % ir->mtsLevels[1].stepFactor == 0)
+                                    ? f.view().forceMtsCombinedWithPadding()
+                                    : f.view().forceWithPadding();
+                    upd.update_coords(*ir,
+                                      step,
+                                      md->homenr,
+                                      md->havePartiallyFrozenAtoms,
+                                      md->ptype,
+                                      md->invmass,
+                                      md->invMassPerDim,
+                                      state_,
+                                      forceCombined,
+                                      &fcdata,
+                                      ekind_,
+                                      parrinelloRahmanM,
+                                      etrtPOSITION,
+                                      cr_,
+                                      constr_ != nullptr);
+
+                    wallcycle_stop(wallCycleCounters_, WallCycleCounter::Update);
+
+                    constrain_coordinates(constr_,
+                                          do_log || do_ene,
+                                          step,
+                                          state_,
+                                          upd.xp()->arrayRefWithPadding(),
+                                          separateVirialConstraining ? nullptr : &dvdl_constr,
+                                          bCalcVir && !separateVirialConstraining,
+                                          shake_vir);
+
+                    upd.update_sd_second_half(*ir,
+                                              step,
+                                              &dvdl_constr,
+                                              md->homenr,
+                                              md->ptype,
+                                              md->invmass,
+                                              state_,
+                                              cr_,
+                                              nrnb_,
+                                              wallCycleCounters_,
+                                              constr_,
+                                              do_log,
+                                              do_ene);
+                    upd.finish_update(*ir,
+                                      md->havePartiallyFrozenAtoms,
+                                      md->homenr,
+                                      state_,
+                                      wallCycleCounters_,
+                                      constr_ != nullptr);
+                }
+
+                if (ir->bPull && ir->pull->bSetPbcRefToPrevStepCOM)
+                {
+                    updatePrevStepPullCom(pullWork_, state_->pull_com_prev_step);
+                }
+
+                enerd_->term[F_DVDL_CONSTR] += dvdl_constr;
+            }
+        }
+
+        if (simulationWork.useMdGpuGraph)
+        {
+            GMX_ASSERT((mdGraph != nullptr), "MD GPU graph does not exist.");
+            if (mdGraph->graphIsCapturingThisStep())
+            {
+                mdGraph->endRecord();
+                // Force graph reinstantiation (instead of graph exec
+                // update): with PME tuning, since the GPU kernels
+                // chosen by the FFT library can vary with grid size;
+                // or with an odd nstlist, since the odd/even step
+                // pruning pattern will change
+                bool forceGraphReinstantiation =
+                        pme_loadbal_is_active(pme_loadbal) || ((ir->nstlist % 2) == 1);
+                mdGraph->createExecutableGraph(forceGraphReinstantiation);
+            }
+            if (mdGraph->useGraphThisStep())
+            {
+                mdGraph->launchGraphMdStep(integrator->xUpdatedOnDeviceEvent());
+            }
+            if (bNS)
+            {
+                // TODO: merge disableForDomainIfAnyPpRankHasCpuForces() back into reset() when
+                // domainWork initialization is moved out of do_force().
+                fr_->mdGraph[MdGraphEvenOrOddStep::EvenStep]->disableForDomainIfAnyPpRankHasCpuForces(
+                        runScheduleWork_->domainWork.haveCpuLocalForceWork);
+                fr_->mdGraph[MdGraphEvenOrOddStep::OddStep]->disableForDomainIfAnyPpRankHasCpuForces(
+                        runScheduleWork_->domainWork.haveCpuLocalForceWork);
+            }
+            usedMdGpuGraphLastStep = mdGraph->useGraphThisStep();
+        }
+
+        /* ############## IF NOT VV, Calculate globals HERE  ############ */
+        /* With Leap-Frog we can skip compute_globals at
+         * non-communication steps, but we need to calculate
+         * the kinetic energy one step before communication.
+         */
+        {
+            // Organize to do inter-simulation signalling on steps if
+            // and when algorithms require it.
+            const bool doInterSimSignal = (simulationsShareState && do_per_step(step, nstSignalComm));
+
+            if (useGpuForUpdate)
+            {
+                const bool coordinatesRequiredForStopCM =
+                        bStopCM && (bGStat || needHalfStepKineticEnergy || doInterSimSignal)
+                        && !EI_VV(ir->eI);
+
+                // Copy coordinates when needed to stop the CM motion or for replica exchange
+                if (coordinatesRequiredForStopCM || bDoReplEx)
+                {
+                    stateGpu->copyCoordinatesFromGpu(state_->x, AtomLocality::Local);
+                    stateGpu->waitCoordinatesReadyOnHost(AtomLocality::Local);
+                }
+
+                // Copy velocities back to the host if:
+                // - Globals are computed this step (includes the energy output steps).
+                // - Temperature is needed for the next step.
+                // - This is a replica exchange step (even though we will only need
+                //     the velocities if an exchange succeeds)
+                if (bGStat || needHalfStepKineticEnergy || bDoReplEx)
+                {
+                    stateGpu->copyVelocitiesFromGpu(state_->v, AtomLocality::Local);
+                    stateGpu->waitVelocitiesReadyOnHost(AtomLocality::Local);
+                }
+            }
+
+            if (bGStat || needHalfStepKineticEnergy || doInterSimSignal)
+            {
+                // Since we're already communicating at this step, we
+                // can propagate intra-simulation signals. Note that
+                // check_nstglobalcomm has the responsibility for
+                // choosing the value of nstglobalcomm that is one way
+                // bGStat becomes true, so we can't get into a
+                // situation where e.g. checkpointing can't be
+                // signalled.
+                bool doIntraSimSignal = true;
+                SimulationSignaller signaller(&signals, cr_, ms_, doInterSimSignal, doIntraSimSignal);
+
+                compute_globals(gstat,
+                                cr_,
+                                ir,
+                                fr_,
+                                ekind_,
+                                makeConstArrayRef(state_->x),
+                                makeConstArrayRef(state_->v),
+                                state_->box,
+                                md,
+                                nrnb_,
+                                &vcm,
+                                wallCycleCounters_,
+                                enerd_,
+                                force_vir,
+                                shake_vir,
+                                total_vir,
+                                pres,
+                                &signaller,
+                                lastbox,
+                                &bSumEkinhOld,
+                                (bGStat ? CGLO_GSTAT : 0) | (!EI_VV(ir->eI) && bCalcEner ? CGLO_ENERGY : 0)
+                                        | (!EI_VV(ir->eI) && bStopCM ? CGLO_STOPCM : 0)
+                                        | (!EI_VV(ir->eI) ? CGLO_TEMPERATURE : 0)
+                                        | (!EI_VV(ir->eI) ? CGLO_PRESSURE : 0) | CGLO_CONSTRAINT,
+                                step,
+                                &observablesReducer);
+                if (!EI_VV(ir->eI) && bStopCM)
+                {
+                    process_and_stopcm_grp(
+                            fpLog_, &vcm, *md, makeArrayRef(state_->x), makeArrayRef(state_->v));
+                    inc_nrnb(nrnb_, eNR_STOPCM, md->homenr);
+
+                    // TODO: The special case of removing CM motion should be dealt more gracefully
+                    if (useGpuForUpdate)
+                    {
+                        // Issue #3988, #4106.
+                        stateGpu->resetCoordinatesCopiedToDeviceEvent(AtomLocality::Local);
+                        stateGpu->copyCoordinatesToGpu(state_->x, AtomLocality::Local);
+                        // Here we block until the H2D copy completes because event sync with the
+                        // force kernels that use the coordinates on the next steps is not implemented
+                        // (not because of a race on state->x being modified on the CPU while H2D is in progress).
+                        stateGpu->waitCoordinatesCopiedToDevice(AtomLocality::Local);
+                        // If the COM removal changed the velocities on the CPU, this has to be accounted for.
+                        if (vcm.mode != ComRemovalAlgorithm::No)
+                        {
+                            stateGpu->copyVelocitiesToGpu(state_->v, AtomLocality::Local);
+                        }
+                    }
+                }
+            }
+        }
+
+        /* #############  END CALC EKIN AND PRESSURE ################# */
+
+        /* Note: this is OK, but there are some numerical precision issues with using the convergence of
+           the virial that should probably be addressed eventually. state->veta has better properies,
+           but what we actually need entering the new cycle is the new shake_vir value. Ideally, we could
+           generate the new shake_vir, but test the veta value for convergence.  This will take some thought. */
+
+        if (ir->efep != FreeEnergyPerturbationType::No && !EI_VV(ir->eI))
+        {
+            /* Sum up the foreign energy and dK/dl terms for md and sd.
+               Currently done every step so that dH/dl is correct in the .edr */
+            accumulateKineticLambdaComponents(enerd_, state_->lambda, *ir->fepvals);
+        }
+
+        const real currentSystemRefT =
+                (haveEnsembleTemperature(*ir) ? ekind_->currentEnsembleTemperature() : 0.0_real);
+        const bool scaleCoordinates = !useGpuForUpdate || bDoReplEx;
+        update_pcouple_after_coordinates(fpLog_,
+                                         step,
+                                         ir->pressureCouplingOptions,
+                                         ir->ld_seed,
+                                         currentSystemRefT,
+                                         ir->opts.nFreeze,
+                                         ir->deform,
+                                         ir->delta_t,
+                                         md->homenr,
+                                         md->cFREEZE,
+                                         pres,
+                                         force_vir,
+                                         shake_vir,
+                                         &pressureCouplingMu,
+                                         state_,
+                                         nrnb_,
+                                         upd.deform(),
+                                         scaleCoordinates);
+
+        const bool doBerendsenPressureCoupling =
+                (inputRec_->pressureCouplingOptions.epc == PressureCoupling::Berendsen
+                 && do_per_step(step, inputRec_->pressureCouplingOptions.nstpcouple));
+        const bool doCRescalePressureCoupling =
+                (inputRec_->pressureCouplingOptions.epc == PressureCoupling::CRescale
+                 && do_per_step(step, inputRec_->pressureCouplingOptions.nstpcouple));
+        if (useGpuForUpdate
+            && (doBerendsenPressureCoupling || doCRescalePressureCoupling || doParrinelloRahman))
+        {
+            integrator->scaleCoordinates(pressureCouplingMu);
+            if (doCRescalePressureCoupling)
+            {
+                integrator->scaleVelocities(invertBoxMatrix(pressureCouplingMu));
+            }
+            integrator->setPbc(PbcType::Xyz, state_->box);
+        }
+
+        /* ################# END UPDATE STEP 2 ################# */
+        /* #### We now have r(t+dt) and v(t+dt/2)  ############# */
+
+        /* The coordinates (x) were unshifted in update */
+        if (!bGStat)
+        {
+            /* We will not sum ekinh_old,
+             * so signal that we still have to do it.
+             */
+            bSumEkinhOld = TRUE;
+        }
+
+        if (bCalcEner)
+        {
+            /* #########  BEGIN PREPARING EDR OUTPUT  ###########  */
+
+            /* use the directly determined last velocity, not actually the averaged half steps */
+            if (bTrotter && ir->eI == IntegrationAlgorithm::VV)
+            {
+                enerd_->term[F_EKIN] = last_ekin;
+            }
+            enerd_->term[F_ETOT] = enerd_->term[F_EPOT] + enerd_->term[F_EKIN];
+
+            if (integratorHasConservedEnergyQuantity(ir))
+            {
+                if (EI_VV(ir->eI))
+                {
+                    enerd_->term[F_ECONSERVED] = enerd_->term[F_ETOT] + saved_conserved_quantity;
+                }
+                else
+                {
+                    enerd_->term[F_ECONSERVED] =
+                            enerd_->term[F_ETOT]
+                            + NPT_energy(ir->pressureCouplingOptions,
+                                         ir->etc,
+                                         gmx::constArrayRefFromArray(ir->opts.nrdf, ir->opts.ngtc),
+                                         *ekind_,
+                                         inputrecNvtTrotter(ir) || inputrecNptTrotter(ir),
+                                         state_,
+                                         &MassQ);
+                }
+            }
+            /* #########  END PREPARING EDR OUTPUT  ###########  */
+        }
+
+        /* Output stuff */
+        if (MAIN(cr_))
+        {
+            if (fpLog_ && do_log && bDoExpanded)
+            {
+                /* only needed if doing expanded ensemble */
+                PrintFreeEnergyInfoToFile(fpLog_,
+                                          ir->fepvals.get(),
+                                          ir->expandedvals.get(),
+                                          ir->bSimTemp ? ir->simtempvals.get() : nullptr,
+                                          stateGlobal_->dfhist,
+                                          state_->fep_state,
+                                          ir->nstlog,
+                                          step);
+            }
+            if (bCalcEner)
+            {
+                const bool outputDHDL = (computeDHDL && do_per_step(step, ir->fepvals->nstdhdl));
+
+                energyOutput.addDataAtEnergyStep(outputDHDL,
+                                                 bCalcEnerStep,
+                                                 t,
+                                                 md->tmass,
+                                                 enerd_,
+                                                 ir->fepvals.get(),
+                                                 lastbox,
+                                                 PTCouplingArrays{ state_->boxv,
+                                                                   state_->nosehoover_xi,
+                                                                   state_->nosehoover_vxi,
+                                                                   state_->nhpres_xi,
+                                                                   state_->nhpres_vxi },
+                                                 state_->fep_state,
+                                                 total_vir,
+                                                 pres,
+                                                 ekind_,
+                                                 mu_tot,
+                                                 constr_);
+            }
+            else
+            {
+                energyOutput.recordNonEnergyStep();
+            }
+
+            gmx_bool do_dr = do_per_step(step, ir->nstdisreout);
+            gmx_bool do_or = do_per_step(step, ir->nstorireout);
+
+            if (doSimulatedAnnealing)
+            {
+                gmx::EnergyOutput::printAnnealingTemperatures(
+                        do_log ? fpLog_ : nullptr, *groups, ir->opts, *ekind_);
+            }
+            if (do_log || do_ene || do_dr || do_or)
+            {
+                energyOutput.printStepToEnergyFile(mdoutf_get_fp_ene(outf),
+                                                   do_ene,
+                                                   do_dr,
+                                                   do_or,
+                                                   do_log ? fpLog_ : nullptr,
+                                                   step,
+                                                   t,
+                                                   fr_->fcdata.get(),
+                                                   awh.get());
+            }
+            if (do_log && ((ir->bDoAwh && awh->hasFepLambdaDimension()) || ir->fepvals->delta_lambda != 0))
+            {
+                const bool isInitialOutput = false;
+                printLambdaStateToLog(fpLog_, state_->lambda, isInitialOutput);
+            }
+
+            if (ir->bPull)
+            {
+                pull_print_output(pullWork_, step, t);
+            }
+
+            if (do_per_step(step, ir->nstlog))
+            {
+                if (fflush(fpLog_) != 0)
+                {
+                    gmx_fatal(FARGS, "Cannot flush logfile - maybe you are out of disk space?");
+                }
+            }
+        }
+        if (bDoExpanded)
+        {
+            /* Have to do this part _after_ outputting the logfile and the edr file */
+            /* Gets written into the state at the beginning of next loop*/
+            state_->fep_state = lamnew;
+        }
+        else if (ir->bDoAwh && awh->needForeignEnergyDifferences(step))
+        {
+            state_->fep_state = awh->fepLambdaState();
+        }
+        /* Print the remaining wall clock time for the run */
+        if (isMainSimMainRank(ms_, MAIN(cr_)) && (do_verbose || gmx_got_usr_signal()) && !bPMETunePrinting)
+        {
+            if (shellfc)
+            {
+                fprintf(stderr, "\n");
+            }
+            print_time(stderr, wallTimeAccounting_, step, ir, cr_);
+        }
+
+        /* Ion/water position swapping.
+         * Not done in last step since trajectory writing happens before this call
+         * in the MD loop and exchanges would be lost anyway. */
+        bNeedRepartition = FALSE;
+        if ((ir->eSwapCoords != SwapType::No) && (step > 0) && !bLastStep
+            && do_per_step(step, ir->swap->nstswap))
+        {
+            bNeedRepartition = do_swapcoords(cr_,
+                                             step,
+                                             t,
+                                             ir,
+                                             swap_,
+                                             wallCycleCounters_,
+                                             as_rvec_array(state_->x.data()),
+                                             state_->box,
+                                             MAIN(cr_) && mdrunOptions_.verbose,
+                                             bRerunMD);
+
+            if (bNeedRepartition && haveDDAtomOrdering(*cr_))
+            {
+                dd_collect_state(cr_->dd, state_, stateGlobal_);
+            }
+        }
+
+        /* Replica exchange */
+        bExchanged = FALSE;
+        if (bDoReplEx)
+        {
+            bExchanged =
+                    replica_exchange(fpLog_, cr_, ms_, repl_ex, stateGlobal_, enerd_, state_, step, t);
+        }
+
+        if ((bExchanged || bNeedRepartition) && haveDDAtomOrdering(*cr_))
+        {
+            dd_partition_system(fpLog_,
+                                mdLog_,
+                                step,
+                                cr_,
+                                TRUE,
+                                stateGlobal_,
+                                topGlobal_,
+                                *ir,
+                                mdModulesNotifiers_,
+                                imdSession_,
+                                pullWork_,
+                                state_,
+                                &f,
+                                mdAtoms_,
+                                top_,
+                                fr_,
+                                virtualSites_,
+                                constr_,
+                                nrnb_,
+                                wallCycleCounters_,
+                                FALSE);
+            upd.updateAfterPartition(state_->numAtoms(), md->cFREEZE, md->cTC, md->cACC);
+            fr_->longRangeNonbondeds->updateAfterPartition(*md);
+        }
+
+        bFirstStep = FALSE;
+        bInitStep  = FALSE;
+
+        /* #######  SET VARIABLES FOR NEXT ITERATION IF THEY STILL NEED IT ###### */
+        /* With all integrators, except VV, we need to retain the pressure
+         * at the current step for coupling at the next step.
+         */
+        if (state_->hasEntry(StateEntry::PressurePrevious)
+            && (bGStatEveryStep
+                || (ir->pressureCouplingOptions.nstpcouple > 0
+                    && step % ir->pressureCouplingOptions.nstpcouple == 0)))
+        {
+            /* Store the pressure in t_state for pressure coupling
+             * at the next MD step.
+             */
+            copy_mat(pres, state_->pres_prev);
+        }
+
+        /* #######  END SET VARIABLES FOR NEXT ITERATION ###### */
+
+        if ((membed_ != nullptr) && (!bLastStep))
+        {
+            rescale_membed(step_rel, membed_, as_rvec_array(stateGlobal_->x.data()));
+        }
+
+        const double cycles = wallcycle_stop(wallCycleCounters_, WallCycleCounter::Step);
+        if (haveDDAtomOrdering(*cr_) && wallCycleCounters_)
+        {
+            dd_cycles_add(cr_->dd, cycles, ddCyclStep);
+        }
+
+        /* increase the MD step number */
+        step++;
+        step_rel++;
+        observablesReducer.markAsReadyToReduce();
+
+#if GMX_FAHCORE
+        if (MAIN(cr))
+        {
+            fcReportProgress(ir->nsteps + ir->init_step, step);
+        }
+#endif
+
+        resetHandler->resetCounters(
+                step, step_rel, mdLog_, fpLog_, cr_, fr_->nbv.get(), nrnb_, fr_->pmedata, pme_loadbal, wallCycleCounters_, wallTimeAccounting_);
+
+        /* If bIMD is TRUE, the main updates the IMD energy record and sends positions to VMD client */
+        imdSession_->updateEnergyRecordAndSendPositionsAndEnergies(bInteractiveMDstep, step, bCalcEner);
+
+        // any run that uses GPUs must be at least offloading nonbondeds
+        const bool usingGpu = simulationWork.useGpuNonbonded;
+        if (usingGpu)
+        {
+            // ensure that GPU errors do not propagate between MD steps
+            checkPendingDeviceErrorBetweenSteps();
+        }
+    }
+    /* End of main MD loop */
+
+    /* Closing TNG files can include compressing data. Therefore it is good to do that
+     * before stopping the time measurements. */
+    mdoutf_tng_close(outf);
+
+    /* Stop measuring walltime */
+    walltime_accounting_end_time(wallTimeAccounting_);
+
+    if (simulationWork.haveSeparatePmeRank)
+    {
+        /* Tell the PME only node to finish */
+        gmx_pme_send_finish(cr_);
+    }
+
+    // This is to free PP ranks gpuhaloexchange symmetric buffer `d_recvBuf_`
+    // as calling its destruction happens very late causing hang as this is a collective
+    // call, the PME side free of the same buffer happens quite early.
+    if (PAR(cr_) && simulationWork.useNvshmem)
+    {
+        destroyGpuHaloExchangeNvshmemBuf(*cr_);
+    }
+
+    if (MAIN(cr_))
+    {
+        if (ir->nstcalcenergy > 0)
+        {
+            energyOutput.printEnergyConservation(fpLog_, ir->simulation_part, EI_MD(ir->eI));
+
+            gmx::EnergyOutput::printAnnealingTemperatures(fpLog_, *groups, ir->opts, *ekind_);
+            energyOutput.printAverages(fpLog_, groups);
+        }
+    }
+    done_mdoutf(outf);
+
+    if (bPMETune)
+    {
+        pme_loadbal_done(pme_loadbal, fpLog_, mdLog_, fr_->nbv->useGpu());
+    }
+
+    done_shellfc(fpLog_, shellfc, step_rel);
+
+    if (useReplicaExchange && MAIN(cr_))
+    {
+        print_replica_exchange_statistics(fpLog_, repl_ex);
+    }
+
+    walltime_accounting_set_nsteps_done(wallTimeAccounting_, step_rel);
+
+    global_stat_destroy(gstat);
+}

--- a/patches/gromacs-2025.0.diff/src/gromacs/mdtypes/iforceprovider.cpp
+++ b/patches/gromacs-2025.0.diff/src/gromacs/mdtypes/iforceprovider.cpp
@@ -1,0 +1,121 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2017- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements classes from iforceprovider.h.
+ *
+ * \author Teemu Murtola <teemu.murtola@gmail.com>
+ * \ingroup module_mdtypes
+ */
+#include "gmxpre.h"
+
+#include "iforceprovider.h"
+
+#include <utility>
+#include <vector>
+
+#include "gromacs/timing/wallcycle.h"
+#include "gromacs/utility/arrayref.h"
+
+using namespace gmx;
+
+class ForceProviders::Impl
+{
+public:
+    Impl(gmx_wallcycle* wallCycle) : wallCycle_(wallCycle) {}
+
+    std::vector<std::pair<IForceProvider*, std::optional<WallCycleCounter>>> providers_;
+    gmx_wallcycle*                                                           wallCycle_;
+};
+
+ForceProviders::ForceProviders(gmx_wallcycle* wallCycle) : impl_(new Impl(wallCycle)) {}
+
+ForceProviders::~ForceProviders() {}
+
+void ForceProviders::addForceProvider(gmx::IForceProvider* provider, const std::string& cycleCounterName)
+{
+    std::optional<WallCycleCounter> counter;
+    if (impl_->wallCycle_)
+    {
+        counter = impl_->wallCycle_->registerCycleCounter(cycleCounterName);
+    }
+
+    impl_->providers_.emplace_back(provider, counter);
+}
+
+bool ForceProviders::hasForceProvider() const
+{
+    return !impl_->providers_.empty();
+}
+
+void ForceProviders::calculateForces(const ForceProviderInput& forceProviderInput,
+                                     ForceProviderOutput*      forceProviderOutput) const
+{
+    for (auto& provider : impl_->providers_)
+    {
+        if (provider.second)
+        {
+            wallcycle_start(impl_->wallCycle_, provider.second.value());
+        }
+
+        provider.first->calculateForces(forceProviderInput, forceProviderOutput);
+
+        if (provider.second)
+        {
+            wallcycle_stop(impl_->wallCycle_, provider.second.value());
+        }
+    }
+}
+
+bool ForceProviders::requestsPotentialEnergy(int64_t step) const
+{
+    bool needed = false;
+    for (auto& provider : impl_->providers_)
+    {
+        // Every provider is asked, they may need the call to prepare for the step.
+        needed = provider.first->requestsPotentialEnergy(step) || needed;
+    }
+    return needed;
+}
+
+void ForceProviders::applyAfterPotentialEnergy(bool          energyWasComputed,
+                                               real*         potentialEnergy,
+                                               ArrayRef<RVec> force,
+                                               tensor        virial) const
+{
+    for (auto& provider : impl_->providers_)
+    {
+        provider.first->applyAfterPotentialEnergy(energyWasComputed, potentialEnergy, force, virial);
+    }
+}

--- a/patches/gromacs-2025.0.diff/src/gromacs/mdtypes/iforceprovider.cpp.preplumed
+++ b/patches/gromacs-2025.0.diff/src/gromacs/mdtypes/iforceprovider.cpp.preplumed
@@ -1,0 +1,99 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2017- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \internal \file
+ * \brief
+ * Implements classes from iforceprovider.h.
+ *
+ * \author Teemu Murtola <teemu.murtola@gmail.com>
+ * \ingroup module_mdtypes
+ */
+#include "gmxpre.h"
+
+#include "iforceprovider.h"
+
+#include <utility>
+#include <vector>
+
+#include "gromacs/timing/wallcycle.h"
+#include "gromacs/utility/arrayref.h"
+
+using namespace gmx;
+
+class ForceProviders::Impl
+{
+public:
+    Impl(gmx_wallcycle* wallCycle) : wallCycle_(wallCycle) {}
+
+    std::vector<std::pair<IForceProvider*, std::optional<WallCycleCounter>>> providers_;
+    gmx_wallcycle*                                                           wallCycle_;
+};
+
+ForceProviders::ForceProviders(gmx_wallcycle* wallCycle) : impl_(new Impl(wallCycle)) {}
+
+ForceProviders::~ForceProviders() {}
+
+void ForceProviders::addForceProvider(gmx::IForceProvider* provider, const std::string& cycleCounterName)
+{
+    std::optional<WallCycleCounter> counter;
+    if (impl_->wallCycle_)
+    {
+        counter = impl_->wallCycle_->registerCycleCounter(cycleCounterName);
+    }
+
+    impl_->providers_.emplace_back(provider, counter);
+}
+
+bool ForceProviders::hasForceProvider() const
+{
+    return !impl_->providers_.empty();
+}
+
+void ForceProviders::calculateForces(const ForceProviderInput& forceProviderInput,
+                                     ForceProviderOutput*      forceProviderOutput) const
+{
+    for (auto& provider : impl_->providers_)
+    {
+        if (provider.second)
+        {
+            wallcycle_start(impl_->wallCycle_, provider.second.value());
+        }
+
+        provider.first->calculateForces(forceProviderInput, forceProviderOutput);
+
+        if (provider.second)
+        {
+            wallcycle_stop(impl_->wallCycle_, provider.second.value());
+        }
+    }
+}

--- a/patches/gromacs-2025.0.diff/src/gromacs/mdtypes/iforceprovider.h
+++ b/patches/gromacs-2025.0.diff/src/gromacs/mdtypes/iforceprovider.h
@@ -1,0 +1,267 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2016- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \libinternal \file
+ * \brief
+ * Declares gmx::IForceProvider and ForceProviders.
+ *
+ * See \ref page_mdmodules for an overview of this and associated interfaces.
+ *
+ * \author Teemu Murtola <teemu.murtola@gmail.com>
+ * \author Carsten Kutzner <ckutzne@gwdg.de>
+ * \inlibraryapi
+ * \ingroup module_mdtypes
+ */
+#ifndef GMX_MDTYPES_IFORCEPROVIDER_H
+#define GMX_MDTYPES_IFORCEPROVIDER_H
+
+#include <cstdint>
+
+#include <memory>
+#include <string>
+
+#include "gromacs/math/vec.h"
+#include "gromacs/math/vectypes.h"
+#include "gromacs/utility/arrayref.h"
+#include "gromacs/utility/gmxassert.h"
+#include "gromacs/utility/real.h"
+
+struct gmx_enerdata_t;
+struct gmx_wallcycle;
+struct t_commrec;
+struct t_forcerec;
+
+namespace gmx
+{
+
+template<typename T>
+class ArrayRef;
+class ForceWithVirial;
+
+
+/*! \libinternal \brief
+ * Helper struct that bundles data for passing it over to the force providers
+ *
+ * This is a short-lived container that bundles up all necessary input data for the
+ * force providers. Its only purpose is to allow calling forceProviders->calculateForces()
+ * with just two arguments, one being the container for the input data,
+ * the other the container for the output data.
+ *
+ * Both ForceProviderInput as well as ForceProviderOutput only package existing
+ * data structs together for handing it over to calculateForces(). Apart from the
+ * POD entries they own nothing.
+ */
+class ForceProviderInput
+{
+public:
+    /*! \brief Constructor assembles all necessary force provider input data
+     *
+     * \param[in]  x        Atomic positions.
+     * \param[in]  homenr   Number of atoms on the domain.
+     * \param[in]  chargeA  Atomic charges for atoms on the domain.
+     * \param[in]  massT    Atomic masses for atoms on the domain.
+     * \param[in]  time     The current time in the simulation.
+     * \param[in]  step     The current step in the simulation
+     * \param[in]  box      The simulation box.
+     * \param[in]  cr       Communication record structure.
+     */
+    ForceProviderInput(ArrayRef<const RVec> x,
+                       int                  homenr,
+                       ArrayRef<const real> chargeA,
+                       ArrayRef<const real> massT,
+                       double               time,
+                       int64_t              step,
+                       const matrix         box,
+                       const t_commrec&     cr) :
+        x_(x), homenr_(homenr), chargeA_(chargeA), massT_(massT), t_(time), step_(step), cr_(cr)
+    {
+        copy_mat(box, box_);
+    }
+
+    ArrayRef<const RVec> x_; //!< The atomic positions
+    int                  homenr_;
+    ArrayRef<const real> chargeA_;
+    ArrayRef<const real> massT_;
+    double               t_;    //!< The current time in the simulation
+    int64_t              step_; //!< The current step in the simulation
+    matrix               box_ = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } }; //!< The simulation box
+    const t_commrec&     cr_; //!< Communication record structure
+};
+
+/*! \brief Take pointer, check if valid, return reference
+ */
+template<class T>
+T& makeRefFromPointer(T* ptr)
+{
+    GMX_ASSERT(ptr != nullptr, "got null pointer");
+    return *ptr;
+}
+
+/*! \libinternal \brief
+ * Helper struct bundling the output data of a force provider
+ *
+ * Same as for the ForceProviderInput class, but these variables can be written as well.
+ */
+class ForceProviderOutput
+{
+public:
+    /*! \brief Constructor assembles all necessary force provider output data
+     *
+     * \param[in,out]  forceWithVirial  Container for force and virial
+     * \param[in,out]  enerd            Structure containing energy data
+     */
+    ForceProviderOutput(ForceWithVirial* forceWithVirial, gmx_enerdata_t* enerd) :
+        forceWithVirial_(makeRefFromPointer(forceWithVirial)), enerd_(makeRefFromPointer(enerd))
+    {
+    }
+
+    ForceWithVirial& forceWithVirial_; //!< Container for force and virial
+    gmx_enerdata_t&  enerd_;           //!< Structure containing energy data
+};
+
+
+/*! \libinternal \brief
+ * Interface for a component that provides forces during MD.
+ *
+ * Modules implementing IMDModule generally implement this internally, and use
+ * IMDModule::initForceProviders() to register their implementation in
+ * ForceProviders.
+ *
+ * The interface most likely requires additional generalization for use in
+ * other modules than the current electric field implementation.
+ *
+ * The forces that are produced by force providers are not taken into account
+ * in the calculation of the virial. When applicable, the provider should
+ * compute its own virial contribution.
+ *
+ * \inlibraryapi
+ * \ingroup module_mdtypes
+ */
+class IForceProvider
+{
+public:
+    /*! \brief
+     * Computes forces.
+     *
+     * \param[in]    forceProviderInput    struct that collects input data for the force providers
+     * \param[in,out] forceProviderOutput   struct that collects output data of the force providers
+     */
+    virtual void calculateForces(const ForceProviderInput& forceProviderInput,
+                                 ForceProviderOutput*      forceProviderOutput) = 0;
+
+    /*! \brief
+     * Whether this provider needs the MD potential energy on \p step.
+     *
+     * Called from the MD loop before setupStepWorkload(), which is the last
+     * point at which the workload can still be changed. A true return value
+     * requests GMX_FORCE_ENERGY | GMX_FORCE_VIRIAL so that F_EPOT is valid
+     * in applyAfterPotentialEnergy().
+     *
+     * \param[in] step  The step that is about to be computed
+     */
+    virtual bool requestsPotentialEnergy(int64_t /*step*/) { return false; }
+
+    /*! \brief
+     * Optional callback after the potential energy has been accumulated
+     * and the total force buffer is complete.
+     *
+     * Used by PLUMED to pass ENERGY to the CV and to rescale the MD forces
+     * when biasing the potential energy.
+     *
+     * \param[in]     energyWasComputed  Whether term[F_EPOT] is valid this step
+     * \param[in,out] potentialEnergy    Pointer to the potential energy (F_EPOT)
+     * \param[in,out] force              Complete force array (home atoms)
+     * \param[in,out] virial             Force virial tensor
+     */
+    virtual void applyAfterPotentialEnergy(bool /*energyWasComputed*/,
+                                           real* /*potentialEnergy*/,
+                                           ArrayRef<RVec> /*force*/,
+                                           tensor /*virial*/)
+    {
+    }
+
+protected:
+    ~IForceProvider() {}
+};
+
+/*! \libinternal \brief
+ * Evaluates forces from a collection of gmx::IForceProvider.
+ *
+ * \inlibraryapi
+ * \ingroup module_mdtypes
+ */
+class ForceProviders
+{
+public:
+    /*! \brief
+     * Constructor.
+     *
+     * \param[in] wallCycle  Pointer to a wallcycle counter struct, can be nullptr
+     */
+    ForceProviders(gmx_wallcycle* wallCycle = nullptr);
+    ~ForceProviders();
+
+    /*! \brief
+     * Adds a provider.
+     *
+     * \param[in] provider          The force provider callback function
+     * \param[in] cycleCounterName  A non-empty string will add a cycle counter with the given name
+     *                              that registers the time spent in the force provider function
+     */
+    void addForceProvider(gmx::IForceProvider* provider, const std::string& cycleCounterName = "");
+
+    //! Whether there are modules added.
+    bool hasForceProvider() const;
+
+    //! Computes forces.
+    void calculateForces(const gmx::ForceProviderInput& forceProviderInput,
+                         gmx::ForceProviderOutput*      forceProviderOutput) const;
+
+    //! Whether any provider needs the potential energy on \p step.
+    bool requestsPotentialEnergy(int64_t step) const;
+
+    //! Forwards applyAfterPotentialEnergy() to all providers.
+    void applyAfterPotentialEnergy(bool energyWasComputed,
+                                   real* potentialEnergy,
+                                   ArrayRef<RVec> force,
+                                   tensor virial) const;
+
+private:
+    class Impl;
+
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace gmx
+
+#endif

--- a/patches/gromacs-2025.0.diff/src/gromacs/mdtypes/iforceprovider.h.preplumed
+++ b/patches/gromacs-2025.0.diff/src/gromacs/mdtypes/iforceprovider.h.preplumed
@@ -1,0 +1,227 @@
+/*
+ * This file is part of the GROMACS molecular simulation package.
+ *
+ * Copyright 2016- The GROMACS Authors
+ * and the project initiators Erik Lindahl, Berk Hess and David van der Spoel.
+ * Consult the AUTHORS/COPYING files and https://www.gromacs.org for details.
+ *
+ * GROMACS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * GROMACS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with GROMACS; if not, see
+ * https://www.gnu.org/licenses, or write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *
+ * If you want to redistribute modifications to GROMACS, please
+ * consider that scientific software is very special. Version
+ * control is crucial - bugs must be traceable. We will be happy to
+ * consider code for inclusion in the official distribution, but
+ * derived work must not be called official GROMACS. Details are found
+ * in the README & COPYING files - if they are missing, get the
+ * official version at https://www.gromacs.org.
+ *
+ * To help us fund GROMACS development, we humbly ask that you cite
+ * the research papers on the package. Check out https://www.gromacs.org.
+ */
+/*! \libinternal \file
+ * \brief
+ * Declares gmx::IForceProvider and ForceProviders.
+ *
+ * See \ref page_mdmodules for an overview of this and associated interfaces.
+ *
+ * \author Teemu Murtola <teemu.murtola@gmail.com>
+ * \author Carsten Kutzner <ckutzne@gwdg.de>
+ * \inlibraryapi
+ * \ingroup module_mdtypes
+ */
+#ifndef GMX_MDTYPES_IFORCEPROVIDER_H
+#define GMX_MDTYPES_IFORCEPROVIDER_H
+
+#include <cstdint>
+
+#include <memory>
+#include <string>
+
+#include "gromacs/math/vec.h"
+#include "gromacs/math/vectypes.h"
+#include "gromacs/utility/arrayref.h"
+#include "gromacs/utility/gmxassert.h"
+#include "gromacs/utility/real.h"
+
+struct gmx_enerdata_t;
+struct gmx_wallcycle;
+struct t_commrec;
+struct t_forcerec;
+
+namespace gmx
+{
+
+template<typename T>
+class ArrayRef;
+class ForceWithVirial;
+
+
+/*! \libinternal \brief
+ * Helper struct that bundles data for passing it over to the force providers
+ *
+ * This is a short-lived container that bundles up all necessary input data for the
+ * force providers. Its only purpose is to allow calling forceProviders->calculateForces()
+ * with just two arguments, one being the container for the input data,
+ * the other the container for the output data.
+ *
+ * Both ForceProviderInput as well as ForceProviderOutput only package existing
+ * data structs together for handing it over to calculateForces(). Apart from the
+ * POD entries they own nothing.
+ */
+class ForceProviderInput
+{
+public:
+    /*! \brief Constructor assembles all necessary force provider input data
+     *
+     * \param[in]  x        Atomic positions.
+     * \param[in]  homenr   Number of atoms on the domain.
+     * \param[in]  chargeA  Atomic charges for atoms on the domain.
+     * \param[in]  massT    Atomic masses for atoms on the domain.
+     * \param[in]  time     The current time in the simulation.
+     * \param[in]  step     The current step in the simulation
+     * \param[in]  box      The simulation box.
+     * \param[in]  cr       Communication record structure.
+     */
+    ForceProviderInput(ArrayRef<const RVec> x,
+                       int                  homenr,
+                       ArrayRef<const real> chargeA,
+                       ArrayRef<const real> massT,
+                       double               time,
+                       int64_t              step,
+                       const matrix         box,
+                       const t_commrec&     cr) :
+        x_(x), homenr_(homenr), chargeA_(chargeA), massT_(massT), t_(time), step_(step), cr_(cr)
+    {
+        copy_mat(box, box_);
+    }
+
+    ArrayRef<const RVec> x_; //!< The atomic positions
+    int                  homenr_;
+    ArrayRef<const real> chargeA_;
+    ArrayRef<const real> massT_;
+    double               t_;    //!< The current time in the simulation
+    int64_t              step_; //!< The current step in the simulation
+    matrix               box_ = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } }; //!< The simulation box
+    const t_commrec&     cr_; //!< Communication record structure
+};
+
+/*! \brief Take pointer, check if valid, return reference
+ */
+template<class T>
+T& makeRefFromPointer(T* ptr)
+{
+    GMX_ASSERT(ptr != nullptr, "got null pointer");
+    return *ptr;
+}
+
+/*! \libinternal \brief
+ * Helper struct bundling the output data of a force provider
+ *
+ * Same as for the ForceProviderInput class, but these variables can be written as well.
+ */
+class ForceProviderOutput
+{
+public:
+    /*! \brief Constructor assembles all necessary force provider output data
+     *
+     * \param[in,out]  forceWithVirial  Container for force and virial
+     * \param[in,out]  enerd            Structure containing energy data
+     */
+    ForceProviderOutput(ForceWithVirial* forceWithVirial, gmx_enerdata_t* enerd) :
+        forceWithVirial_(makeRefFromPointer(forceWithVirial)), enerd_(makeRefFromPointer(enerd))
+    {
+    }
+
+    ForceWithVirial& forceWithVirial_; //!< Container for force and virial
+    gmx_enerdata_t&  enerd_;           //!< Structure containing energy data
+};
+
+
+/*! \libinternal \brief
+ * Interface for a component that provides forces during MD.
+ *
+ * Modules implementing IMDModule generally implement this internally, and use
+ * IMDModule::initForceProviders() to register their implementation in
+ * ForceProviders.
+ *
+ * The interface most likely requires additional generalization for use in
+ * other modules than the current electric field implementation.
+ *
+ * The forces that are produced by force providers are not taken into account
+ * in the calculation of the virial. When applicable, the provider should
+ * compute its own virial contribution.
+ *
+ * \inlibraryapi
+ * \ingroup module_mdtypes
+ */
+class IForceProvider
+{
+public:
+    /*! \brief
+     * Computes forces.
+     *
+     * \param[in]    forceProviderInput    struct that collects input data for the force providers
+     * \param[in,out] forceProviderOutput   struct that collects output data of the force providers
+     */
+    virtual void calculateForces(const ForceProviderInput& forceProviderInput,
+                                 ForceProviderOutput*      forceProviderOutput) = 0;
+
+protected:
+    ~IForceProvider() {}
+};
+
+/*! \libinternal \brief
+ * Evaluates forces from a collection of gmx::IForceProvider.
+ *
+ * \inlibraryapi
+ * \ingroup module_mdtypes
+ */
+class ForceProviders
+{
+public:
+    /*! \brief
+     * Constructor.
+     *
+     * \param[in] wallCycle  Pointer to a wallcycle counter struct, can be nullptr
+     */
+    ForceProviders(gmx_wallcycle* wallCycle = nullptr);
+    ~ForceProviders();
+
+    /*! \brief
+     * Adds a provider.
+     *
+     * \param[in] provider          The force provider callback function
+     * \param[in] cycleCounterName  A non-empty string will add a cycle counter with the given name
+     *                              that registers the time spent in the force provider function
+     */
+    void addForceProvider(gmx::IForceProvider* provider, const std::string& cycleCounterName = "");
+
+    //! Whether there are modules added.
+    bool hasForceProvider() const;
+
+    //! Computes forces.
+    void calculateForces(const gmx::ForceProviderInput& forceProviderInput,
+                         gmx::ForceProviderOutput*      forceProviderOutput) const;
+
+private:
+    class Impl;
+
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace gmx
+
+#endif

--- a/src/colvar/Energy.cpp
+++ b/src/colvar/Energy.cpp
@@ -39,13 +39,9 @@ it is available, and when also replica exchange is available,
 metadynamics applied to ENERGY can be used to decrease the
 number of required replicas.
 
-\warning Whether long tail corrections are included in \ref ENERGY depends on the MD code.
-With GROMACS they are: \ref ENERGY receives the same potential energy that GROMACS reports as
-`Potential` in its energy file, and that already contains the `DispCorr` term, so
-`"DispCorr Ener"` and `"DispCorr EnerPres"` are accounted for.
-With other codes, such as LAMMPS with `"pair_modify tail yes"`, you should check that \ref ENERGY
-matches the potential energy reported by the MD engine before biasing it. If it does not, you can
-still use \ref ENERGY and then reweight your simulation with the correct MD energy value.
+\warning Some MD engines communicate to PLUMED the energy without the long tail corrections,
+leading to a small mismatch. If this is the case, use the energy from the MD engine for
+reweighting. See \issue{567}.
 
 \bug Acceptance for replica exchange when \ref ENERGY is biased
 is computed correctly only if all the replicas have the same

--- a/src/colvar/Energy.cpp
+++ b/src/colvar/Energy.cpp
@@ -39,10 +39,13 @@ it is available, and when also replica exchange is available,
 metadynamics applied to ENERGY can be used to decrease the
 number of required replicas.
 
-\bug This \ref ENERGY does not include long tail corrections.
-Thus when using e.g. LAMMPS `"pair_modify tail yes"` or GROMACS `"DispCorr Ener"` (or `"DispCorr EnerPres"`),
-the potential energy from \ref ENERGY will be slightly different form the one of the MD code.
-You should still be able to use \ref ENERGY and then reweight your simulation with the correct MD energy value.
+\warning Whether long tail corrections are included in \ref ENERGY depends on the MD code.
+With GROMACS they are: \ref ENERGY receives the same potential energy that GROMACS reports as
+`Potential` in its energy file, and that already contains the `DispCorr` term, so
+`"DispCorr Ener"` and `"DispCorr EnerPres"` are accounted for.
+With other codes, such as LAMMPS with `"pair_modify tail yes"`, you should check that \ref ENERGY
+matches the potential energy reported by the MD engine before biasing it. If it does not, you can
+still use \ref ENERGY and then reweight your simulation with the correct MD energy value.
 
 \bug Acceptance for replica exchange when \ref ENERGY is biased
 is computed correctly only if all the replicas have the same

--- a/src/core/ActionToPutData.cpp
+++ b/src/core/ActionToPutData.cpp
@@ -229,12 +229,17 @@ void ActionToPutData::apply() {
 }
 
 unsigned ActionToPutData::getNumberOfForcesToRescale() const {
-  if( getName()!="ENERGY" || getDependencies().size()>0 ) {
+  // Values that are passed through the domain decomposition only store the atoms
+  // that are local to this rank, so the number of forces held in the buffer of the
+  // MD code is the number of local atoms and not the number of values
+  if( !from_domains || getDependencies().size()!=1 ) {
     return copyOutput(0)->getNumberOfValues();
   }
-  plumed_assert( getDependencies().size()==1 );
   plumed_assert(getDependencies()[0]); // needed for following calls, see #1046
   ActionForInterface* ai = getDependencies()[0]->castToActionForInterface();
+  if( !ai ) {
+    return copyOutput(0)->getNumberOfValues();
+  }
   return ai->getNumberOfForcesToRescale();
 }
 

--- a/src/core/DataPassingObject.cpp
+++ b/src/core/DataPassingObject.cpp
@@ -101,8 +101,10 @@ void DataPassingObjectTyped<float>::saveValueAsDouble( const TypesafePtr & val )
   // The following is to avoid extra digits in case the MD code uses floats
   // e.g.: float f=0.002 when converted to double becomes 0.002000000094995
   // To avoid this, we keep only up to 6 significant digits after first one
-  double magnitude=std::pow(10,std::floor(std::log10(bvalue)));
-  bvalue = std::round(bvalue/magnitude*1e6)/1e6*magnitude;
+  if( bvalue != 0.0 ) {
+    double magnitude=std::pow(10,std::floor(std::log10(std::fabs(bvalue))));
+    bvalue = std::round(bvalue/magnitude*1e6)/1e6*magnitude;
+  }
 }
 
 template <class T>


### PR DESCRIPTION
# Fix ENERGY with GROMACS 2024, and support it with the native GROMACS 2025 interface

**Branch:** `fix-1205-gromacs2024-energy-v2.10` → base `v2.10` · **Fixes:** #1205 (and the root cause behind #1384)
**Companions:** the same 2024 fix against `v2.9`; the GROMACS 2026 counterpart stacked on #1439,
which needs part 4 below and so should be merged after this one

> **Disclaimer.** This PR was entirely generated by Claude, supervised by @invemichele.

##### Description

Energy-based PLUMED input is broken or unavailable on every GROMACS newer than 2023:

- **2024** — `ENERGY` silently returns `0.0` except on `nstcalcenergy` steps (#1205).
- **2025** — the native PLUMED module never calls `setEnergy`, so `ENERGY` stays `0.0` for the
  whole run with no error. The GROMACS manual lists "interaction with GROMACS energy" under the
  interface Limitations.
- **Single-precision builds, every version** — the core converts the scalars passed by the MD code
  from `float` to `double` by rounding them through `std::log10`, which is `NaN` for a negative
  argument. The energy is negative, so wherever it did arrive it arrived as `NaN`.
- **Every version, more than one MPI rank** — applying a force on `ENERGY` writes past the end of
  the force buffer of the MD code and corrupts the heap. This one is a v2.10 regression in the
  core and is not specific to GROMACS.

This PR fixes all four, so `ENERGY`, `OPES_EXPANDED` with `ECV_MULTITHERMAL`, the well-tempered
ensemble and energy reweighting behave on 2024 and 2025 as they do on 2023.

> **Scope.** This branch carries three bug fixes that belong on a maintenance branch (the 2024
> patch, identical to the `v2.9` companion, and the `DataPassingObject` and domain decomposition
> fixes) plus one new feature (ENERGY in the 2025 patch). If needed we can split it into smaller chunks.

**Part 1 — GROMACS 2024: `ENERGY` is zero on most steps.** The patch asks for the energy by
OR-ing bits into `force_flags` after `isEnergyNeeded`. In 2023 that worked because `force_flags`
went straight into the `do_force()` call below; in 2024 `do_force()` no longer takes flags and
the workload is snapshotted ~120 lines earlier by `setupStepWorkload()`, so the PLUMED line
became dead code. `do_force()` zeroes `term[F_EPOT]` every step and only refills it when
`stepWork.computeEnergy` is set, so PLUMED received `0.0` on 99 steps out of 100 with the default
`nstcalcenergy = 100`. The virial was lost the same way, so the force rescaling used for energy
biasing was wrong too. In `patches/gromacs-2024.3.diff/.../md.cpp`: carry the request forward
before `setupStepWorkload()`; rebuild `runScheduleWork_->stepWork` right after `isEnergyNeeded`
answers for the current step, which makes the fix exact rather than one step late; `gmx_fatal` if
the energy is still not scheduled; treat `plumedNeedsEnergy` like `bCalcVir` in the MD GPU graph
reset and reuse conditions.

**Part 2 — the `float` to `double` conversion returns `NaN` for negative scalars.**
`DataPassingObjectTyped<float>::saveValueAsDouble` rounds to 6 significant figures using
`std::log10(bvalue)`, to keep single-precision values from acquiring meaningless digits when
widened. `std::log10` is `NaN` for a negative argument and `-inf` for zero, which then gives
`0/0`, so any negative or zero scalar coming from a single-precision engine is turned into `NaN`.
The potential energy is essentially always negative, so `ENERGY` arrived as `NaN` and poisoned
every bias built on it. Fixed by taking the magnitude from `std::fabs(bvalue)` and leaving exact
zeros alone. Nothing here is specific to GROMACS or to `ENERGY`, but `ENERGY` is the only value
affected in practice: array data keeps the pointer of the MD code and is never rounded, `timestep`
and `kBT` take the same path but are strictly positive, and `EXTRACV` values are declared
`MUTABLE`, which sends them down the pointer branch instead.

**Part 3 — GROMACS 2025: teaching the native interface about the energy.** From 2025 the
interface is an `IForceProvider` rather than a source patch, and three things block energy
biasing: nobody can ask GROMACS to compute the energy, since a force provider cannot influence
`stepWork`; at `calculateForces()` time the energy does not exist yet, as it is called from
`computeSpecialForces()` several hundred lines before `accumulatePotentialEnergies()`; and the
force-rescaling trick is not expressible, because biasing the energy multiplies the *entire*
force array by `1 - ∂V/∂E` (`Energy::apply()` → `rescaleForces`) while a provider only owns a
separate additive `ForceWithVirial` buffer. Two hooks are added to `IForceProvider`, both
defaulting to no-ops so no other module is affected:

```cpp
//! Whether this provider needs the MD potential energy on `step`.
virtual bool requestsPotentialEnergy(int64_t /*step*/) { return false; }

//! Called once the potential energy is accumulated and the force buffer is complete.
virtual void applyAfterPotentialEnergy(bool /*energyWasComputed*/, real* /*potentialEnergy*/,
                                       ArrayRef<RVec> /*force*/, tensor /*virial*/) {}
```

`md.cpp` calls the first immediately before `setupStepWorkload()`, the last moment the workload
can change. The answer must be exact for *this* step rather than inherited from the previous one,
so `requestsPotentialEnergy()` splits `prepareCalc()` in two: whether PLUMED needs the energy is
known after `prepareDependencies()`, and that half needs only the step number
(`setStepLong` → `prepareDependencies` → `isEnergyNeeded`, the sequence `src/generic/Plumed.cpp`
already uses, so no new PLUMED command is required). `calculateForces()` runs the second half
(`shareData`) once positions are available, falling back to the full `prepareCalc()` when the
early hook did not run for this step — which is what makes energy minimisation and `mdrun -rerun`
work, since neither goes through the `md.cpp` loop but both always compute the energy.
`sim_util.cpp` calls the second hook after `accumulatePotentialEnergies()` and `postProcessForces()`,
where `term[F_EPOT]` is valid and the total force buffer is complete; there PLUMED does
`setEnergy` / `setForces` on the total force / `setVirial` / `performCalc`, with the same `2 ×`
/ `0.5 ×` virial convention and virial *replacement* as the legacy 2023 and 2024 patches. When
the energy is not needed the existing additive path is unchanged.

**Part 4 — energy biasing overran the force buffer under domain decomposition.** Applying a force
on `ENERGY` makes PLUMED rescale *all* of the forces of the MD code by `1 - ∂V/∂E`
(`Energy::apply()` → `ActionToPutData::rescaleForces`). The loop length comes from
`getNumberOfForcesToRescale()`, which returned `copyOutput(0)->getNumberOfValues()` — the **total**
number of atoms — while under domain decomposition the buffer of the MD code only holds the atoms
local to the rank. On 4 ranks PLUMED therefore wrote about four times past the end of that buffer,
which shows up as `double free or corruption` or a segfault the moment the bias switches on. The
domain-aware branch that returns the local count exists but is unreachable: it is guarded by
`getName()!="ENERGY"`, whereas the values actually being rescaled are the `posx`/`posy`/`posz`
objects created as `PUT FROM_DOMAINS`, and it would have hit its own
`plumed_assert(getDependencies().size()==1)` if it had ever been entered. The fix keys the branch
off the existing `from_domains` flag instead. v2.9 is not affected — it rescales over `gatindex`,
i.e. the local atoms — so this is a v2.10 regression introduced with the new data-passing
architecture, and it is present in **2.10.1 and in current `master`** as well.

This is the same combination as #1205: OPES multithermal and the well-tempered ensemble are
precisely the inputs that put a force on `ENERGY`, so anyone running them on more than one rank
was hitting silent memory corruption.

<details>
<summary><b>Verification</b></summary>

216 SPC waters (648 atoms), OPLS-AA, 0.8 nm cut-offs, `dt = 2 fs`, v-rescale at 300 K, LINCS on
h-bonds, `nstcalcenergy = 100` unless stated, mixed precision. **GROMACS 2023.5 with the legacy
patch is the reference throughout**, since it predates the regression and works as shipped.

| | 2023.5 (reference) | 2025.0 + this PR |
|:---|---:|---:|
| `ENERGY` every step, 250 steps | 251 / 251 | 251 / 251 |
| temperatures chosen by OPES | 10 | 10 |
| steps with `ENERGY == 0` | 0 / 1501 | 0 / 1501 |
| bias switches on at | 0.402 ps | 0.402 ps |
| `∂V/∂E` non-zero after observation | 1300 / 1300 | 1300 / 1300 |
| `DeltaF` at 350 K after 3 ps (kJ/mol) | 1435 | 1442 |

Unpatched 2024.3 manages 4 / 251, exactly the `nstcalcenergy` steps. The temperature count is the
sharpest check, since OPES sizes that grid from the energy fluctuations seen during observation, so
a zero or intermittent energy collapses it to 2 temperatures; a control at `nstcalcenergy = 1`
picks the same 10. Trajectories are not bit-identical across GROMACS versions, so the residual
`DeltaF` spread is MD noise. Also checked: `PRINT ARG=ene STRIDE=7` against `nstcalcenergy = 100`,
a stride sharing no factor with the energy period and the case an inherited, one-step-late request
cannot serve; restart via `-cpi` from step 150, not a multiple of `nstcalcenergy`, with the energy
continuous across the restart; `DISTANCE` + `RESTRAINT` unchanged, confirming the additive path is
untouched; and `plumed patch -p -e gromacs-2025.0` applying to a pristine tarball with no fuzz and
no rejects, with `plumed patch -r` restoring the tree byte-for-byte.

Part 4 needs a bigger box, so that one uses 1728 SPC waters (5184 atoms) with
OpenMPI, `-DGMX_MPI=ON`, on 1, 2 and 4 ranks (DD grids `2 x 1 x 1` and `4 x 1 x 1`). Before the
fix, every run with a force on `ENERGY` died — `double free or corruption` on 2023.5 and on 2026.3
alike, in NVT and NPT, always at the step the bias switched on; `ENERGY` *without* a force, and a
`RESTRAINT` on a `DISTANCE`, both survived, which is what isolates the rescaling. After the fix:

| check | result |
|:---|:---|
| OPES multithermal, 1 vs 4 ranks (2023.5 NVT / NPT, 2026.3 NPT) | clean; `DeltaF` at 350 K agrees to 1 kJ/mol |
| biased ÷ unbiased force, per atom, single force evaluation | uniform over all 5184 atoms, `= 1 - ∂V/∂E`, spread 2 × 10⁻⁵, same at 1 / 2 / 4 ranks |
| `ENERGY` vs `.edr` `Potential`, `DispCorr = EnerPres` | ≤ 0.015 kJ/mol, i.e. ≤ 1.5 × 10⁻⁷ relative, at every rank count |
| `regtest/basic` and `regtest/opes` | identical results with and without the fix |

The force-ratio row is the direct check: because a force on the energy only ever multiplies the
existing forces by a scalar, every atom on every rank must show the same ratio, and it must equal
`1 - ∂V/∂E`. It does. PLUMED 2.9 built with the same MPI stack was run through the same test and
is clean at 1, 2 and 4 ranks, confirming the regression is 2.10-only.

</details>

**Also: the long tail correction warning in the docs is stale (#567).** While checking what the
energy PLUMED receives actually contains, it turned out that the `\bug` note on `ENERGY` — "does
not include long tail corrections … GROMACS `DispCorr Ener`" — no longer holds for GROMACS. The
correction is computed inside `do_force()` and folded into `F_EPOT` by `sum_epot()`, both before
PLUMED reads the energy. With `DispCorr = EnerPres`, `ENERGY` matches the `Potential` term in the
GROMACS energy file to **0.005 kJ/mol** on 2023.5, 2024.3 and 2026.3, while the correction itself
is −154 kJ/mol. Under **NPT**, where the volume varies by up to 29% and the correction with it by
40 kJ/mol, `ENERGY` still tracks GROMACS to 0.005 kJ/mol over 401 frames — so the correction is
not merely present but correctly updated. The note is reworded rather than deleted, and kept short
and engine-agnostic: codes other than GROMACS, such as LAMMPS with `pair_modify tail yes`, were not
tested here, and where the mismatch is real the advice to reweight with the energy of the engine
still stands.

**Remaining gaps.** GPU was tested through the companion 2026 patch, which carries the identical
design, since GROMACS 2025 does not build against the CUDA toolkit available here: `-nb gpu`,
`-nb gpu -pme gpu`, fully GPU-resident `-update gpu` and `GMX_CUDA_GRAPH=1` all give correct
energies, matching GROMACS' own `.edr` `Potential` term to ≤ 5 × 10⁻⁸ relative, and OPES
multithermal reproduces the CPU temperature grid and `DeltaF`. The modular simulator is the one
unsupported path: it bypasses the `md.cpp` loop, so
the early hook never runs. It is the **default for `md-vv`**, where energy-dependent input now
fails with a `NotImplementedError` naming it and pointing at `GMX_DISABLE_MODULAR_SIMULATOR=1`;
with that set, `md-vv` works. Input that does not use the energy is unaffected. Under MTS the
total force is taken from the combined buffer only on slow steps. The two hooks are the minimal
shape of what would have to go upstream; GROMACS issue
[#4939](https://gitlab.com/gromacs/gromacs/-/issues/4939) does not list energy biasing among the
requirements for the PLUMED interface, which is probably why it was never designed in.

##### Target release

I would like my code to appear in release **2.10**.

##### Type of contribution
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [ ] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright
- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

##### Tests
- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [ ] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

Parts 1 and 3 live entirely under `patches/`, which PLUMED does not compile, so the test suite
cannot exercise them; the GROMACS builds and MD runs above are the substitute. Part 2 is core
code and is covered by existing regtests, since it is on the path every float-precision engine
uses to pass a scalar. Part 4 is core code too, but no regtest can reach it today: the failure
needs `gatindex.size() < natoms`, and with no MPI communicator `DomainDecomposition::shareAll()`
takes the branch that assumes every atom is local, so a serial fake-MD harness cannot set it up —
and the regtest framework has no multi-rank test type. It would need a small MPI harness; happy to
add one, here or separately, if you want the infrastructure. `regtest/basic` and `regtest/opes`
were run with and without the fix and give identical results (the same two pre-existing failures,
`rt-average` and `rt-multi-1`, in both).
