### PR TITLE
Plugins documentation

### DIFF
--- a/new-manual/build_manual.py
+++ b/new-manual/build_manual.py
@@ -460,7 +460,7 @@ LOAD FILE=/path/to/myplugin.so
 
 Once the library is loaded you can then use the functionality that is contained within it in your PLUMED input.
 
-Typically, functionality is included in a plugin rather than a library special compilation options are required to build the associated functionality. For example,
+Typically, functionality is included in a plugin rather than a module when special compilation options are required to build the associated functionality. For example,
 much of the code that allows you to run PLUMED on GPUs is provided through plugins because additional compilation options are required. The code in these plugins is 
 also more experimental than the code in the modules. This sadly often means that it is tested less frequently.  Consequently, if you do try to use these plugins for production calulculations,
  you are strongly recommended __to run the test suite after compilation__.  To run these test suits you change to the `regtest` directory that will be contained in the plugin directory.  Once in that 

--- a/new-manual/build_manual.py
+++ b/new-manual/build_manual.py
@@ -445,7 +445,8 @@ view of this information is available [here](modulegraph.md).
     mf.write(content)
     printDataTable(mf, ["Name", "Description", "Authors", "Type"], tabledata)
 
-def printPluginListPage(mf, version, tabledata): 
+
+def printPluginListPage(mf, version, tabledata):
     content = f"""
 Plugins that you can use with PLUMED Version {version}
 ------------------------------------------------------
@@ -460,12 +461,21 @@ LOAD FILE=/path/to/myplugin.so
 Once the library is loaded you can then use the functionality that is contained within it in your PLUMED input.
 
 Typically, functionality is included in a plugin rather than a library special compilation options are required to build the associated functionality. For example,
-much of the code that allows you to run PLUMED on GPUs is provided through plugins because additional compilation options are required. 
+much of the code that allows you to run PLUMED on GPUs is provided through plugins because additional compilation options are required. The code in these plugins is 
+also more experimental than the code in the modules. This sadly often means that it is tested less frequently.  Consequently, if you do try to use these plugins for production calulculations,
+ you are strongly recommended __to run the test suite after compilation__.  To run these test suits you change to the `regtest` directory that will be contained in the plugin directory.  Once in that 
+directory you then simply type:
+
+```bash
+make
+``` 
+
+The tests will then run and any errors are reported. 
 
 The plugins that you can use with PLUMED are listed below: 
 """
     mf.write(content)
-    printDataTable(mf, ["Name", "Description", "Authors"], tabledata )
+    printDataTable(mf, ["Name", "Description", "Authors"], tabledata)
 
 
 def addSpecialGroupsToPage(file, groups):
@@ -659,17 +669,19 @@ def getModuleDictionary(modname):
         "dois": [],
     }
 
+
 def getPluginDictionary(plugname):
     if os.path.exists("../../plugins/" + plugname + "/plugin.yml"):
         with open("../../plugins/" + plugname + "/plugin.yml") as f:
             plugdict = yaml.load(f, Loader=yaml.BaseLoader)
         return plugdict
-    return {        
+    return {
         "name": plugname,
         "authors": "authors",
         "description": "Information about the plugin",
         "dois": [],
-    }  
+    }
+
 
 def createModulePage(
     version,
@@ -846,18 +858,20 @@ def createModulePage(
                 ref, ref_url = get_reference(doi)
                 f.write("- [" + ref + "](" + ref_url + ")\n")
 
+
 def createPluginPage(
     version,
     plugname,
     plug_dict,
     neggs,
-    nlessons,   
+    nlessons,
+    tutorial_searchterm,
     plumed_syntax,
     plumedtags,
     tagdictionary,
     broken_inputs,
-):      
-    with open("plugin_" + plugname + ".md", "w") as f:        
+):
+    with open("plugin_" + plugname + ".md", "w") as f:
         f.write("# [Plugin](modules.md): " + plugname + "\n\n")
         f.write("| Description    | Usage |\n")
         f.write("|:--------|:--------:|\n")
@@ -874,8 +888,8 @@ def createPluginPage(
                 + str(nlessons)
                 + " tutorials](https://img.shields.io/badge/tutorials-"
                 + str(nlessons)
-                + "-green.svg)](https://www.plumed-tutorials.org/browse.html?module="
-                + modname
+                + "-green.svg)](https://www.plumed-tutorials.org/browse.html?search="
+                + tutorial_searchterm
                 + ")"
             )
         else:
@@ -923,6 +937,7 @@ def createPluginPage(
                         str(nf[0]),
                     ]
                 )
+
 
 def getKeywordDescription(docs):
     desc = docs["description"]
@@ -1689,39 +1704,35 @@ if (
 
     # And create a page for each plugin
     plugintabledata = []
-    for plugin in os.listdir("../plugins/") :
-        if not os.path.isdir("../plugins/" + plugin ) :
-           continue
+    for plugin in os.listdir("../plugins/"):
+        if not os.path.isdir("../plugins/" + plugin):
+            continue
         plink = '<a href="../plugin_' + plugin + '">' + plugin + "</a>"
-        print( "Building plugin page", plugin )
+        print("Building plugin page", plugin)
         with cd("docs"):
-            plug_dict = getPluginDictionary( plugin )
-    
+            plug_dict = getPluginDictionary(plugin)
+
             plugintabledata.append(
-                [   
-                    plink,
-                    plug_dict["description"],
-                    plug_dict["authors"]
-                ]
+                [plink, plug_dict["description"], plug_dict["authors"]]
             )
             createPluginPage(
                 version,
                 plugin,
                 plug_dict,
                 0,
-                0,
+                int(plug_dict["nlessons"]),
+                plug_dict["searchterm"],
                 plumed_syntax,
                 plumedtags,
                 tagdictionary,
                 broken_inputs,
             )
-        if not os.path.exists("../plugins/" + plugin + "/README.md") or not os.path.exists(
-                "../plugins/" + plugin + "/plugin.yml"
-            ):
-                nodocs.append(
-                    ['<a href="../plugin_' + plugin + '">' + plugin + "</a>", "plugin"]
-                )
-
+        if not os.path.exists(
+            "../plugins/" + plugin + "/README.md"
+        ) or not os.path.exists("../plugins/" + plugin + "/plugin.yml"):
+            nodocs.append(
+                ['<a href="../plugin_' + plugin + '">' + plugin + "</a>", "plugin"]
+            )
 
     # And the page with the list of modules
     with open("docs/modules.md", "w+") as module_file:

--- a/new-manual/build_manual.py
+++ b/new-manual/build_manual.py
@@ -445,6 +445,28 @@ view of this information is available [here](modulegraph.md).
     mf.write(content)
     printDataTable(mf, ["Name", "Description", "Authors", "Type"], tabledata)
 
+def printPluginListPage(mf, version, tabledata): 
+    content = f"""
+Plugins that you can use with PLUMED Version {version}
+------------------------------------------------------
+
+Further functionality for PLUMED is provided in a series of plugins. These plugins are compiled as dynamic libraries that are separate to the main PLUMED
+dynamic library. You can use the [LOAD](LOAD.md) action to load the contents of one of these plugins at runtime using an input similar to the one shown below:
+
+````
+LOAD FILE=/path/to/myplugin.so
+````
+
+Once the library is loaded you can then use the functionality that is contained within it in your PLUMED input.
+
+Typically, functionality is included in a plugin rather than a library special compilation options are required to build the associated functionality. For example,
+much of the code that allows you to run PLUMED on GPUs is provided through plugins because additional compilation options are required. 
+
+The plugins that you can use with PLUMED are listed below: 
+"""
+    mf.write(content)
+    printDataTable(mf, ["Name", "Description", "Authors"], tabledata )
+
 
 def addSpecialGroupsToPage(file, groups):
     with open(file, "r") as f:
@@ -637,6 +659,17 @@ def getModuleDictionary(modname):
         "dois": [],
     }
 
+def getPluginDictionary(plugname):
+    if os.path.exists("../../plugins/" + plugname + "/plugin.yml"):
+        with open("../../plugins/" + plugname + "/plugin.yml") as f:
+            plugdict = yaml.load(f, Loader=yaml.BaseLoader)
+        return plugdict
+    return {        
+        "name": plugname,
+        "authors": "authors",
+        "description": "Information about the plugin",
+        "dois": [],
+    }  
 
 def createModulePage(
     version,
@@ -813,6 +846,83 @@ def createModulePage(
                 ref, ref_url = get_reference(doi)
                 f.write("- [" + ref + "](" + ref_url + ")\n")
 
+def createPluginPage(
+    version,
+    plugname,
+    plug_dict,
+    neggs,
+    nlessons,   
+    plumed_syntax,
+    plumedtags,
+    tagdictionary,
+    broken_inputs,
+):      
+    with open("plugin_" + plugname + ".md", "w") as f:        
+        f.write("# [Plugin](modules.md): " + plugname + "\n\n")
+        f.write("| Description    | Usage |\n")
+        f.write("|:--------|:--------:|\n")
+        f.write(
+            "| "
+            + plug_dict["description"]
+            + "\n __Authors:__ "
+            + plug_dict["authors"]
+            + " | "
+        )
+        if nlessons > 0:
+            f.write(
+                "[![used in "
+                + str(nlessons)
+                + " tutorials](https://img.shields.io/badge/tutorials-"
+                + str(nlessons)
+                + "-green.svg)](https://www.plumed-tutorials.org/browse.html?module="
+                + modname
+                + ")"
+            )
+        else:
+            f.write(
+                "![used in "
+                + str(nlessons)
+                + " tutorials](https://img.shields.io/badge/tutorials-0-red.svg)"
+            )
+        if neggs > 0:
+            f.write(
+                "[![used in "
+                + str(neggs)
+                + " eggs](https://img.shields.io/badge/nest-"
+                + str(neggs)
+                + "-green.svg)](https://www.plumed-nest.org/browse.html?module="
+                + modname
+                + ")"
+            )
+        else:
+            f.write(
+                "![used in "
+                + str(neggs)
+                + " eggs](https://img.shields.io/badge/nest-0-red.svg)"
+            )
+        f.write("|\n\n")
+        f.write("## Details \n")
+        if os.path.exists("../../plugins/" + plugname + "/README.md"):
+            with open("../../plugins/" + plugname + "/README.md") as iff:
+                docs = iff.read()
+            actions = set()
+            _, nf = processMarkdownString(
+                docs,
+                "plugins_" + plugname + ".md",
+                (PLUMED,),
+                (version,),
+                actions,
+                f,
+                ghmarkdown=False,
+                test_plumed_kwargs={"header": MKDOCS_IGNORE_SEARCH},
+            )
+            if nf[0] > 0:
+                broken_inputs.append(
+                    [
+                        '<a href="../plugins_' + plugname + '">' + plugname + "</a>",
+                        str(nf[0]),
+                    ]
+                )
 
 def getKeywordDescription(docs):
     desc = docs["description"]
@@ -1576,9 +1686,47 @@ if (
             nodocs.append(
                 ['<a href="../module_' + module + '">' + module + "</a>", "module"]
             )
+
+    # And create a page for each plugin
+    plugintabledata = []
+    for plugin in os.listdir("../plugins/") :
+        if not os.path.isdir("../plugins/" + plugin ) :
+           continue
+        plink = '<a href="../plugin_' + plugin + '">' + plugin + "</a>"
+        print( "Building plugin page", plugin )
+        with cd("docs"):
+            plug_dict = getPluginDictionary( plugin )
+    
+            plugintabledata.append(
+                [   
+                    plink,
+                    plug_dict["description"],
+                    plug_dict["authors"]
+                ]
+            )
+            createPluginPage(
+                version,
+                plugin,
+                plug_dict,
+                0,
+                0,
+                plumed_syntax,
+                plumedtags,
+                tagdictionary,
+                broken_inputs,
+            )
+        if not os.path.exists("../plugins/" + plugin + "/README.md") or not os.path.exists(
+                "../plugins/" + plugin + "/plugin.yml"
+            ):
+                nodocs.append(
+                    ['<a href="../plugin_' + plugin + '">' + plugin + "</a>", "plugin"]
+                )
+
+
     # And the page with the list of modules
     with open("docs/modules.md", "w+") as module_file:
         printModuleListPage(module_file, version, moduletabledata)
+        printPluginListPage(module_file, version, plugintabledata)
     # Create the graph that shows all the modules
     createModuleGraph(version, plumed_syntax)
 

--- a/new-manual/build_manual.py
+++ b/new-manual/build_manual.py
@@ -303,6 +303,8 @@ Each module contains implementations of a number of [actions](actions.md), [shor
 You can find a list of all the commands that you can use in a PLUMED input file [here](actionlist.md) and descriptions of some of the tools you can use these commands with [here](module_cltools.md).
 
 Please also note that some developers prefer not to include their codes in PLUMED.  To use functionality that has been written by these developed you can use the [LOAD](LOAD.md) command.
+There are also some features that are released within PLUMED as plugins. You can read about these plugins by scrolling to the bottom of [this page](modules.md). The code within these 
+plugins is compiled separately to PLUMED. The dynamic library that results compilatiing a plugin can then be loaded at runtime using the [LOAD](LOAD.md) command.   
 
 You can find instructions for installing PLUMED [here](https://www.plumed-tutorials.org/lessons/20/001/data/NAVIGATION.html).
 

--- a/plugins/cudaCoord/README.md
+++ b/plugins/cudaCoord/README.md
@@ -1,5 +1,3 @@
-# The cudaCoord plugin for PLUMED 2
-
 This is the optimized version of the lesson that I presented in the [plumed-school](https://plumed-school.github.io/lessons/23/004/data/NAVIGATION.html) with a step-by-step approach.
 
 `CUDACOORDINATION` and `CUDACOORDINATIONFLOAT` depend on [CCCL](https://github.com/NVIDIA/cccl) which is automatically fetched by the cuda compiler (if you use nvcc, you have access to the CCCL headers).

--- a/plugins/cudaCoord/README.md
+++ b/plugins/cudaCoord/README.md
@@ -1,4 +1,4 @@
-# Coordination in Cuda
+# The cudaCoord plugin for PLUMED 2
 
 This is the optimized version of the lesson that I presented in the [plumed-school](https://plumed-school.github.io/lessons/23/004/data/NAVIGATION.html) with a step-by-step approach.
 

--- a/plugins/cudaCoord/plugin.yml
+++ b/plugins/cudaCoord/plugin.yml
@@ -2,3 +2,5 @@ name: cudaCoord
 authors: Daniele Rapetti 
 description: version of coordination number that can run on the GPU with parallelism written in CUDA
 dois: []
+nlessons: 2
+searchterm: cuda

--- a/plugins/cudaCoord/plugin.yml
+++ b/plugins/cudaCoord/plugin.yml
@@ -1,0 +1,4 @@
+name: cudaCoord
+authors: Daniele Rapetti 
+description: version of coordination number that can run on the GPU with parallelism written in CUDA
+dois: []

--- a/plugins/openaccPTM/README.md
+++ b/plugins/openaccPTM/README.md
@@ -1,3 +1,74 @@
 # Then openaccPTM plugin for PLUMED 2
 
-You can use this plugin to run certain actions on a GPU
+This plugin allows you to use the USEGPU flag with certain actions in PLUMED. This flag turns on an experimental GPU parallized version of the 
+command. GPU parallelism in PLUMED has been implemented using [openACC](https://www.openacc.org) and is currently experimental. We are actively working
+on these features at the moment. __There is thus no guarantee that the GPU accelerated versions of actions are any faster than 
+the CPU versions.__ If you have experimented with these features on your own calculations we would love to hear from you (even
+if your experience was negative.)
+
+## [Experimental] Compiling plumed with openacc
+
+_This section will likely be moved  in the proper installation page_
+
+To compile the plugin you need to have the [NVIDIA HPC SDK](https://developer.nvidia.com/hpc-sdk) avaiable on your path.
+
+Plumed is tested with the [24.3](https://developer.nvidia.com/nvidia-hpc-sdk-243-downloads) version.
+
+To prepare the compilation add `--enable-opeacc` to the `./configure` options.
+It is also possible to pass some extra options by exporting or specifying the the following variables:
+ - **PLUMED_ACC_TYPE**: if omitted defaults to `gpu`, can be changed to `host` or `multicore` to try a compilation that targets the CPU also for the openacc accellerate part of the code.
+ - **PLUMED_ACC_GPU**: if `PLUMED_ACC_TYPE` is set to `gpu`, it can be used to specify a range of `-gpu` optios to pass to the nvhpc compiler (for example the target gpu, see the [compiler manual](https://docs.nvidia.com/hpc-sdk/compilers/hpc-compilers-user-guide/index.html) for the options) options can be comma separated or space separated
+
+
+!!! warning
+    (Currently) modules that use a custom openmp reduction can be compiled with nvhpc.
+    Currently `membranefusion` is not compatible and should be excluded from the compilation
+
+## List of actions that can be called with the USEGPU option:
+
+ - module:
+   - ACTION
+
+ - colvar:
+   - [ANGLE](ANGLE.md)
+   - [DIPOLE](DIPOLE.md)
+   - [DISTANCE](DISTANCE.md)
+   - [PLANE](PLANE.md)
+   - [POSITION](POSITION.md)
+   - [TORSION](TORSION.md)
+ - crystdistrib:
+   - ~~[QUATERNION_BOND_PRODUCT_MATRIX](QUATERNION_BOND_PRODUCT_MATRIX.md)~~ setup, but deactivated
+ - secondarystructure:
+   - [SECONDARY_STRUCTURE_DRMSD](SECONDARY_STRUCTURE_DRMSD.md), and in particular:
+     - [ALPHARMSD](ALPHARMSD.md) only with **TYPE=DRMSD**
+     - [ANTIBETARMSD](ANTIBETARMSD.md) only with **TYPE=DRMSD**
+     - [PARABETARMSD](PARABETARMSD.md) only with **TYPE=DRMSD**
+ - volumes:
+   - [AROUND](AROUND.md)
+   - [INCYLINDER](INCYLINDER.md)
+   - [INSPHERE](INSPHERE.md)
+- adjmat
+   - [CONTACT_MATRIX](CONTACT_MATRIX.md)
+- function
+   - [LESS_THAN](LESS_THAN.md)
+   - [MORE_THAN](MORE_THAN.md)
+   - [BETWEEN](BETWEEN.md)
+   - [COMBINE](COMBINE.md)
+- matrixtools
+   - [MATRIX_PRODUCT](MATRIX_PRODUCT.md)
+   - [MATRIX_VECTOR_PRODUCT](MATRIX_VECTOR_PRODUCT.md)
+- symfunc
+   - [Q1](Q1.md)
+   - [Q3](Q3.md)
+   - [Q4](Q4.md)
+   - [Q6](Q6.md)
+   - [LOCAL_AVERAGE](LOCAL_AVERAGE.md)
+   - [FCCUBIC](FCCUBIC.md)
+   - [TETRAHEDRAL](TETRAHEDRAL.md)
+   - [SIMPLECUBIC](SIMPLECUBIC.md)
+   - [COORDINATION_SHELL_FUNCTION](COORDINATION_SHELL_FUNCTION.md)
+   - [COORDINATION_SHELL_AVERAGE](COORDINATION_SHELL_AVERAGE.md)
+   - [LOCAL_Q1](LOCAL_qQ1.md)
+   - [LOCAL_Q3](LOCAL_qQ3.md)
+   - [LOCAL_Q4](LOCAL_qQ4.md)
+   - [LOCAL_Q6](LOCAL_qQ6.md)

--- a/plugins/openaccPTM/README.md
+++ b/plugins/openaccPTM/README.md
@@ -1,28 +1,53 @@
-# Then openaccPTM plugin for PLUMED 2
-
 This plugin allows you to use the USEGPU flag with certain actions in PLUMED. This flag turns on an experimental GPU parallized version of the 
 command. GPU parallelism in PLUMED has been implemented using [openACC](https://www.openacc.org) and is currently experimental. We are actively working
 on these features at the moment. __There is thus no guarantee that the GPU accelerated versions of actions are any faster than 
 the CPU versions.__ If you have experimented with these features on your own calculations we would love to hear from you (even
 if your experience was negative.)
 
-## [Experimental] Compiling plumed with openacc
+## [Experimental] Compiling the openaccPTM plugin
 
-_This section will likely be moved  in the proper installation page_
+The openaccPTM plugin is compiled separately to the main PLUMED code. To compile the plugin you need to have the 
+[NVIDIA HPC SDK](https://developer.nvidia.com/hpc-sdk) and the plumed library avaiable in your path.  You then compile 
+the plugin by issuing the following commands:
 
-To compile the plugin you need to have the [NVIDIA HPC SDK](https://developer.nvidia.com/hpc-sdk) avaiable on your path.
+```bash
+cd plugin/openaccPTM
+./configure 
+make clean
+NVCXX=mpic++ make
+```  
 
-Plumed is tested with the [24.3](https://developer.nvidia.com/nvidia-hpc-sdk-243-downloads) version.
+It is worth running these commands more than once if the compilation doesn't work the first time. If they complete correctly a dynamic libarary called `plumedOpenACC.so` 
+will be created in the plumed2/plugin directory.
 
-To prepare the compilation add `--enable-opeacc` to the `./configure` options.
-It is also possible to pass some extra options by exporting or specifying the the following variables:
- - **PLUMED_ACC_TYPE**: if omitted defaults to `gpu`, can be changed to `host` or `multicore` to try a compilation that targets the CPU also for the openacc accellerate part of the code.
- - **PLUMED_ACC_GPU**: if `PLUMED_ACC_TYPE` is set to `gpu`, it can be used to specify a range of `-gpu` optios to pass to the nvhpc compiler (for example the target gpu, see the [compiler manual](https://docs.nvidia.com/hpc-sdk/compilers/hpc-compilers-user-guide/index.html) for the options) options can be comma separated or space separated
+We have tested this module with the [24.3](https://developer.nvidia.com/nvidia-hpc-sdk-243-downloads) version of the NVIDIA HPC SDK compiler and found that it works.
+It currently does not work with NVHPC 26.5 compiler.
 
+Note that we recommend running the test suite after compilation.  You can do this by issuing the following commands:
 
-!!! warning
-    (Currently) modules that use a custom openmp reduction can be compiled with nvhpc.
-    Currently `membranefusion` is not compatible and should be excluded from the compilation
+```bash
+cd plugin/openaccPTM/regtest
+make
+```
+
+## [Experimental] Using PLUMED with the openaccPTM plugin
+
+To use openACC in PLUMED you need to load the dynamic libary that you compiled in the previous section.  You can do this as follows:
+
+```plumed
+LOAD FILE=/path/to/plumedOpenACC.so
+```
+
+where `/path/to` is the directory that contains the compiled plugins. If you choose not to move the library after compilation this will 
+be the `plumed2/plugin` directory. To use the plugin to calculate an action using the GPU you add the `USEGPU` keyword to the list of keywords
+for that action.  For example, to calculate a contact matrix using the GPU you would use the following input:
+
+```plumed
+LOAD FILE=/path/to/plumedOpenACC.so
+CONTACT_MATRIX GROUP=1-1000 SWITCH={EXP D_0=0.2 R_0=0.1 D_MAX=0.66} USEGPU
+``` 
+
+The next section contains a list of the actions that can take the USEGPU command in input and that can thus be run on the GPU using this plugin.
 
 ## List of actions that can be called with the USEGPU option:
 

--- a/plugins/openaccPTM/README.md
+++ b/plugins/openaccPTM/README.md
@@ -1,0 +1,3 @@
+# Then openaccPTM plugin for PLUMED 2
+
+You can use this plugin to run certain actions on a GPU

--- a/plugins/openaccPTM/plugin.yml
+++ b/plugins/openaccPTM/plugin.yml
@@ -1,0 +1,4 @@
+name: openaccPTM
+authors: Daniele Rapetti and Gareth Tribello
+description: versions of CVs in PLUMED that can run on the GPU using OpenACC parallelism
+dois: []

--- a/plugins/openaccPTM/plugin.yml
+++ b/plugins/openaccPTM/plugin.yml
@@ -2,3 +2,5 @@ name: openaccPTM
 authors: Daniele Rapetti and Gareth Tribello
 description: versions of CVs in PLUMED that can run on the GPU using OpenACC parallelism
 dois: []
+nlessons: 0
+searchterm: ""

--- a/plugins/pycv/README.md
+++ b/plugins/pycv/README.md
@@ -1,4 +1,4 @@
-# The PYCV module/plugin for PLUMED 2
+# The PYCV plugin for PLUMED 2
 
 The PYCV module enables
 PLUMED2 Collective Variables (CVs) and arbitrary functions to be

--- a/plugins/pycv/README.md
+++ b/plugins/pycv/README.md
@@ -1,5 +1,3 @@
-# The PYCV plugin for PLUMED 2
-
 The PYCV module enables
 PLUMED2 Collective Variables (CVs) and arbitrary functions to be
 defined and auto-differentiated in the Python language.

--- a/plugins/pycv/plugin.yml
+++ b/plugins/pycv/plugin.yml
@@ -1,0 +1,4 @@
+name: pycv
+authors: Daniele Rapetti and Toni Giorgino
+description: functionality for calling python from PLUMED to calculate CVs and functions
+dois: []

--- a/plugins/pycv/plugin.yml
+++ b/plugins/pycv/plugin.yml
@@ -2,3 +2,5 @@ name: pycv
 authors: Daniele Rapetti and Toni Giorgino
 description: functionality for calling python from PLUMED to calculate CVs and functions
 dois: []
+nlessons: 1
+searchterm: pycv

--- a/src/adjmat/ContactMatrixShortcut.h
+++ b/src/adjmat/ContactMatrixShortcut.h
@@ -50,7 +50,7 @@ void ContactMatrixShortcut<CM>::registerKeywords(Keywords& keys) {
   keys.addActionNameSuffix("_PROPERACC");
   if(!keys.exists("USEGPU")) {
     keys.addFlag("USEGPU",false,"run this calculation on the GPU");
-    keys.addLinkInDocForFlag("USEGPU","gpu.md");
+    keys.addLinkInDocForFlag("USEGPU","plugin_openaccPTM.md");
   }
   keys.needsAction("TRANSPOSE");
   keys.needsAction("CONCATENATE");

--- a/src/colvar/ColvarShortcut.h
+++ b/src/colvar/ColvarShortcut.h
@@ -47,7 +47,7 @@ void ColvarShortcut<T>::registerKeywords(Keywords& keys ) {
   keys.addActionNameSuffix("_VECTOR");
   //GPU related settings
   keys.addFlag("USEGPU",false,"run this calculation on the GPU");
-  keys.addLinkInDocForFlag("USEGPU","gpu.md");
+  keys.addLinkInDocForFlag("USEGPU","plugin_openaccPTM.md");
   keys.addActionNameSuffix("_VECTORACC");
 }
 

--- a/src/core/AccelerableShortcut.h
+++ b/src/core/AccelerableShortcut.h
@@ -41,7 +41,7 @@ struct AccelerableShortcut : public ActionShortcut {
     //GPU related settings
     if (!keys.exists("USEGPU")) {
       keys.addFlag("USEGPU",false,"run this calculation on the GPU or the accelerated version, if avaiable");
-      keys.addLinkInDocForFlag("USEGPU","gpu.md");
+      keys.addLinkInDocForFlag("USEGPU","plugin_openaccPTM.md");
     }
   }
 

--- a/src/core/ParallelTaskManager.h
+++ b/src/core/ParallelTaskManager.h
@@ -492,7 +492,7 @@ template <class T>
 void ParallelTaskManager<T>::registerKeywords( Keywords& keys ) {
   keys.addFlag("SERIAL",false,"do the calculation in serial.  Do not parallelize");
   keys.addFlag("USEGPU",false,"run this calculation on the GPU");
-  keys.addLinkInDocForFlag("USEGPU","gpu.md");
+  keys.addLinkInDocForFlag("USEGPU","plugin_openaccPTM.md");
   keys.addLinkInDocForFlag("SERIAL", "actions.md");
 }
 

--- a/src/function/FunctionShortcut.h
+++ b/src/function/FunctionShortcut.h
@@ -62,7 +62,7 @@ void FunctionShortcut<T>::registerKeywords(Keywords& keys ) {
   keys.addActionNameSuffix("_GRID");
   //keys.addActionNameSuffix("_GRIDACC");
   keys.addFlag("USEGPU",false,"run this calculation on the GPU");
-  keys.addLinkInDocForFlag("USEGPU","gpu.md");
+  keys.addLinkInDocForFlag("USEGPU","plugin_openaccPTM.md");
   T::registerKeywords( keys );
   if( keys.getDisplayName()=="SUM" || keys.getDisplayName()=="CUSTOM" || keys.getDisplayName()=="MATHEVAL" ) {
     keys.addInputKeyword("compulsory","ARG","scalar/vector/matrix/grid","the values input to this function");

--- a/src/matrixtools/MatrixTimesVector.cpp
+++ b/src/matrixtools/MatrixTimesVector.cpp
@@ -88,7 +88,7 @@ void MatrixTimesVector::registerKeywords( Keywords& keys ) {
 
   if(!keys.exists("USEGPU")) {
     keys.addFlag("USEGPU",false,"run this calculation on the GPU");
-    keys.addLinkInDocForFlag("USEGPU","gpu.md");
+    keys.addLinkInDocForFlag("USEGPU","plugin_openaccPTM.md.md");
   }
 }
 


### PR DESCRIPTION
##### Description

This is my suggestion for how to include documentation for the plugins that Daniele wrote in the PLUMED manual.  

My idea was to add a table at the bottom of the modules page that has the plugins in.  This will look like this:

<img width="1819" height="1018" alt="plugins-page" src="https://github.com/user-attachments/assets/260e4598-243a-44db-8e7a-9598618df931" />

(I can adjust the authors in the table to whatever people feel they should be.)

If you then go to the pycv page you see the following:

<img width="1819" height="1018" alt="pycv" src="https://github.com/user-attachments/assets/aa86e62c-fb44-4eb0-86ec-533d64f3a24b" />

which is a rendered version of whatever was in the `README.md` that is in this particular plugins directory with the titles that are shared by the other pages in the manual.  I can't find things in the nest that use the plugin.  For the tutorials page, I am allowing plugin developers to use a custom search term to search through the lessons to find the appropriate tutorials.

I was looking through the README files and I think that we may want to refine them a bit with Daneiele.  I think that the one for the openaccPTM is not correct anymore.  It may be worth doing this as part of this PR.

It is also worth noting that as I did this I noticed the following announcement:

https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/

To be clear, we are using materials for mkdocs to build the documentation so this may well affect us.  Any thoughts on what we should do here.

##### Target release

<!-- please tell us where you would like your code to appear (e.g. v2.4): -->
I would like my code to appear in release 2.11

##### Type of contribution

<!--
  Please select the type of your contribution among these:
  (Change [ ] to [X] to tick an option)
-->
- [x] changes to code or doc authored by PLUMED developers, or additions of code in the core or within the default modules
- [x] changes to a module not authored by you
- [ ] new module contribution or edit of a module authored by you

##### Copyright

<!--
  In case you picked one of the first two choices
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [x] I agree to transfer the copyright of the code I have written to the PLUMED developers or to the author of the code I am modifying.

<!--
  In case you picked the third choice (new module authored by you)
  MAKE SURE TO TICK ALSO THE FOLLOWING BOX
-->

- [ ] the module I added or modified contains a `COPYRIGHT` file with the correct license information. Code should be released under an open source license. I also used the command `cd src && ./header.sh mymodulename` in order to make sure the headers of the module are correct. 

##### Tests

<!--
  Make sure these boxes are checked. For Travis-CI tests, you can wait for them
  to be completed monitoring this page after your pull request has been submitted:
  http://travis-ci.org/plumed/plumed2/pull_requests
-->

- [ ] I added a new regtest or modified an existing regtest to validate my changes.
- [x] I verified that all regtests are passed successfully on [GitHub Actions](https://github.com/plumed/plumed2/actions).

<!--
  After your branch has been merged to the desired branch and then to plumed2/master, and after the
  plumed official manual has been updated, please check out the coverage scan at
  http://www.plumed.org/coverage-master
  In case your new features are not well covered, please try to add more complete regtests.
-->
